### PR TITLE
feature: hakuindeksin poisto-, sekä uudelleenindeksointitoiminto

### DIFF
--- a/backend/integrationtest/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
+++ b/backend/integrationtest/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProjektiSearchService should index, update, search, and delete document to search engine successfully 1`] = `
+Object {
+  "liittyvatSuunnitelmat": Array [
+    Object {
+      "asiatunnus": "atunnus123",
+      "nimi": "Littyva suunnitelma 1 nimi",
+    },
+  ],
+  "muistiinpano": "Testiprojekti 1:n muistiinpano",
+  "oid": "ProjektiSearchService1",
+  "velho": Object {
+    "kunnat": Array [
+      "Tampere",
+      "Nokia",
+    ],
+    "nimi": "Testiprojekti 1",
+    "tilaajaOrganisaatio": "Uudenmaan ELY-keskus",
+    "tyyppi": "TIE",
+    "vaylamuoto": Array [
+      "tie",
+    ],
+  },
+}
+`;

--- a/backend/integrationtest/projektiSearch/projektiSearchService.test.ts
+++ b/backend/integrationtest/projektiSearch/projektiSearchService.test.ts
@@ -2,26 +2,39 @@
 import { describe, it } from "mocha";
 import { ProjektiFixture } from "../../test/fixture/projektiFixture";
 import { projektiSearchService } from "../../src/projektiSearch/projektiSearchService";
+import { projektiDatabase } from "../../src/database/projektiDatabase";
+import { setupLocalDatabase } from "../util/databaseUtil";
+import { ProjektiSearchMaintenanceService } from "../../src/projektiSearch/projektiSearchMaintenanceService";
 
 const { expect } = require("chai");
 
 const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
-describe("ProjektiSearchService", () => {
-  const projekti = new ProjektiFixture().dbProjekti1;
+describe.skip("ProjektiSearchService", () => {
+  const projektiFixture = new ProjektiFixture();
+  const projekti1 = { ...projektiFixture.dbProjekti1, oid: "ProjektiSearchService1" };
+  const projekti2 = { ...projektiFixture.dbProjekti1, oid: "ProjektiSearchService2" };
 
-  it.skip("should index, update, search, and delete document to search engine successfully", async () => {
-    await projektiSearchService.indexProjekti(projekti);
-    await projektiSearchService.indexProjekti(projekti);
+  before(async () => {
+    await setupLocalDatabase();
+    await projektiDatabase.createProjekti(projekti1);
+    await projektiDatabase.createProjekti(projekti2);
+  });
+
+  after(async () => {
+    await projektiSearchService.removeProjekti(projekti1.oid);
+    await projektiSearchService.removeProjekti(projekti2.oid);
+  });
+
+  it("should index, update, search, and delete document to search engine successfully", async () => {
+    const maintenanceService = new ProjektiSearchMaintenanceService();
+    const startKey = await maintenanceService.index({ action: "index" });
+    expect(startKey).to.be.undefined;
     await delay(500);
+
     const dbProjektis = await projektiSearchService.search({
-      oid: [projekti.oid],
+      oid: [projekti1.oid],
     });
-    expect(dbProjektis[0]).to.deep.equal({
-      oid: projekti.oid,
-      muistiinpano: projekti.muistiinpano,
-      velho: projekti.velho,
-    });
-    await projektiSearchService.removeProjekti(projekti.oid);
+    expect(dbProjektis[0]).toMatchSnapshot();
   });
 });

--- a/backend/src/database/projektiDatabase.ts
+++ b/backend/src/database/projektiDatabase.ts
@@ -30,6 +30,24 @@ async function listProjektit(): Promise<DBProjekti[]> {
   return data.Items as DBProjekti[];
 }
 
+async function scanProjektit(startKey?: string): Promise<{ startKey: string; projektis: DBProjekti[] }> {
+  try {
+    const params: DocumentClient.ScanInput = {
+      TableName: projektiTableName,
+      Limit: 10,
+      ExclusiveStartKey: startKey ? JSON.parse(startKey) : undefined,
+    };
+    const data: DocumentClient.ScanOutput = await getDynamoDBDocumentClient().scan(params).promise();
+    return {
+      projektis: data.Items as DBProjekti[],
+      startKey: data.LastEvaluatedKey ? JSON.stringify(data.LastEvaluatedKey) : undefined,
+    };
+  } catch (e) {
+    log.error(e);
+    throw e;
+  }
+}
+
 async function loadProjektiByOid(oid: string): Promise<DBProjekti | undefined> {
   const params: DocumentClient.GetItemInput = {
     TableName: projektiTableName,
@@ -219,6 +237,7 @@ export const projektiDatabase = {
   createProjekti,
   saveProjekti,
   listProjektit,
+  scanProjektit,
   loadProjektiByOid,
   archiveProjektiByOid,
   insertAloitusKuulutusJulkaisu,

--- a/backend/src/projektiSearch/openSearchClient.ts
+++ b/backend/src/projektiSearch/openSearchClient.ts
@@ -67,6 +67,18 @@ export class OpenSearchClient {
     return await sendRequest(request);
   }
 
+  async deleteIndex(): Promise<void> {
+    const request = new HttpRequest({
+      headers: {
+        host: domain,
+      },
+      hostname: domain,
+      method: "DELETE",
+      path: index,
+    });
+    return await sendRequest(request);
+  }
+
   async query(query: any): Promise<any> {
     const request = new HttpRequest({
       body: JSON.stringify({

--- a/backend/src/projektiSearch/projektiSearchMaintenanceService.ts
+++ b/backend/src/projektiSearch/projektiSearchMaintenanceService.ts
@@ -1,0 +1,22 @@
+import { openSearchClient } from "./openSearchClient";
+import { projektiDatabase } from "../database/projektiDatabase";
+import { projektiSearchService } from "./projektiSearchService";
+
+export type MaintenanceEvent = {
+  action: "deleteIndex" | "index";
+  startKey?: string;
+};
+
+export class ProjektiSearchMaintenanceService {
+  async deleteIndex() {
+    return await openSearchClient.deleteIndex();
+  }
+
+  async index(event: MaintenanceEvent) {
+    const scanResult = await projektiDatabase.scanProjektit(event.startKey);
+    for (const projekti of scanResult.projektis) {
+      await projektiSearchService.indexProjekti(projekti);
+    }
+    return scanResult.startKey;
+  }
+}

--- a/backend/test/projektiSearch/dynamoDBStreamHandler.test.ts
+++ b/backend/test/projektiSearch/dynamoDBStreamHandler.test.ts
@@ -3,6 +3,7 @@ import { handleDynamoDBEvents } from "../../src/projektiSearch/dynamoDBStreamHan
 import { ProjektiSearchFixture } from "./projektiSearchFixture";
 import { openSearchClient } from "../../src/projektiSearch/openSearchClient";
 import { ProjektiFixture } from "../fixture/projektiFixture";
+import { Context } from "aws-lambda";
 
 const sandbox = require("sinon").createSandbox();
 
@@ -25,28 +26,29 @@ describe("dynamoDBStreamHandler", () => {
     sandbox.restore();
   });
 
+  const context = { functionName: "myFunction" } as Context;
   it("should index new projektis successfully", async () => {
-    await handleDynamoDBEvents(fixture.createNewProjektiEvent(projekti));
+    await handleDynamoDBEvents(fixture.createNewProjektiEvent(projekti), context);
     expect(indexProjektiStub).callCount(1);
     expect(indexProjektiStub.getCall(0).args[0]).to.be.equal(projekti.oid);
     expect(indexProjektiStub.getCall(0).args[1]).toMatchSnapshot();
   });
 
   it("should index projekti updates successfully", async () => {
-    await handleDynamoDBEvents(fixture.createUpdateProjektiEvent(projekti));
+    await handleDynamoDBEvents(fixture.createUpdateProjektiEvent(projekti), context);
     expect(indexProjektiStub).callCount(1);
     expect(indexProjektiStub.getCall(0).args[0]).to.be.equal(projekti.oid);
     expect(indexProjektiStub.getCall(0).args[1]).toMatchSnapshot();
   });
 
   it("should remove deleted projekti from index successfully", async () => {
-    await handleDynamoDBEvents(fixture.createdDeleteProjektiEvent(projekti.oid));
+    await handleDynamoDBEvents(fixture.createdDeleteProjektiEvent(projekti.oid), context);
     expect(removeProjektiStub).callCount(1);
     expect(removeProjektiStub.getCall(0).firstArg).to.be.equal(projekti.oid);
   });
 
   it("should search projects successfully", async () => {
-    await handleDynamoDBEvents(fixture.createdDeleteProjektiEvent(projekti.oid));
+    await handleDynamoDBEvents(fixture.createdDeleteProjektiEvent(projekti.oid), context);
     expect(removeProjektiStub).callCount(1);
     expect(removeProjektiStub.getCall(0).firstArg).to.be.equal(projekti.oid);
   });

--- a/backend/test/setup.js
+++ b/backend/test/setup.js
@@ -28,7 +28,6 @@ process.env.AWS_ACCESS_KEY_ID = "test";
 process.env.AWS_SECRET_ACCESS_KEY = "test";
 
 process.env.PERSON_SEARCH_UPDATER_LAMBDA_ARN = "not-supported-in-local-tests";
-process.env.SEARCH_DOMAIN = "search-not-supported-in-local-tests";
 process.env.FRONTEND_DOMAIN_NAME = "localhost";
 
 process.env.FRONTEND_PRIVATEKEY =


### PR DESCRIPTION
Käyttö: aws konsolista hassu-dynamodb-stream-handler-[env] lambdan testaustoiminnolla voi antaa seuraavat komennot:
Indeksin poisto:
```
{
  "action": "deleteIndex"
}
```

Uudelleenindeksointi:
```
{
  "action": "index"
}
```
