### PR TITLE
added behavior without a frontend lambda for keycloak paths

### DIFF
--- a/deployment/lib/hassu-frontend.ts
+++ b/deployment/lib/hassu-frontend.ts
@@ -147,7 +147,7 @@ export class HassuFrontendStack extends cdk.Stack {
   }
 
   private static createDmzProxyBehavior(dmzProxyEndpoint: string, frontendRequestFunction?: cloudfront.Function) {
-    let dmzBehavior: BehaviorOptions = {
+    const dmzBehavior: BehaviorOptions = {
       compress: true,
       origin: new HttpOrigin(dmzProxyEndpoint, {
         originSslProtocols: [


### PR DESCRIPTION
Laitoin createDmzProxyBehavior funktio-parametrin optionaaliseksi, ja jos se on tyhjä, niin BehaviorOptionsin functionAssociations propertyksi tyhjän taulukon - kai tuo ok? Käytän sitten tuon tyyppistä behavioroptionia /keycloak-kutsuille distribuutiopropsien luonnissa.