### PR TITLE
Feat: siirtyminen aloituskuulutukseen

### DIFF
--- a/backend/src/database/projektiDatabase.ts
+++ b/backend/src/database/projektiDatabase.ts
@@ -47,6 +47,7 @@ async function saveProjekti(dbProjekti: DBProjekti) {
   log.info("Updating projekti to Hassu ", { dbProjekti });
   const setExpression: string[] = [];
   const removeExpression: string[] = [];
+  const ExpressionAttributeNames = {} as any;
   const ExpressionAttributeValues = {} as any;
   for (const property in dbProjekti) {
     if (dbProjekti.hasOwnProperty(property)) {
@@ -60,7 +61,8 @@ async function saveProjekti(dbProjekti: DBProjekti) {
       if (value === null) {
         removeExpression.push(property);
       } else {
-        setExpression.push(`${property} = :${property}`);
+        setExpression.push(`#${property} = :${property}`);
+        ExpressionAttributeNames["#" + property] = property;
         ExpressionAttributeValues[":" + property] = value;
       }
     }
@@ -74,6 +76,7 @@ async function saveProjekti(dbProjekti: DBProjekti) {
       oid: dbProjekti.oid,
     },
     UpdateExpression: updateExpression,
+    ExpressionAttributeNames,
     ExpressionAttributeValues,
   };
 

--- a/backend/src/handler/projektiAdapter.ts
+++ b/backend/src/handler/projektiAdapter.ts
@@ -33,6 +33,7 @@ export class ProjektiAdapter {
       lisakuulutuskieli,
       eurahoitus,
       liittyvatSuunnitelmat,
+      status,
     } = changes;
     const kayttoOikeudetManager = new KayttoOikeudetManager(projekti.kayttoOikeudet, await personSearch.getKayttajas());
     kayttoOikeudetManager.applyChanges(kayttoOikeudet);
@@ -47,6 +48,7 @@ export class ProjektiAdapter {
         lisakuulutuskieli,
         eurahoitus,
         liittyvatSuunnitelmat,
+        status,
       }
     ) as DBProjekti;
   }

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -142,6 +142,7 @@ Array [
     "lisakuulutuskieli": undefined,
     "muistiinpano": undefined,
     "oid": "1",
+    "status": undefined,
     "suunnitteluSopimus": undefined,
   },
 ]
@@ -195,6 +196,7 @@ Array [
     "lisakuulutuskieli": undefined,
     "muistiinpano": undefined,
     "oid": "1",
+    "status": undefined,
     "suunnitteluSopimus": undefined,
   },
 ]
@@ -258,6 +260,7 @@ Array [
     "lisakuulutuskieli": undefined,
     "muistiinpano": undefined,
     "oid": "1",
+    "status": undefined,
     "suunnitteluSopimus": null,
   },
 ]

--- a/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
+++ b/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
@@ -2,6 +2,17 @@
 
 exports[`apiHandler updateSuunnitelma saveProjekti should pass expected parameters to DynamoDB 1`] = `
 Object {
+  "ExpressionAttributeNames": Object {
+    "#aloitusKuulutus": "aloitusKuulutus",
+    "#eurahoitus": "eurahoitus",
+    "#kayttoOikeudet": "kayttoOikeudet",
+    "#liittyvatSuunnitelmat": "liittyvatSuunnitelmat",
+    "#lisakuulutuskieli": "lisakuulutuskieli",
+    "#muistiinpano": "muistiinpano",
+    "#status": "status",
+    "#suunnitteluSopimus": "suunnitteluSopimus",
+    "#velho": "velho",
+  },
   "ExpressionAttributeValues": Object {
     ":aloitusKuulutus": Object {
       "elyKeskus": "Pirkanmaa",
@@ -61,12 +72,15 @@ Object {
     "oid": "1",
   },
   "TableName": "Projekti-localstack",
-  "UpdateExpression": "SET kayttoOikeudet = :kayttoOikeudet , velho = :velho , muistiinpano = :muistiinpano , status = :status , suunnitteluSopimus = :suunnitteluSopimus , aloitusKuulutus = :aloitusKuulutus , lisakuulutuskieli = :lisakuulutuskieli , eurahoitus = :eurahoitus , liittyvatSuunnitelmat = :liittyvatSuunnitelmat ",
+  "UpdateExpression": "SET #kayttoOikeudet = :kayttoOikeudet , #velho = :velho , #muistiinpano = :muistiinpano , #status = :status , #suunnitteluSopimus = :suunnitteluSopimus , #aloitusKuulutus = :aloitusKuulutus , #lisakuulutuskieli = :lisakuulutuskieli , #eurahoitus = :eurahoitus , #liittyvatSuunnitelmat = :liittyvatSuunnitelmat ",
 }
 `;
 
 exports[`apiHandler updateSuunnitelma saveProjekti should remove null fields from DynamoDB 1`] = `
 Object {
+  "ExpressionAttributeNames": Object {
+    "#muistiinpano": "muistiinpano",
+  },
   "ExpressionAttributeValues": Object {
     ":muistiinpano": "foo",
   },
@@ -74,6 +88,6 @@ Object {
     "oid": "1",
   },
   "TableName": "Projekti-localstack",
-  "UpdateExpression": "SET muistiinpano = :muistiinpano REMOVE suunnitteluSopimus",
+  "UpdateExpression": "SET #muistiinpano = :muistiinpano REMOVE suunnitteluSopimus",
 }
 `;

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -7,6 +7,7 @@ input TallennaProjektiInput {
   aloitusKuulutus: AloitusKuulutusInput
   suunnitteluSopimus: SuunnitteluSopimusInput
   kayttoOikeudet: [ProjektiKayttajaInput!]
+  status: Status
 }
 
 input SuunnitelmaInput {

--- a/src/components/projekti/ProjektiLiittyvatSuunnitelmat.tsx
+++ b/src/components/projekti/ProjektiLiittyvatSuunnitelmat.tsx
@@ -36,9 +36,10 @@ export default function ProjektiPerustiedot({ projekti }: Props): ReactElement {
     }
   }, [projekti]);
 
-  useEffect(()=> {
-    if(!isLiittyviaSuunnitelmia) remove()
-
+  useEffect(() => {
+    if (!isLiittyviaSuunnitelmia) {
+      remove();
+    }
   }, [isLiittyviaSuunnitelmia, remove]);
 
   return (

--- a/src/components/projekti/ProjektiLiittyvatSuunnitelmat.tsx
+++ b/src/components/projekti/ProjektiLiittyvatSuunnitelmat.tsx
@@ -17,7 +17,11 @@ interface Props {
 }
 
 export default function ProjektiPerustiedot({ projekti }: Props): ReactElement {
-  const { register, control } = useFormContext(); // retrieve all hook methods
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useFormContext(); // retrieve all hook methods
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -32,80 +36,90 @@ export default function ProjektiPerustiedot({ projekti }: Props): ReactElement {
     }
   }, [projekti]);
 
+  useEffect(()=> {
+    if(!isLiittyviaSuunnitelmia) remove()
+
+  }, [isLiittyviaSuunnitelmia, remove]);
+
   return (
     <>
       <h4 className="vayla-small-title">Projektiin liittyvät suunnitelmat</h4>
-      <fieldset>
-        <FormGroup label="Liittyykö projektiin muita voimassaolevia läkisääteisiä suunnitelmia" flexDirection="row">
-          <RadioButton
-            label="Kyllä"
-            name="liittyvia_suunnitelmia"
-            value="true"
-            id="liittyvia_suunnitelmia_kylla"
-            onChange={() => setLiittyviaSuunnitelmia(true)}
-            checked={isLiittyviaSuunnitelmia}
-          />
-          <RadioButton
-            label="Ei"
-            name="liittyvia_suunnitelmia"
-            value="false"
-            id="liittyvia_suunnitelmia_ei"
-            onChange={() => setLiittyviaSuunnitelmia(false)}
-            checked={!isLiittyviaSuunnitelmia}
-          />
-        </FormGroup>
-        <div>
-          {fields.map((field, index) => (
-            <div key={field.id} className="grid grid-cols-1 md:grid-cols-12 gap-x-6 mb-3">
-              <div className="md:col-span-4">
-                <TextInput
-                  label="Asiatunnus"
-                  {...register(`liittyvatSuunnitelmat.${index}.asiatunnus`)}
-                  disabled={!isLiittyviaSuunnitelmia}
-                />
-              </div>
-              <div className="md:col-span-6">
-                <TextInput
-                  label="Suunnitelman nimi"
-                  {...register(`liittyvatSuunnitelmat.${index}.nimi`)}
-                  disabled={!isLiittyviaSuunnitelmia}
-                />
-              </div>
-              <div>
-                <div className="hidden lg:block lg:mt-6">
-                  <IconButton
-                    icon="trash"
-                    onClick={(event) => {
-                      event.preventDefault();
-                      remove(index);
-                    }}
+
+      <FormGroup label="Liittyykö projektiin muita voimassaolevia läkisääteisiä suunnitelmia" flexDirection="row">
+        <RadioButton
+          label="Kyllä"
+          name="liittyvia_suunnitelmia"
+          value="true"
+          id="liittyvia_suunnitelmia_kylla"
+          onChange={() => setLiittyviaSuunnitelmia(true)}
+          checked={isLiittyviaSuunnitelmia}
+        />
+        <RadioButton
+          label="Ei"
+          name="liittyvia_suunnitelmia"
+          value="false"
+          id="liittyvia_suunnitelmia_ei"
+          onChange={() => setLiittyviaSuunnitelmia(false)}
+          checked={!isLiittyviaSuunnitelmia}
+        />
+      </FormGroup>
+      {isLiittyviaSuunnitelmia && (
+        <fieldset>
+          <div>
+            {fields.map((field, index) => (
+              <div key={field.id} className="grid grid-cols-1 md:grid-cols-12 gap-x-6 mb-3">
+                <div className="md:col-span-4">
+                  <TextInput
+                    label="Asiatunnus"
+                    {...register(`liittyvatSuunnitelmat.${index}.asiatunnus`)}
+                    disabled={!isLiittyviaSuunnitelmia}
+                    error={errors?.liittyvatSuunnitelmat?.[index]?.asiatunnus}
                   />
                 </div>
-                <div className="block lg:hidden">
-                  <Button
-                    onClick={(event) => {
-                      event.preventDefault();
-                      remove(index);
-                    }}
-                    endIcon="trash"
-                  >
-                    Poista
-                  </Button>
+                <div className="md:col-span-6">
+                  <TextInput
+                    label="Suunnitelman nimi"
+                    {...register(`liittyvatSuunnitelmat.${index}.nimi`)}
+                    disabled={!isLiittyviaSuunnitelmia}
+                    error={errors?.liittyvatSuunnitelmat?.[index]?.nimi}
+                  />
+                </div>
+                <div>
+                  <div className="hidden lg:block lg:mt-6">
+                    <IconButton
+                      icon="trash"
+                      onClick={(event) => {
+                        event.preventDefault();
+                        remove(index);
+                      }}
+                    />
+                  </div>
+                  <div className="block lg:hidden">
+                    <Button
+                      onClick={(event) => {
+                        event.preventDefault();
+                        remove(index);
+                      }}
+                      endIcon="trash"
+                    >
+                      Poista
+                    </Button>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
-        <Button
-          onClick={(event) => {
-            event.preventDefault();
-            append(defaultSuunnitelma);
-          }}
-          disabled={!isLiittyviaSuunnitelmia}
-        >
-          Uusi rivi +
-        </Button>
-      </fieldset>
+            ))}
+          </div>
+          <Button
+            onClick={(event) => {
+              event.preventDefault();
+              append(defaultSuunnitelma);
+            }}
+            disabled={!isLiittyviaSuunnitelmia}
+          >
+            Uusi rivi +
+          </Button>
+        </fieldset>
+      )}
     </>
   );
 }

--- a/src/components/projekti/ProjektiSideNavigation.tsx
+++ b/src/components/projekti/ProjektiSideNavigation.tsx
@@ -27,7 +27,7 @@ export default function ProjektiSideNavigation(): ReactElement {
     {
       title: "Aloituskuulutus",
       href: oid && `/yllapito/projekti/${oid}/aloituskuulutus`,
-      disabled: !projekti?.tallennettu,
+      disabled: !projekti?.aloitusKuulutus?.siirtyySuunnitteluVaiheeseen, //TODO: lisaa vaiheille tila enum tmv. ja vertaa sita
     },
     { title: "Suunnitteluvaihe", href: oid && `/yllapito/projekti/${oid}/suunnittelu`, disabled: true },
     { title: "Nähtävilläolovaihe", href: oid && `/yllapito/projekti/${oid}/nahtavillaolo`, disabled: true },

--- a/src/components/projekti/ProjektiSideNavigation.tsx
+++ b/src/components/projekti/ProjektiSideNavigation.tsx
@@ -28,7 +28,7 @@ export default function ProjektiSideNavigation(): ReactElement {
     {
       title: "Aloituskuulutus",
       href: oid && `/yllapito/projekti/${oid}/aloituskuulutus`,
-      disabled: projekti?.status === Status.EI_JULKAISTU, //TODO: muuta vertailemaan aloituskuulutuksen omaa tilaa myohemmassa vaiheessa
+      disabled: projekti?.status === Status.EI_JULKAISTU, // TODO: muuta vertailemaan aloituskuulutuksen omaa tilaa myohemmassa vaiheessa
     },
     { title: "Suunnitteluvaihe", href: oid && `/yllapito/projekti/${oid}/suunnittelu`, disabled: true },
     { title: "Nähtävilläolovaihe", href: oid && `/yllapito/projekti/${oid}/nahtavillaolo`, disabled: true },

--- a/src/components/projekti/ProjektiSideNavigation.tsx
+++ b/src/components/projekti/ProjektiSideNavigation.tsx
@@ -4,6 +4,7 @@ import styles from "@styles/projekti/ProjektiSideNavigation.module.css";
 import classNames from "classnames";
 import { useRouter } from "next/router";
 import useProjekti from "src/hooks/useProjekti";
+import { Status } from "@services/api";
 
 interface Route {
   title: string;
@@ -27,7 +28,7 @@ export default function ProjektiSideNavigation(): ReactElement {
     {
       title: "Aloituskuulutus",
       href: oid && `/yllapito/projekti/${oid}/aloituskuulutus`,
-      disabled: !projekti?.aloitusKuulutus?.siirtyySuunnitteluVaiheeseen, //TODO: lisaa vaiheille tila enum tmv. ja vertaa sita
+      disabled: projekti?.status === Status.EI_JULKAISTU, //TODO: muuta vertailemaan aloituskuulutuksen omaa tilaa myohemmassa vaiheessa
     },
     { title: "Suunnitteluvaihe", href: oid && `/yllapito/projekti/${oid}/suunnittelu`, disabled: true },
     { title: "Nähtävilläolovaihe", href: oid && `/yllapito/projekti/${oid}/nahtavillaolo`, disabled: true },

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -11,7 +11,6 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { FormProvider, useForm, UseFormProps } from "react-hook-form";
 import Button from "@components/button/Button";
 import Textarea from "@components/form/Textarea";
-import ButtonLink from "@components/button/ButtonLink";
 import Notification from "@components/notification/Notification";
 import ProjektiPerustiedot from "@components/projekti/ProjektiPerustiedot";
 import ExtLink from "@components/ExtLink";
@@ -27,6 +26,7 @@ import FormGroup from "@components/form/FormGroup";
 import axios from "axios";
 import { cloneDeep } from "lodash";
 import { puhelinNumeroSchema } from "src/schemas/puhelinNumero";
+import { Alert, Snackbar } from "@mui/material";
 
 export type FormValues = Pick<
   TallennaProjektiInput,
@@ -37,15 +37,25 @@ const maxNoteLength = 2000;
 
 const validationSchema: SchemaOf<FormValues> = Yup.object().shape({
   oid: Yup.string().required(),
-  lisakuulutuskieli: Yup.string().notRequired(),
+  lisakuulutuskieli: Yup.string().notRequired().nullable().test(
+    "not-null-when-lisakuulutus-selected-test",
+    "Valitse lisäkuulutuskieli",
+    function(kieli){
+      // if lisakuulutuskieli checkbox checked, select one language option
+      if(this.options?.context?.requireLisakuulutuskieli){
+        return kieli ? true : false;
+      }
+      return true;
+    }
+  ).default(null),
   liittyvatSuunnitelmat: Yup.array()
     .of(
       Yup.object().shape({
-        asiatunnus: Yup.string().required(),
-        nimi: Yup.string().required(),
+        asiatunnus: Yup.string().required("Asiatunnus puuttuu"),
+        nimi: Yup.string().required("Suunnitelman nimi puuttuu"),
       })
     )
-    .notRequired(),
+    .notRequired().nullable().default(null),
   eurahoitus: Yup.string().nullable().required("EU-rahoitustieto on pakollinen"),
   muistiinpano: Yup.string().max(
     maxNoteLength,
@@ -81,6 +91,10 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
 
   const [formIsSubmitting, setFormIsSubmitting] = useState(false);
   const [selectLanguageAvailable, setLanguageChoicesAvailable] = useState(false);
+  const [openToast, setToastOpen] = React.useState(false);
+  const handleClose = () => {
+    setToastOpen(false);
+  };
 
   const projektiHasErrors = !isLoadingProjekti && !loadedProjektiValidationSchema.isValidSync(projekti);
   const disableFormEdit = projektiHasErrors || isLoadingProjekti || formIsSubmitting;
@@ -88,10 +102,10 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
 
   const formOptions: UseFormProps<FormValues> = {
     resolver: yupResolver(validationSchema, { abortEarly: false, recursive: true }),
-    defaultValues: { muistiinpano: "", lisakuulutuskieli: "", eurahoitus: "", liittyvatSuunnitelmat: [] },
+    defaultValues: { muistiinpano: "", lisakuulutuskieli: null, eurahoitus: "", liittyvatSuunnitelmat: null },
     mode: "onChange",
     reValidateMode: "onChange",
-    context: formContext,
+    context: {requireLisakuulutuskieli: selectLanguageAvailable, ...formContext},
   };
 
   const useFormReturn = useForm<FormValues>(formOptions);
@@ -127,6 +141,7 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
       }
       await api.tallennaProjekti(formData);
       await reloadProjekti();
+      setToastOpen(true);
     } catch (e) {
       log.log("OnSubmit Error", e);
     }
@@ -141,7 +156,7 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
       const tallentamisTiedot: FormValues = {
         oid: projekti.oid,
         muistiinpano: projekti.muistiinpano || "",
-        lisakuulutuskieli: projekti.lisakuulutuskieli || "",
+        lisakuulutuskieli: projekti.lisakuulutuskieli || null,
         eurahoitus: projekti.eurahoitus || "",
         liittyvatSuunnitelmat:
           projekti?.liittyvatSuunnitelmat?.map((suunnitelma) => {
@@ -197,28 +212,34 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
             <hr />
             <div className="content">
               <h4 className="vayla-small-title">Projektin kuulutusten kielet</h4>
-              <Checkbox
-                label="Projekti kuulutetaan suomenkielen lisäksi myös muilla kielillä"
-                id="kuulutuskieli"
-                onChange={() => setLanguageChoicesAvailable(!selectLanguageAvailable)}
-                checked={selectLanguageAvailable}
-              ></Checkbox>
-              <div className="indent">
-                <RadioButton
-                  label="Suomen lisäksi ruotsi"
-                  value="ruotsi"
-                  id="ruotsi"
-                  disabled={!selectLanguageAvailable}
-                  {...register("lisakuulutuskieli")}
-                ></RadioButton>
-                <RadioButton
-                  label="Suomen lisäksi saame"
-                  value="saame"
-                  id="saame"
-                  disabled={!selectLanguageAvailable}
-                  {...register("lisakuulutuskieli")}
-                ></RadioButton>
-              </div>
+              <FormGroup 
+                flexDirection="col"
+                errorMessage={errors.lisakuulutuskieli?.message}
+              >
+                <Checkbox
+                  label="Projekti kuulutetaan suomenkielen lisäksi myös muilla kielillä"
+                  id="kuulutuskieli"
+                  onChange={() => setLanguageChoicesAvailable(!selectLanguageAvailable)}
+                  checked={selectLanguageAvailable}
+                  
+                ></Checkbox>
+                <div className="indent">
+                  <RadioButton
+                    label="Suomen lisäksi ruotsi"
+                    value="ruotsi"
+                    id="ruotsi"
+                    disabled={!selectLanguageAvailable}
+                    {...register("lisakuulutuskieli")}
+                  ></RadioButton>
+                  <RadioButton
+                    label="Suomen lisäksi saame"
+                    value="saame"
+                    id="saame"
+                    disabled={!selectLanguageAvailable}
+                    {...register("lisakuulutuskieli")}
+                  ></RadioButton>
+                </div>
+              </FormGroup>
             </div>
             <hr />
             <div className="content">
@@ -259,17 +280,28 @@ export default function ProjektiSivu({ setRouteLabels }: PageProps) {
             <hr />
             <Notification>Tallennus ei vielä julkaise tietoja.</Notification>
             <div className="flex justify-between flex-wrap gap-4">
-              <Button primary={!projekti?.tallennettu} disabled={disableFormEdit}>
-                Tallenna projekti
+              <Button primary={true} disabled={disableFormEdit}>
+                Tallenna ja siirry aloituskuulutukseen
               </Button>
-              {projekti?.tallennettu && projekti?.oid && (
-                <ButtonLink primary href={`/yllapito/projekti/${projekti?.oid}/aloituskuulutus`}>
-                  Siirry Aloituskuulutukseen
-                </ButtonLink>
-              )}
             </div>
           </fieldset>
         </form>
+        <Snackbar 
+          open={openToast} 
+          autoHideDuration={6000} 
+          onClose={handleClose}
+          anchorOrigin={{vertical: 'top', horizontal:'right'}}
+          sx={{paddingTop:'10px'}}
+        >
+          <Alert 
+            onClose={handleClose} 
+            elevation={6} 
+            variant="filled" 
+            severity="success" 
+          >
+            Tietojen tallennus onnistui!
+          </Alert>
+        </Snackbar>
       </FormProvider>
     </ProjektiPageLayout>
   );


### PR DESCRIPTION
Toistaiseksi käyttää projektin status kenttää mm. navigointipalkin kohteiden näyttämisessä, mutta ehdotukseni aiemmin oli, että jokaiselle vaiheelle (aloituskuulutus, suunniteluvaihe, nähtävilläolo jne) tulee vaihekohtainen tila/status (esim. AVOIN, AKTIIVINEN, LOPPUNUT, SULJETTU tms.). Näin saadaan hienojakoisempi vaiheistus/tila, jolle on tarvetta muutenkin, kuin vain navigoinnissa.

Samoin toistaiseksi perustietojen tallennuksen onnistumisilmoitus tulee ennen siirtymistä, ja siirtymä on viivästetty, mutta jatkossa ilmoitusten näyttäminen ulkoistetaan tuolta komponentilta ja ainakaan sen vuoksi ei tarvitse siirtymää viivästyttää, mutta mahdollisesti muista saavutettavuus tms syistä silloinkin?