### PR TITLE
Feature/kuulutusten kielivalinnat

### DIFF
--- a/backend/integrationtest/api/api.test.ts
+++ b/backend/integrationtest/api/api.test.ts
@@ -97,7 +97,7 @@ describe("Api", () => {
       muistiinpano: newNote,
       aloitusKuulutus,
       suunnitteluSopimus: suunnitteluSopimusInput,
-      lisakuulutuskieli
+      lisakuulutuskieli,
     });
 
     const updatedProjekti = await loadProjektiFromDatabase(oid);

--- a/backend/integrationtest/api/api.test.ts
+++ b/backend/integrationtest/api/api.test.ts
@@ -90,11 +90,14 @@ describe("Api", () => {
       yhteystiedot: [user.uid as string],
     };
 
+    const lisakuulutuskieli = "ruotsi";
+
     await api.tallennaProjekti({
       oid,
       muistiinpano: newNote,
       aloitusKuulutus,
       suunnitteluSopimus: suunnitteluSopimusInput,
+      lisakuulutuskieli
     });
 
     const updatedProjekti = await loadProjektiFromDatabase(oid);
@@ -102,6 +105,7 @@ describe("Api", () => {
     expect(updatedProjekti.aloitusKuulutus).eql(aloitusKuulutus);
     expect(updatedProjekti.suunnitteluSopimus).include(suunnitteluSopimus);
     expect(updatedProjekti.suunnitteluSopimus.logo).contain("/suunnittelusopimus/logo.png");
+    expect(updatedProjekti.lisakuulutuskieli).to.be.equal(lisakuulutuskieli);
 
     const pdf = await api.lataaKuulutusPDF(oid, KuulutusTyyppi.ALOITUSKUULUTUS);
     expect(pdf.nimi).to.be.equal("aloituskuulutus.pdf");

--- a/backend/src/database/model/projekti.ts
+++ b/backend/src/database/model/projekti.ts
@@ -63,8 +63,7 @@ export type DBProjekti = {
   tyyppi?: ProjektiTyyppi | null;
   status?: Status | null;
   suunnittelustaVastaavaViranomainen?: Viranomainen | null;
-  kuulutuksetRuotsiksi?: Boolean | false;
-  kuulutuksetSaameksi?: Boolean | false;
+  lisakuulutuskieli?: string | null;
   aloitusKuulutus?: AloitusKuulutus | null;
   EURahoitus?: boolean | null;
   suunnitteluSopimus?: SuunnitteluSopimus | null;

--- a/backend/src/handler/projektiAdapter.ts
+++ b/backend/src/handler/projektiAdapter.ts
@@ -25,7 +25,7 @@ export class ProjektiAdapter {
 
   async adaptProjektiToSave(projekti: DBProjekti, changes: API.TallennaProjektiInput): Promise<DBProjekti> {
     // Pick only fields that are relevant to DB
-    const { oid, muistiinpano, kayttoOikeudet, aloitusKuulutus, suunnitteluSopimus } = changes;
+    const { oid, muistiinpano, kayttoOikeudet, aloitusKuulutus, suunnitteluSopimus, lisakuulutuskieli } = changes;
     const kayttoOikeudetManager = new KayttoOikeudetManager(projekti.kayttoOikeudet);
     await kayttoOikeudetManager.applyChanges(kayttoOikeudet);
     return removeUndefinedFields(
@@ -37,6 +37,7 @@ export class ProjektiAdapter {
           aloitusKuulutus,
           suunnitteluSopimus,
           kayttoOikeudet: kayttoOikeudetManager.getKayttoOikeudet(),
+          lisakuulutuskieli,
         }
       )
     ) as DBProjekti;

--- a/backend/src/projektiSearch/projektiSearchAdapter.ts
+++ b/backend/src/projektiSearch/projektiSearchAdapter.ts
@@ -7,6 +7,7 @@ export function adaptProjektiToIndex(projekti: DBProjekti): any {
   delete doc.oid;
   delete doc.suunnitteluSopimus;
   delete doc.aloitusKuulutus;
+  delete doc.lisakuulutuskieli;
   return doc;
 }
 

--- a/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
+++ b/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   "ExpressionAttributeNames": Object {
     "#aloitusKuulutus": "aloitusKuulutus",
     "#kayttoOikeudet": "kayttoOikeudet",
+    "#lisakuulutuskieli": "lisakuulutuskieli",
     "#muistiinpano": "muistiinpano",
     "#status": "status",
     "#suunnitteluSopimus": "suunnitteluSopimus",
@@ -32,6 +33,7 @@ Object {
         "rooli": "PROJEKTIPAALLIKKO",
       },
     ],
+    ":lisakuulutuskieli": "ruotsi",
     ":muistiinpano": "Testiprojekti 1:n muistiinpano",
     ":status": "EI_JULKAISTU",
     ":suunnitteluSopimus": Object {
@@ -53,6 +55,6 @@ Object {
     "oid": "1",
   },
   "TableName": "Projekti-localstack",
-  "UpdateExpression": "set #kayttoOikeudet = :kayttoOikeudet , #velho = :velho , #muistiinpano = :muistiinpano , #status = :status , #suunnitteluSopimus = :suunnitteluSopimus , #aloitusKuulutus = :aloitusKuulutus ",
+  "UpdateExpression": "set #kayttoOikeudet = :kayttoOikeudet , #velho = :velho , #muistiinpano = :muistiinpano , #status = :status , #suunnitteluSopimus = :suunnitteluSopimus , #aloitusKuulutus = :aloitusKuulutus , #lisakuulutuskieli = :lisakuulutuskieli ",
 }
 `;

--- a/backend/test/fixture/projektiFixture.ts
+++ b/backend/test/fixture/projektiFixture.ts
@@ -40,6 +40,7 @@ export class ProjektiFixture {
     tallennettu: false,
     kayttoOikeudet: [ProjektiFixture.pekkaProjariProjektiKayttaja],
     tyyppi: ProjektiTyyppi.TIE,
+    lisakuulutuskieli: "ruotsi",
   };
 
   velhoprojekti1: DBProjekti = {
@@ -86,5 +87,6 @@ export class ProjektiFixture {
       elyKeskus: "Pirkanmaa",
       yhteystiedot: [ProjektiFixture.pekkaProjariProjektiKayttaja.kayttajatunnus],
     },
+    lisakuulutuskieli: "ruotsi",
   };
 }

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -1,8 +1,7 @@
 input TallennaProjektiInput {
   oid: String!
   muistiinpano: String
-  kuulutuksetRuotsiksi: Boolean
-  kuulutuksetSaameksi: Boolean
+  lisakuulutuskieli: String
   aloitusKuulutus: AloitusKuulutusInput
   suunnitteluSopimus: SuunnitteluSopimusInput
   kayttoOikeudet: [ProjektiKayttajaInput!]

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -48,8 +48,7 @@ type Projekti {
   false, jos projekti ladattiin Velhosta, mutta ei ole vielä tallennettu tietokantaan
   """
   tallennettu: Boolean
-  kuulutuksetRuotsiksi: Boolean
-  kuulutuksetSaameksi: Boolean
+  lisakuulutuskieli: String
 }
 
 type Velho {

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -109,6 +109,9 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
     setFormIsSubmitting(false);
   };
 
+  const hasLanguageSelected = 
+    projekti?.lisakuulutuskieli?.startsWith("ruotsi") || projekti?.lisakuulutuskieli?.startsWith("saame") || false
+
   useEffect(() => {
     if (projekti && projekti.oid) {
       const tallentamisTiedot: FormValues = {
@@ -125,12 +128,9 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
       reset(tallentamisTiedot);
       setLanguageChoicesAvailable( hasLanguageSelected );
     }
-  }, [projekti, reset]);
+  }, [projekti, reset, hasLanguageSelected]);
 
-  const hasLanguageSelected = () => {
-    const retval = (projekti?.lisakuulutuskieli?.startsWith("ruotsi") || projekti?.lisakuulutuskieli?.startsWith("saame") || false);
-    return retval;
-  }
+  ;
 
   useEffect(() => {
     if (router.isReady) {

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -29,7 +29,7 @@ import ProjektiRahoitus from "@components/projekti/ProjektiRahoitus";
 // Extend TallennaProjektiInput by making fields other than muistiinpano nonnullable and required
 type RequiredFields = Omit<
   TallennaProjektiInput,
-  "muistiinpano" | "suunnittelustaVastaavaViranomainen" | "aloitusKuulutus" | "suunnitteluSopimus"
+  "muistiinpano" | "suunnittelustaVastaavaViranomainen" | "aloitusKuulutus" | "suunnitteluSopimus" | "lisakuulutuskieli"
 >;
 type RequiredInputValues = Required<{
   [K in keyof RequiredFields]: NonNullable<RequiredFields[K]>;
@@ -49,7 +49,7 @@ const maxNoteLength = 2000;
 
 const validationSchema: SchemaOf<FormValues> = Yup.object().shape({
   oid: Yup.string().required(),
-  lisakuulutuskieli: Yup.string().required(),
+  lisakuulutuskieli: Yup.string().notRequired(),
   muistiinpano: Yup.string().max(
     maxNoteLength,
     `Muistiinpanoon voidaan kirjoittaa maksimissaan ${maxNoteLength} merkkiä.`
@@ -72,7 +72,6 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
 
   const [formIsSubmitting, setFormIsSubmitting] = useState(false);
   const [selectLanguageAvailable, setLanguageChoicesAvailable] = useState(false);
-  const [selectedKieli, onKieliValueChange] = useState("");
 
   const { data: kayttajat, error: kayttajatLoadError } = useSWR(apiConfig.listaaKayttajat.graphql, kayttajatLoader);
   const isLoadingKayttajat = !kayttajat && !kayttajatLoadError;
@@ -124,14 +123,12 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
           })) || [],
       };
       reset(tallentamisTiedot);
-      setLanguageChoicesAvailable( foo );
+      setLanguageChoicesAvailable( hasLanguageSelected );
     }
   }, [projekti, reset]);
 
-  const foo = function(){
-    console.log("projekti ladattu lisakuulutuskielella: ", projekti?.lisakuulutuskieli);
+  const hasLanguageSelected = function(){
     const retval = (projekti?.lisakuulutuskieli?.startsWith("ruotsi") || projekti?.lisakuulutuskieli?.startsWith("saame") || false);
-    console.log("asetetaan setlanguagechocieavailable: ", retval);
     return retval;
   }
 
@@ -148,17 +145,6 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
       }
     }
   }, [router.isReady, oid, projekti, setRouteLabels]);
-  
-/*   useEffect(() => {
-    console.log("valittu kieli: ", selectedKieli);
-    if(projekti) projekti.lisakuulutuskieli = selectedKieli;
-    console.log("projektin kieli: ", projekti?.lisakuulutuskieli);
-  }, [selectedKieli]) */
-
-  useEffect(() => {
-    console.log("kielivalintasäätimen uusi arvo: ", selectLanguageAvailable);
-    if(!selectLanguageAvailable) onKieliValueChange("-");
-  }, [selectLanguageAvailable])
 
   return (
     <ProjektiPageLayout title={"Projektin perustiedot"}>
@@ -212,9 +198,7 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
                 value="ruotsi" 
                 id="ruotsi" 
                 disabled={!selectLanguageAvailable}
-                //checked={selectedKieli === "ruotsi"}
-                {...register("lisakuulutuskieli")}
-                //onChange={() => onKieliValueChange("ruotsi")}
+                {...register("lisakuulutuskieli")}              
               >
               </RadioButton>
               <RadioButton 
@@ -222,9 +206,7 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
                 value="saame" 
                 id="saame" 
                 disabled={!selectLanguageAvailable}
-                //checked={selectedKieli === "saame"}
-                {...register("lisakuulutuskieli")}
-                //onChange={() => onKieliValueChange("saame")}
+                {...register("lisakuulutuskieli")}              
               >
               </RadioButton>
             </div>
@@ -277,6 +259,6 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
 }
 
 async function kayttajatLoader(_: string): Promise<Kayttaja[]> {
-  return [{__typename:"Kayttaja",etuNimi:"foo",sukuNimi:"bar"}];
+  //return [{__typename:"Kayttaja",etuNimi:"foo",sukuNimi:"bar"}];
   return await api.listUsers();
 }

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -35,7 +35,7 @@ type RequiredInputValues = Required<{
   [K in keyof RequiredFields]: NonNullable<RequiredFields[K]>;
 }>;
 
-type OptionalInputValues = Partial<Pick<TallennaProjektiInput, "muistiinpano">>;
+type OptionalInputValues = Partial<Pick<TallennaProjektiInput, "muistiinpano" | "lisakuulutuskieli">>;
 type FormValues = RequiredInputValues & OptionalInputValues;
 
 const defaultKayttaja: ProjektiKayttajaInput = {
@@ -49,8 +49,7 @@ const maxNoteLength = 2000;
 
 const validationSchema: SchemaOf<FormValues> = Yup.object().shape({
   oid: Yup.string().required(),
-  kuulutuksetRuotsiksi: Yup.boolean().required(),
-  kuulutuksetSaameksi: Yup.boolean().required(),
+  lisakuulutuskieli: Yup.string().required(),
   muistiinpano: Yup.string().max(
     maxNoteLength,
     `Muistiinpanoon voidaan kirjoittaa maksimissaan ${maxNoteLength} merkkiä.`
@@ -72,7 +71,8 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
   const isLoadingProjekti = !projekti && !projektiLoadError;
 
   const [formIsSubmitting, setFormIsSubmitting] = useState(false);
-  const [selectLanguageDisabled, setLanguageChoices] = useState(true);
+  const [selectLanguageAvailable, setLanguageChoicesAvailable] = useState(false);
+  const [selectedKieli, onKieliValueChange] = useState("");
 
   const { data: kayttajat, error: kayttajatLoadError } = useSWR(apiConfig.listaaKayttajat.graphql, kayttajatLoader);
   const isLoadingKayttajat = !kayttajat && !kayttajatLoadError;
@@ -86,7 +86,7 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
 
   const formOptions: UseFormProps<FormValues> = {
     resolver: yupResolver(validationSchema, { abortEarly: false, recursive: true }),
-    defaultValues: { muistiinpano: "", kayttoOikeudet: [defaultKayttaja] },
+    defaultValues: { muistiinpano: "", kayttoOikeudet: [defaultKayttaja], lisakuulutuskieli: "" },
     mode: "onChange",
     reValidateMode: "onChange",
   };
@@ -115,8 +115,7 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
       const tallentamisTiedot: FormValues = {
         oid: projekti.oid,
         muistiinpano: projekti.muistiinpano || "",
-        kuulutuksetRuotsiksi: projekti.kuulutuksetRuotsiksi || false,
-        kuulutuksetSaameksi: projekti.kuulutuksetSaameksi || false,
+        lisakuulutuskieli: projekti.lisakuulutuskieli || "",
         kayttoOikeudet:
           projekti.kayttoOikeudet?.map(({ kayttajatunnus, puhelinnumero, rooli }) => ({
             kayttajatunnus,
@@ -125,8 +124,16 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
           })) || [],
       };
       reset(tallentamisTiedot);
+      setLanguageChoicesAvailable( foo );
     }
   }, [projekti, reset]);
+
+  const foo = function(){
+    console.log("projekti ladattu lisakuulutuskielella: ", projekti?.lisakuulutuskieli);
+    const retval = (projekti?.lisakuulutuskieli?.startsWith("ruotsi") || projekti?.lisakuulutuskieli?.startsWith("saame") || false);
+    console.log("asetetaan setlanguagechocieavailable: ", retval);
+    return retval;
+  }
 
   useEffect(() => {
     if (router.isReady) {
@@ -141,6 +148,17 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
       }
     }
   }, [router.isReady, oid, projekti, setRouteLabels]);
+  
+/*   useEffect(() => {
+    console.log("valittu kieli: ", selectedKieli);
+    if(projekti) projekti.lisakuulutuskieli = selectedKieli;
+    console.log("projektin kieli: ", projekti?.lisakuulutuskieli);
+  }, [selectedKieli]) */
+
+  useEffect(() => {
+    console.log("kielivalintasäätimen uusi arvo: ", selectLanguageAvailable);
+    if(!selectLanguageAvailable) onKieliValueChange("-");
+  }, [selectLanguageAvailable])
 
   return (
     <ProjektiPageLayout title={"Projektin perustiedot"}>
@@ -184,10 +202,31 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
             <h4 className="vayla-small-title">Projetin kuulutusten kielet</h4>
             <Checkbox
               label="Projekti kuulutetaan suomenkielen lisäksi myös muilla kielillä"
-              id="kuulutuskieli" onChange={() => setLanguageChoices(!selectLanguageDisabled)}></Checkbox>
+              id="kuulutuskieli" 
+              onChange={() => setLanguageChoicesAvailable(!selectLanguageAvailable)}
+              checked={selectLanguageAvailable}
+            ></Checkbox>
             <div style={indentedStyle}>
-              <RadioButton label="Suomen lisäksi ruotsi" name="kielet" value="ruotsi" id="ruotsi" disabled={selectLanguageDisabled}></RadioButton>
-              <RadioButton label="Suomen lisäksi saame" name="kielet" value="saame" id="saame" disabled={selectLanguageDisabled}></RadioButton>
+              <RadioButton 
+                label="Suomen lisäksi ruotsi" 
+                value="ruotsi" 
+                id="ruotsi" 
+                disabled={!selectLanguageAvailable}
+                //checked={selectedKieli === "ruotsi"}
+                {...register("lisakuulutuskieli")}
+                //onChange={() => onKieliValueChange("ruotsi")}
+              >
+              </RadioButton>
+              <RadioButton 
+                label="Suomen lisäksi saame" 
+                value="saame" 
+                id="saame" 
+                disabled={!selectLanguageAvailable}
+                //checked={selectedKieli === "saame"}
+                {...register("lisakuulutuskieli")}
+                //onChange={() => onKieliValueChange("saame")}
+              >
+              </RadioButton>
             </div>
           </div>
           <hr />
@@ -238,5 +277,6 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
 }
 
 async function kayttajatLoader(_: string): Promise<Kayttaja[]> {
+  return [{__typename:"Kayttaja",etuNimi:"foo",sukuNimi:"bar"}];
   return await api.listUsers();
 }

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -127,7 +127,7 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
     }
   }, [projekti, reset]);
 
-  const hasLanguageSelected = function(){
+  const hasLanguageSelected = () => {
     const retval = (projekti?.lisakuulutuskieli?.startsWith("ruotsi") || projekti?.lisakuulutuskieli?.startsWith("saame") || false);
     return retval;
   }
@@ -259,6 +259,5 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
 }
 
 async function kayttajatLoader(_: string): Promise<Kayttaja[]> {
-  //return [{__typename:"Kayttaja",etuNimi:"foo",sukuNimi:"bar"}];
   return await api.listUsers();
 }


### PR DESCRIPTION
Perustietolomakkeen kielivalinta liikkuu. 

Puute: jos on tallennettu kielivalinta, ja koittaa poistaa sen UI:llä (rasti pois kohdasta Projektin kuulutusten kielet), niin se ei poistu tietokannasta. Yleisesti puuttuu vielä käsittely kenttien poistamiselle/tyhjentämiselle tietokannasta.