### PR TITLE
feat: Vuorovaikutuskierroksen julkaisun jälkeinen tila (HASSU-652)

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -18,6 +18,7 @@ const Button = (
     primary,
     className,
     onClick,
+    style,
     ...props
   }: Props & React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
   ref: React.ForwardedRef<HTMLButtonElement>
@@ -26,6 +27,7 @@ const Button = (
 
   return (
     <button
+      style={style}
       className={classNames(buttonClass, className)}
       ref={ref}
       // Work around for click events bubbling from children even if button is disabled

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -6,6 +6,7 @@ interface Props {
   noDivider?: boolean;
   children?: ReactNode;
   smallGaps?: boolean;
+  className?: string;
 }
 
 function Section({ children, noDivider, ...rest }: Props): ReactElement {

--- a/src/components/projekti/suunnitteluvaihe/EsitettavatYhteystiedot.tsx
+++ b/src/components/projekti/suunnitteluvaihe/EsitettavatYhteystiedot.tsx
@@ -8,7 +8,7 @@ import {
   YhteystietoInput
 } from "@services/api";
 import Section from "@components/layout/Section";
-import { ReactElement, Fragment } from "react";
+import { ReactElement, useMemo, Fragment } from "react";
 import Button from "@components/button/Button";
 import HassuStack from "@components/layout/HassuStack";
 import CheckBox from "@components/form/CheckBox";
@@ -18,6 +18,8 @@ import HassuGrid from "@components/HassuGrid";
 import { maxPhoneLength } from "src/schemas/puhelinNumero";
 import IconButton from "@components/button/IconButton";
 import { UseFormReturn } from "react-hook-form";
+import capitalize from "lodash/capitalize";
+import replace from "lodash/replace";
 
 const defaultYhteystieto: YhteystietoInput = {
   etunimi: "",
@@ -44,12 +46,22 @@ type FormValues = RequiredProjektiFields & {
 interface Props<T> {
   useFormReturn: UseFormReturn<T>;
   projekti: Projekti;
+  vuorovaikutusnro: number;
 }
 
 export default function EsitettavatYhteystiedot<T extends FormValues>({
   projekti,
+  vuorovaikutusnro,
   useFormReturn,
 }: Props<T>): ReactElement {
+
+  const v = useMemo(() => {
+    return projekti?.suunnitteluVaihe?.vuorovaikutukset?.find((v) => {
+      return v.vuorovaikutusNumero === vuorovaikutusnro;
+    });
+  }, [projekti, vuorovaikutusnro]);
+
+  const julkinen = v?.julkinen;
 
   const {
     register,
@@ -61,6 +73,23 @@ export default function EsitettavatYhteystiedot<T extends FormValues>({
     control,
     name: "suunnitteluVaihe.vuorovaikutus.esitettavatYhteystiedot",
   });
+
+  //TODO: lisää v?.vuorovaikutusYhteyshenkilot
+  if (julkinen) {
+    return (
+      <Section>
+        <SectionContent>
+          <p className="vayla-label mb-5">Vuorovaikuttamisen yhteyshenkilöt</p>
+          {v?.esitettavatYhteystiedot?.map((yhteystieto, index) => (
+            <p style={{ margin: 0 }} key={index}>
+              {capitalize(yhteystieto.etunimi)} {capitalize(yhteystieto.sukunimi)}, puh. {yhteystieto.puhelinnumero},{" "}
+              {yhteystieto?.sahkoposti ? replace(yhteystieto?.sahkoposti, "@", "[at]") : ""} ({yhteystieto.organisaatio})
+            </p>
+          ))}
+        </SectionContent>
+      </Section>
+    );
+  }
 
   return (
     <Section>

--- a/src/components/projekti/suunnitteluvaihe/HyvaksymisDialogi.tsx
+++ b/src/components/projekti/suunnitteluvaihe/HyvaksymisDialogi.tsx
@@ -1,0 +1,107 @@
+import SectionContent from "@components/layout/SectionContent";
+import Section from "@components/layout/Section";
+import React, { ReactElement } from "react";
+import Button from "@components/button/Button";
+import HassuStack from "@components/layout/HassuStack";
+import HassuDialog from "@components/HassuDialog";
+import WindowCloseButton from "@components/button/WindowCloseButton";
+import useTranslation from "next-translate/useTranslation";
+import {
+  IlmoituksenVastaanottajatInput,
+} from "@services/api";
+
+interface Props {
+  ilmoituksenVastaanottajat: IlmoituksenVastaanottajatInput | null | undefined;
+  dialogiOnAuki: boolean;
+  onClose: () => void;
+  tallenna: (e?: React.BaseSyntheticEvent<object, any, any> | undefined) => Promise<void>;
+  julkinen: boolean;
+}
+
+
+export default function HyvaksymisDialogi({
+  ilmoituksenVastaanottajat,
+  dialogiOnAuki,
+  onClose,
+  tallenna,
+  julkinen
+}: Props): ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <HassuDialog open={dialogiOnAuki} onClose={onClose}>
+      <Section noDivider smallGaps>
+        <SectionContent>
+          <div className="vayla-dialog-title flex">
+            <div className="flex-grow">Kuulutuksen hyväksyminen ja ilmoituksen lähettäminen</div>
+            <div className="justify-end">
+              <WindowCloseButton
+                onClick={() => {
+                  onClose();
+                }}
+              ></WindowCloseButton>
+            </div>
+          </div>
+        </SectionContent>
+        <SectionContent>
+          <div className="vayla-dialog-content">
+            <form>
+              {julkinen
+                ? <p>Olet päivittämässä vuorovaikutustietoja. Ilmoitus päivitetyistä tiedoista lähetetään seuraaville:</p>
+                : <p>
+                    Olet tallentamassa vuorovaikutustiedot ja käynnistämässä siihen liittyvän ilmoituksen automaattisen
+                    lähettämisen. Ilmoitus vuorovaikutuksesta lähetetään seuraaville:
+                  </p>
+              }
+              <div className="content">
+                <p>Viranomaiset</p>
+                <ul className="vayla-dialog-list">
+                  {ilmoituksenVastaanottajat?.viranomaiset?.map((viranomainen) => (
+                    <li key={viranomainen.nimi}>
+                      {t(`common:viranomainen.${viranomainen.nimi}`)}, {viranomainen.sahkoposti}
+                    </li>
+                  ))}
+                </ul>
+                <p>Kunnat</p>
+                <ul className="vayla-dialog-list">
+                  {ilmoituksenVastaanottajat?.kunnat?.map((kunta) => (
+                    <li key={kunta.nimi}>
+                      {kunta.nimi}, {kunta.sahkoposti}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div className="content">
+                {julkinen
+                  ? <p>Ilmoitukset lähetetään automaattisesti painikkeen klikkaamisen jälkeen.</p>
+                  : <p>
+                      Klikkaamalla Tallenna ja lähetä -painiketta vahvistat vuorovaikutustiedot tarkastetuksi ja
+                      hyväksyt sen julkaisun asetettuna julkaisupäivänä sekä ilmoituksien lähettämisen. Ilmoitukset
+                      lähetetään automaattisesti painikkeen klikkaamisen jälkeen.
+                    </p>
+                }
+              </div>
+              <HassuStack
+                direction={["column", "column", "row"]}
+                justifyContent={[undefined, undefined, "flex-end"]}
+                paddingTop={"1rem"}
+              >
+                <Button primary onClick={tallenna}>
+                  Hyväksy ja lähetä
+                </Button>
+                <Button
+                  onClick={(e) => {
+                    onClose();
+                    e.preventDefault();
+                  }}
+                >
+                  Peruuta
+                </Button>
+              </HassuStack>
+            </form>
+          </div>
+        </SectionContent>
+      </Section>
+    </HassuDialog>
+  );
+}

--- a/src/components/projekti/suunnitteluvaihe/IlmoituksenVastaanottajat.tsx
+++ b/src/components/projekti/suunnitteluvaihe/IlmoituksenVastaanottajat.tsx
@@ -8,14 +8,17 @@ import useTranslation from "next-translate/useTranslation";
 import IconButton from "@components/button/IconButton";
 import {
   IlmoitettavaViranomainen,
-  KuntaVastaanottajaInput
+  KuntaVastaanottajaInput,
+  Vuorovaikutus
 } from "@services/api";
 import Section from "@components/layout/Section";
 import SectionContent from "@components/layout/SectionContent";
 import HassuGrid from "@components/HassuGrid";
+import dayjs from "dayjs";
 
 interface Props {
   kirjaamoOsoitteet: KuntaVastaanottajaInput[] | null;
+  vuorovaikutus: Vuorovaikutus | undefined;
 }
 
 type FormFields = {
@@ -31,8 +34,11 @@ type FormFields = {
 
 export default function IlmoituksenVastaanottajat({
   kirjaamoOsoitteet,
+  vuorovaikutus
 }: Props): ReactElement {
   const { t } = useTranslation("commonFI");
+
+  const julkinen = !!vuorovaikutus?.julkinen;
 
   const {
     register,
@@ -72,103 +78,161 @@ export default function IlmoituksenVastaanottajat({
   }
 
   return (
-    <Section>
-      <h4 className="vayla-small-title">Ilmoituksen vastaanottajat</h4>
-      <SectionContent>
-        <p>
-          Vuorovaikuttamisesta lähetetään sähköpostitse tiedote viranomaiselle sekä projektia koskeville kunnille.
-          Kunnat on haettu Projektivelhosta. Jos tiedote pitää lähettää useammalle kuin yhdelle
-          viranomaisorganisaatiolle, lisää uusi rivi Lisää uusi -painikkeella
-        </p>
-        <p>Jos kuntatiedoissa on virhe, tee korjaus Projektivelhoon.</p>
-      </SectionContent>
-
-      <>
-        <SectionContent>
-          <h6 className="font-bold">Viranomaiset</h6>
-          {viranomaisFields.map((viranomainen, index) => (
-            <HassuGrid key={viranomainen.id} cols={{ lg: 3 }}>
-              <Select
-                label="Viranomainen *"
-                options={kirjaamoOsoitteet?.map(({ nimi }) => ({ label: nimi ? t(`viranomainen.${nimi}`) : "", value: nimi }))}
-                {...register(`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.viranomaiset.${index}.nimi`, {
-                  onChange: (event) => {
-                    const sahkoposti = kirjaamoOsoitteet?.find(({ nimi }) => nimi === event.target.value)?.sahkoposti;
-                    setValue(
-                      `suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.viranomaiset.${index}.sahkoposti`,
-                      sahkoposti || ""
-                    );
-                  },
-                })}
-                error={errors?.suunnitteluVaihe?.vuorovaikutus?.ilmoituksenVastaanottajat?.viranomaiset?.[index]?.nimi}
-                addEmptyOption
-              />
-              <Controller
-                control={control}
-                name={`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.viranomaiset.${index}.sahkoposti`}
-                render={({ field }) => (
-                  <>
-                    <TextInput label="Sähköpostiosoite *" value={field.value} disabled />
-                    <input type="hidden" {...field} />
-                  </>
-                )}
-              />
-              {!!index &&
+    <>
+      {julkinen &&
+        <Section>
+          <h4 className="vayla-small-title">Ilmoituksen vastaanottajat</h4>
+          <SectionContent>
+            <p>
+              Ilmoitukset on lähetetty eteenpäin alla oleville viranomaisille ja kunnille. Jos ilmoituksen tila on ‘Ei
+              lähetetty’, tarkasta sähköpostiosoite. Ota tarvittaessa yhteys pääkäyttäjään.
+            </p>
+          </SectionContent>
+          <SectionContent>
+            <h6 className="font-bold">Viranomaiset</h6>
+            <div className="content grid grid-cols-4 mb-4">
+              <p className="vayla-table-header">Kunta</p>
+              <p className="vayla-table-header">Sähköpostiosoite</p>
+              <p className="vayla-table-header">Ilmoituksen tila</p>
+              <p className="vayla-table-header">Lähetysaika</p>
+              {vuorovaikutus?.ilmoituksenVastaanottajat?.viranomaiset?.map((viranomainen, index) => (
                 <>
-                  <div className="hidden lg:block" style={{ alignSelf: "flex-end" }}>
-                    <IconButton
-                      icon="trash"
-                      onClick={(event) => {
-                        event.preventDefault();
-                        remove(index);
-                      }}
-                    />
-                  </div>
-                  <div className="block lg:hidden">
-                    <Button
-                      onClick={(event) => {
-                        event.preventDefault();
-                        remove(index);
-                      }}
-                      endIcon="trash"
-                    >
-                      Poista
-                    </Button>
-                  </div>
+                  <p className={getStyleForRow(index)}>{viranomainen.nimi}</p>
+                  <p className={getStyleForRow(index)}>{viranomainen.sahkoposti}</p>
+                  <p className={getStyleForRow(index)}>{viranomainen.lahetetty ? "Lahetetty" : "Ei lähetetty"}</p>
+                  <p className={getStyleForRow(index)}>
+                    {viranomainen.lahetetty ? dayjs(viranomainen.lahetetty).format("DD.MM.YYYY HH:mm") : null}
+                  </p>
                 </>
-              }
-            </HassuGrid>
-          ))}
-        </SectionContent>
-        <Button
-          type="button"
-          onClick={() => {
-            // @ts-ignore
-            append({ nimi: "", sahkoposti: "" });
-          }}
-        >
-          Lisää uusi +
-        </Button>
-      </>
-      <SectionContent>
-        <h6 className="font-bold">Kunnat</h6>
+              ))}
+            </div>
+            <h6 className="font-bold">Kunnat</h6>
+            <div className="content grid grid-cols-4 mb-4">
+              <p className="vayla-table-header">Kunta</p>
+              <p className="vayla-table-header">Sähköpostiosoite</p>
+              <p className="vayla-table-header">Ilmoituksen tila</p>
+              <p className="vayla-table-header">Lähetysaika</p>
+              {vuorovaikutus?.ilmoituksenVastaanottajat?.kunnat?.map((kunta, index) => (
+                <>
+                  <p className={getStyleForRow(index)}>{kunta.nimi}</p>
+                  <p className={getStyleForRow(index)}>{kunta.sahkoposti}</p>
+                  <p className={getStyleForRow(index)}>{kunta.lahetetty ? "Lahetetty" : "Ei lähetetty"}</p>
+                  <p className={getStyleForRow(index)}>
+                    {kunta.lahetetty ? dayjs(kunta.lahetetty).format("DD.MM.YYYY HH:mm") : null}
+                  </p>
+                </>
+              ))}
+            </div>
+          </SectionContent>
+        </Section>
+      }
+      <div style={julkinen ? { display: "none" } : {}}>
+        <Section>
+          <h4 className="vayla-small-title">Ilmoituksen vastaanottajat</h4>
+          <SectionContent>
+            <p>
+              Vuorovaikuttamisesta lähetetään sähköpostitse tiedote viranomaiselle sekä projektia koskeville kunnille.
+              Kunnat on haettu Projektivelhosta. Jos tiedote pitää lähettää useammalle kuin yhdelle
+              viranomaisorganisaatiolle, lisää uusi rivi Lisää uusi -painikkeella
+            </p>
+            <p>Jos kuntatiedoissa on virhe, tee korjaus Projektivelhoon.</p>
+          </SectionContent>
 
-        {kuntaFields.map((kunta, index) => (
-          <HassuGrid key={kunta.id} cols={{ lg: 3 }}>
-            <input
-              type="hidden"
-              {...register(`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.kunnat.${index}.nimi`)}
-              readOnly
-            />
-            <TextInput label="Kunta *" value={getKuntanimi(index)} disabled />
-            <TextInput
-              label="Sähköpostiosoite *"
-              error={errors?.suunnitteluVaihe?.vuorovaikutus?.ilmoituksenVastaanottajat?.kunnat?.[index]?.sahkoposti}
-              {...register(`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.kunnat.${index}.sahkoposti`)}
-            />
-          </HassuGrid>
-        ))}
-      </SectionContent>
-    </Section>
+          <>
+            <SectionContent>
+              <h6 className="font-bold">Viranomaiset</h6>
+              {viranomaisFields.map((viranomainen, index) => (
+                <HassuGrid key={viranomainen.id} cols={{ lg: 3 }}>
+                  <Select
+                    label="Viranomainen *"
+                    options={kirjaamoOsoitteet?.map(({ nimi }) => ({ label: nimi ? t(`viranomainen.${nimi}`) : "", value: nimi }))}
+                    {...register(`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.viranomaiset.${index}.nimi`, {
+                      onChange: (event) => {
+                        const sahkoposti = kirjaamoOsoitteet?.find(({ nimi }) => nimi === event.target.value)?.sahkoposti;
+                        setValue(
+                          `suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.viranomaiset.${index}.sahkoposti`,
+                          sahkoposti || ""
+                        );
+                      },
+                    })}
+                    error={errors?.suunnitteluVaihe?.vuorovaikutus?.ilmoituksenVastaanottajat?.viranomaiset?.[index]?.nimi}
+                    addEmptyOption
+                  />
+                  <Controller
+                    control={control}
+                    name={`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.viranomaiset.${index}.sahkoposti`}
+                    render={({ field }) => (
+                      <>
+                        <TextInput label="Sähköpostiosoite *" value={field.value} disabled />
+                        <input type="hidden" {...field} />
+                      </>
+                    )}
+                  />
+                  {!!index &&
+                    <>
+                      <div className="hidden lg:block" style={{ alignSelf: "flex-end" }}>
+                        <IconButton
+                          icon="trash"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            remove(index);
+                          }}
+                        />
+                      </div>
+                      <div className="block lg:hidden">
+                        <Button
+                          onClick={(event) => {
+                            event.preventDefault();
+                            remove(index);
+                          }}
+                          endIcon="trash"
+                        >
+                          Poista
+                        </Button>
+                      </div>
+                    </>
+                  }
+                </HassuGrid>
+              ))}
+            </SectionContent>
+            <Button
+              type="button"
+              onClick={() => {
+                // @ts-ignore
+                append({ nimi: "", sahkoposti: "" });
+              }}
+            >
+              Lisää uusi +
+            </Button>
+          </>
+          <SectionContent>
+            <h6 className="font-bold">Kunnat</h6>
+
+            {kuntaFields.map((kunta, index) => (
+              <HassuGrid key={kunta.id} cols={{ lg: 3 }}>
+                <input
+                  type="hidden"
+                  {...register(`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.kunnat.${index}.nimi`)}
+                  readOnly
+                />
+                <TextInput label="Kunta *" value={getKuntanimi(index)} disabled />
+                <TextInput
+                  label="Sähköpostiosoite *"
+                  error={errors?.suunnitteluVaihe?.vuorovaikutus?.ilmoituksenVastaanottajat?.kunnat?.[index]?.sahkoposti}
+                  {...register(`suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat.kunnat.${index}.sahkoposti`)}
+                />
+              </HassuGrid>
+            ))}
+          </SectionContent>
+        </Section>
+      </div>
+    </>
   );
+}
+
+function getStyleForRow(index: number): string | undefined {
+  if (index % 2 == 0) {
+    return "vayla-table-even";
+  }
+  return "vayla-table-odd";
 }

--- a/src/components/projekti/suunnitteluvaihe/LukutilaLinkkiJaKutsut.tsx
+++ b/src/components/projekti/suunnitteluvaihe/LukutilaLinkkiJaKutsut.tsx
@@ -1,0 +1,52 @@
+import SectionContent from "@components/layout/SectionContent";
+import Section from "@components/layout/Section";
+import React, { ReactElement, useMemo } from "react";
+import {
+  Vuorovaikutus,
+  Projekti,
+  Kieli
+} from "@services/api";
+import { examineJulkaisuPaiva } from "src/util/dateUtils";
+import { Link } from "@mui/material";
+import lowerCase from "lodash/lowerCase";
+
+interface Props {
+  vuorovaikutus: Vuorovaikutus;
+  projekti: Projekti;
+}
+
+
+export default function LukutilaLinkkiJaKutsut({
+  vuorovaikutus,
+  projekti
+}: Props): ReactElement {
+
+  let { julkaisuPaiva, published } = examineJulkaisuPaiva(true, vuorovaikutus.vuorovaikutusJulkaisuPaiva);
+
+  const aloituskuulutusjulkaisu = useMemo(() => {
+    return projekti?.aloitusKuulutusJulkaisut?.[projekti?.aloitusKuulutusJulkaisut?.length - 1 || 0];
+  }, [projekti]);
+
+  const ensisijainenKieli = aloituskuulutusjulkaisu?.kielitiedot?.ensisijainenKieli || Kieli.SUOMI;
+  const toissijainenKieli = aloituskuulutusjulkaisu?.kielitiedot?.toissijainenKieli || Kieli.RUOTSI;
+
+
+  return (
+    <Section>
+      <SectionContent>
+        <p className="vayla-label mb-5">Kutsu vuorovaikuttamiseen julkisella puolella</p>
+        {published
+          ? <p><Link underline="none" href={`/suunnitelma/${projekti.oid}/suunnittelu`}>Linkki</Link></p>
+          : <p>Linkki julkiselle puolelle muodostetaan vuorovaikuttamisen julkaisupäivänä. Julkaisupäivä {julkaisuPaiva}. </p>
+        }
+        <p className="vayla-label mb-5">Ladattavat kutsut ja ilmoitukset</p>
+        <div>Kutsu ja ilmoitus pääkielellä ({lowerCase(ensisijainenKieli)})</div>
+        <div><Link underline="none" href="#">Linkki</Link></div>
+        <div><Link underline="none" href="#">Linkki2</Link></div>
+        <div>Kutsu ja ilmoitus toisella kielellä ({lowerCase(toissijainenKieli)})</div>
+        <div><Link underline="none" href="#">Linkki</Link></div>
+        <div><Link underline="none" href="#">Linkki2</Link></div>
+      </SectionContent>
+    </Section>
+  );
+}

--- a/src/components/projekti/suunnitteluvaihe/LuonnoksetJaAineistot.tsx
+++ b/src/components/projekti/suunnitteluvaihe/LuonnoksetJaAineistot.tsx
@@ -7,9 +7,10 @@ import TextInput from "@components/form/TextInput";
 import Notification, { NotificationType } from "@components/notification/Notification";
 import IconButton from "@components/button/IconButton";
 import HassuStack from "@components/layout/HassuStack";
-import { TallennaProjektiInput, VuorovaikutusInput } from "@services/api";
+import { TallennaProjektiInput, VuorovaikutusInput, Vuorovaikutus } from "@services/api";
 import { useFieldArray, UseFormReturn } from "react-hook-form";
 import AineistojenValitseminenDialog from "./AineistojenValitseminenDialog";
+import { Link } from "@mui/material";
 
 type Videot = Pick<VuorovaikutusInput, "videot">;
 type SuunnitteluMateriaali = Pick<VuorovaikutusInput, "suunnittelumateriaali">;
@@ -27,15 +28,18 @@ type FormValues = RequiredProjektiFields & {
 
 interface Props<T> {
   useFormReturn: UseFormReturn<T>;
+  vuorovaikutus: Vuorovaikutus | undefined;
+  avaaHyvaksymisDialogi: () => void;
 }
 
-export default function LuonnoksetJaAineistot<T extends FormValues>({ useFormReturn }: Props<T>) {
+export default function LuonnoksetJaAineistot<T extends FormValues>({ useFormReturn, vuorovaikutus, avaaHyvaksymisDialogi}: Props<T>) {
   const [aineistoDialogOpen, setAineistoDialogOpen] = useState(false);
+  const [muokkaustila, setMuokkaustila] = useState(false);
 
   const openAineistoDialog = () => setAineistoDialogOpen(true);
   const closeAineistoDialog = () => setAineistoDialogOpen(false);
 
-  // const context = useFormContext();
+  const julkinen = vuorovaikutus?.julkinen;
 
   const {
     control,
@@ -52,92 +56,155 @@ export default function LuonnoksetJaAineistot<T extends FormValues>({ useFormRet
     name: "suunnitteluVaihe.vuorovaikutus.videot",
   });
 
+  const esittelyaineistot = vuorovaikutus?.aineistot?.filter(() => true);
+  const suunnitelmaluonnokset = vuorovaikutus?.aineistot?.filter(() => true);
+
   return (
-    <Section>
-      <SectionContent>
-        <h4 className="vayla-small-title">Suunnitelmaluonnokset ja esittelyaineistot</h4>
-        <p>
-          Esittelyvideo tulee olla ladattuna erilliseen videojulkaisupalveluun (esim. Youtube) ja videon katselulinkki
-          tuodaan sille tarkoitettuun kenttään. Luonnokset ja muut materiaalit tuodaan Projektivelhosta.
-          Suunnitelmaluonnokset ja esittelyaineistot on mahdollista. Suunnitelmaluonnokset ja aineistot julkaistaan
-          palvelun julkisella puolella vuorovaikutuksen julkaisupäivänä.{" "}
-        </p>
-        <Notification type={NotificationType.INFO_GRAY}>
-          Huomioithan, että suunnitelmaluonnoksien ja esittelyaineistojen tulee täyttää saavutettavuusvaatimukset.{" "}
-        </Notification>
-      </SectionContent>
-      <SectionContent>
-        <h5 className="vayla-smallest-title">Suunnitelmaluonnokset ja esittelyaineistot</h5>
-        <Button type="button" onClick={openAineistoDialog}>
-          Tuo Aineistoja
-        </Button>
-        <AineistojenValitseminenDialog open={aineistoDialogOpen} onClose={closeAineistoDialog} />
-      </SectionContent>
-      <SectionContent>
-        <h5 className="vayla-smallest-title">Ennalta kuvattu videoesittely</h5>
-        {videotFields.map((field, index) => (
-          <HassuStack key={field.id} direction={"row"}>
-            <TextInput
-              style={{ width: "100%" }}
-              key={field.id}
-              {...register(`suunnitteluVaihe.vuorovaikutus.videot.${index}.url`)}
-              label="Linkki videoon"
-              error={(errors as any)?.suunnitteluVaihe?.vuorovaikutus?.videot?.[index]?.url}
-            />
-            {!!index && (
-              <div>
-                <div className="hidden lg:block lg:mt-8">
-                  <IconButton
-                    icon="trash"
-                    onClick={(event) => {
-                      event.preventDefault();
-                      removeVideot(index);
-                    }}
-                  />
-                </div>
-                <div className="block lg:hidden">
-                  <Button
-                    onClick={(event) => {
-                      event.preventDefault();
-                      removeVideot(index);
-                    }}
-                    endIcon="trash"
-                  >
-                    Poista
+    <>
+      {(!muokkaustila && julkinen) &&
+        <Section>
+          <Button style={{ float: "right" }} type="submit" onClick={() => setMuokkaustila(true)}>
+            Muokkaa
+          </Button>
+          <p className="vayla-label mb-5">Suunnitelmaluonnokset ja esittelyaineistot</p>
+          {!!(vuorovaikutus?.videot && vuorovaikutus?.videot.length) &&
+            <SectionContent>
+              <div>Videoesittely</div>
+              {vuorovaikutus.videot.map(video => <div key={video.url}><Link underline="none" href={video.url}>{video.url}</Link></div>)}
+            </SectionContent>
+          }
+          {!(vuorovaikutus?.aineistot && vuorovaikutus?.aineistot.length) &&
+            <SectionContent>
+              <p>Lisää suunnitelmalle luonnokset ja esittelyaineistot Muokkaa-painikkeesta.</p>
+            </SectionContent>
+          }
+          {!!(esittelyaineistot && esittelyaineistot.length) &&
+            <SectionContent>
+              <div>Esittelyaineistot</div>
+              {esittelyaineistot.map(aineisto => <div key={aineisto.dokumenttiOid}><Link underline="none" href={aineisto.tiedosto || "#"}>{aineisto.tiedosto}</Link></div>)}
+            </SectionContent>
+          }
+          {!!(suunnitelmaluonnokset && suunnitelmaluonnokset.length) &&
+            <SectionContent>
+              <div>Suunnitelmaluonnokset</div>
+              {suunnitelmaluonnokset.map(aineisto => <div key={aineisto.dokumenttiOid}><Link underline="none" href={aineisto.tiedosto || "#"}>{aineisto.tiedosto}</Link></div>)}
+            </SectionContent>
+          }
+          {vuorovaikutus?.suunnittelumateriaali?.nimi &&
+            <SectionContent>
+              <div>Muu esittelymateriaali</div>
+              <div>{vuorovaikutus.suunnittelumateriaali.nimi}</div>
+              <div><Link underline="none" href={vuorovaikutus.suunnittelumateriaali.url}>{vuorovaikutus.suunnittelumateriaali.url}</Link></div>
+            </SectionContent>
+          }
+        </Section>
+      }
+      <Section className={(muokkaustila || !julkinen) ? "" : "hidden"}>
+        <SectionContent>
+          {julkinen
+            ? <HassuStack direction={["column", "column", "row"]} justifyContent="space-between" >
+                <h4 style={{ display: "inline" }} className="vayla-small-title">Suunnitelmaluonnokset ja esittelyaineistot</h4>
+                <HassuStack direction={["column", "column", "row"]}>
+                  <Button primary type="submit" onClick={(e) => {
+                    e.preventDefault();
+                    setMuokkaustila(false);
+                    avaaHyvaksymisDialogi();
+                  }}>
+                    Päivitä
                   </Button>
+                  <Button onClick={(e) => {
+                    e.preventDefault();
+                    setMuokkaustila(false);
+                  }}>
+                    Peruuta
+                  </Button>
+                </HassuStack>
+              </HassuStack>
+            : <h4 className="vayla-small-title">Suunnitelmaluonnokset ja esittelyaineistot</h4>
+          }
+          <p>
+            Esittelyvideo tulee olla ladattuna erilliseen videojulkaisupalveluun (esim. Youtube) ja videon katselulinkki
+            tuodaan sille tarkoitettuun kenttään. Luonnokset ja muut materiaalit tuodaan Projektivelhosta.
+            Suunnitelmaluonnokset ja esittelyaineistot on mahdollista. Suunnitelmaluonnokset ja aineistot julkaistaan
+            palvelun julkisella puolella vuorovaikutuksen julkaisupäivänä.{" "}
+          </p>
+          <Notification type={NotificationType.INFO_GRAY}>
+            Huomioithan, että suunnitelmaluonnoksien ja esittelyaineistojen tulee täyttää saavutettavuusvaatimukset.{" "}
+          </Notification>
+        </SectionContent>
+        <SectionContent>
+          <h5 className="vayla-smallest-title">Suunnitelmaluonnokset ja esittelyaineistot</h5>
+          <Button type="button" onClick={openAineistoDialog}>
+            Tuo Aineistoja
+          </Button>
+          <AineistojenValitseminenDialog open={aineistoDialogOpen} onClose={closeAineistoDialog} />
+        </SectionContent>
+        <SectionContent>
+          <h5 className="vayla-smallest-title">Ennalta kuvattu videoesittely</h5>
+          {videotFields.map((field, index) => (
+            <HassuStack key={field.id} direction={"row"}>
+              <TextInput
+                style={{ width: "100%" }}
+                key={field.id}
+                {...register(`suunnitteluVaihe.vuorovaikutus.videot.${index}.url`)}
+                label="Linkki videoon"
+                error={(errors as any)?.suunnitteluVaihe?.vuorovaikutus?.videot?.[index]?.url}
+              />
+              {!!index && (
+                <div>
+                  <div className="hidden lg:block lg:mt-8">
+                    <IconButton
+                      icon="trash"
+                      onClick={(event) => {
+                        event.preventDefault();
+                        removeVideot(index);
+                      }}
+                    />
+                  </div>
+                  <div className="block lg:hidden">
+                    <Button
+                      onClick={(event) => {
+                        event.preventDefault();
+                        removeVideot(index);
+                      }}
+                      endIcon="trash"
+                    >
+                      Poista
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            )}
-          </HassuStack>
-        ))}
-        <Button
-          onClick={(event) => {
-            event.preventDefault();
-            appendVideot({ nimi: "", url: "" });
-          }}
-        >
-          Lisää uusi +
-        </Button>
-      </SectionContent>
-      <SectionContent>
-        <h5 className="vayla-smallest-title">Muut esittelymateriaalit</h5>
-        <p>
-          Muu esittelymateraali on järjestelmän ulkopuolelle julkaistua suunnitelmaan liittyvää materiaalia. Muun
-          esittelymateriaalin lisääminen on vapaaehtoista.{" "}
-        </p>
-        <TextInput
-          style={{ width: "100%" }}
-          label="Linkin kuvaus"
-          {...register(`suunnitteluVaihe.vuorovaikutus.suunnittelumateriaali.nimi`)}
-          error={(errors as any)?.suunnitteluVaihe?.vuorovaikutus?.suunnittelumateriaali?.nimi}
-        />
-        <TextInput
-          style={{ width: "100%" }}
-          label="Linkki muihin esittelyaineistoihin"
-          {...register(`suunnitteluVaihe.vuorovaikutus.suunnittelumateriaali.url`)}
-          error={(errors as any)?.suunnitteluVaihe?.vuorovaikutus?.suunnittelumateriaali?.url}
-        />
-      </SectionContent>
-    </Section>
+              )}
+            </HassuStack>
+          ))}
+          <Button
+            onClick={(event) => {
+              event.preventDefault();
+              appendVideot({ nimi: "", url: "" });
+            }}
+          >
+            Lisää uusi +
+          </Button>
+        </SectionContent>
+        <SectionContent>
+          <h5 className="vayla-smallest-title">Muut esittelymateriaalit</h5>
+          <p>
+            Muu esittelymateraali on järjestelmän ulkopuolelle julkaistua suunnitelmaan liittyvää materiaalia. Muun
+            esittelymateriaalin lisääminen on vapaaehtoista.{" "}
+          </p>
+          <TextInput
+            style={{ width: "100%" }}
+            label="Linkin kuvaus"
+            {...register(`suunnitteluVaihe.vuorovaikutus.suunnittelumateriaali.nimi`)}
+            error={(errors as any)?.suunnitteluVaihe?.vuorovaikutus?.suunnittelumateriaali?.nimi}
+          />
+          <TextInput
+            style={{ width: "100%" }}
+            label="Linkki muihin esittelyaineistoihin"
+            {...register(`suunnitteluVaihe.vuorovaikutus.suunnittelumateriaali.url`)}
+            error={(errors as any)?.suunnitteluVaihe?.vuorovaikutus?.suunnittelumateriaali?.url}
+          />
+        </SectionContent>
+      </Section>
+    </>
   );
 }

--- a/src/components/projekti/suunnitteluvaihe/PaivamaaratJaTiedot.tsx
+++ b/src/components/projekti/suunnitteluvaihe/PaivamaaratJaTiedot.tsx
@@ -1,0 +1,132 @@
+import SectionContent from "@components/layout/SectionContent";
+import { useFormContext } from "react-hook-form";
+import {
+  Projekti,
+  Kieli
+} from "@services/api";
+import React, { ReactElement, useMemo } from "react";
+import DatePicker from "@components/form/DatePicker";
+import { formatDate } from "src/util/dateUtils";
+import dayjs from "dayjs";
+import lowerCase from "lodash/lowerCase";
+
+
+
+interface Props {
+  projekti?: Projekti | null;
+  vuorovaikutusnro: number | null | undefined;
+}
+
+type FormFields = {
+  suunnitteluVaihe: {
+    vuorovaikutus: {
+      vuorovaikutusJulkaisuPaiva: string | null,
+      kysymyksetJaPalautteetViimeistaan: string | null;
+    }
+  };
+};
+
+export default function SuunnitteluvaiheenVuorovaikuttaminen({
+  projekti,
+  vuorovaikutusnro
+}: Props): ReactElement {
+
+  const {
+    register,
+    formState: { errors }
+  } = useFormContext<FormFields>();
+
+  const today = dayjs().format();
+
+  const v = useMemo(() => {
+    return projekti?.suunnitteluVaihe?.vuorovaikutukset?.find((v) => {
+      return v.vuorovaikutusNumero === vuorovaikutusnro;
+    });
+  }, [projekti, vuorovaikutusnro]);
+
+  const aloituskuulutusjulkaisu = useMemo(() => {
+    return projekti?.aloitusKuulutusJulkaisut?.[projekti?.aloitusKuulutusJulkaisut?.length - 1 || 0];
+  }, [projekti]);
+
+  const ensisijainenKieli = aloituskuulutusjulkaisu?.kielitiedot?.ensisijainenKieli || Kieli.SUOMI;
+  const toissijainenKieli = aloituskuulutusjulkaisu?.kielitiedot?.toissijainenKieli || Kieli.RUOTSI;
+
+  const julkinen = v?.julkinen;
+
+
+  if (!projekti) {
+    return <></>;
+  }
+
+  if (julkinen && aloituskuulutusjulkaisu) {
+    return (
+      <>
+        <SectionContent>
+          <p className="vayla-label">Julkaisupäivä</p>
+          <p>
+            {formatDate(v?.vuorovaikutusJulkaisuPaiva)}
+          </p>
+        </SectionContent>
+        <SectionContent>
+          <p className="vayla-label">
+            Tiivistetty hankkeen sisällönkuvaus ensisijaisella kielellä (
+            {lowerCase(ensisijainenKieli)})
+          </p>
+          <p>
+            {projekti?.aloitusKuulutus?.hankkeenKuvaus?.[ensisijainenKieli]}
+          </p>
+        </SectionContent>
+        {aloituskuulutusjulkaisu.kielitiedot?.toissijainenKieli && (
+          <SectionContent className="content">
+            <p className="vayla-label">
+              Tiivistetty hankkeen sisällönkuvaus toissijaisella kielellä (
+              {lowerCase(toissijainenKieli)})
+            </p>
+            <p>
+              {projekti?.aloitusKuulutus?.hankkeenKuvaus?.[toissijainenKieli]}
+            </p>
+          </SectionContent>
+        )}
+        <SectionContent>
+          <p className="vayla-label">
+            Kysymykset ja palautteet
+          </p>
+          <p>
+            Kansalaisia pyydetään esittämään kysymykset ja palautteet viimeistään   {formatDate(v?.kysymyksetJaPalautteetViimeistaan)}.
+          </p>
+        </SectionContent>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SectionContent>
+        <h4 className="vayla-small-title">Julkaisupäivä</h4>
+        <p>
+          Anna päivämäärä, jolloin vuorovaikutusosio palvelun julkisella puolella ja kutsu vuorovaikutukseen
+          muilla ilmoituskanavilla julkaistaan.
+        </p>
+        <DatePicker
+          label="Julkaisupäivä *"
+          className="md:max-w-min"
+          {...register("suunnitteluVaihe.vuorovaikutus.vuorovaikutusJulkaisuPaiva")}
+          min={today}
+          error={errors.suunnitteluVaihe?.vuorovaikutus?.vuorovaikutusJulkaisuPaiva}
+        />
+      </SectionContent>
+      <SectionContent>
+        <h4 className="vayla-small-title">Kysymyksien esittäminen ja palautteiden antaminen</h4>
+        <p>Anna päivämäärä, johon mennessä kansalaisten toivotaan esittävän kysymykset ja palautteet.</p>
+        <DatePicker
+          label="Kysymykset ja palautteet viimeistään *"
+          className="md:max-w-min"
+          {...register("suunnitteluVaihe.vuorovaikutus.kysymyksetJaPalautteetViimeistaan")}
+          min={today}
+          error={errors.suunnitteluVaihe?.vuorovaikutus?.kysymyksetJaPalautteetViimeistaan}
+        />
+      </SectionContent>
+    </>
+  );
+
+}

--- a/src/components/projekti/suunnitteluvaihe/SuunnitteluvaiheenVuorovaikuttaminen.tsx
+++ b/src/components/projekti/suunnitteluvaihe/SuunnitteluvaiheenVuorovaikuttaminen.tsx
@@ -7,12 +7,9 @@ import {
   Projekti,
   api,
   VuorovaikutusInput,
-  VuorovaikutusTilaisuusTyyppi,
-  Yhteystieto,
-  YhteystietoInput,
   ViranomaisVastaanottajaInput,
   IlmoitettavaViranomainen,
-  IlmoituksenVastaanottajatInput
+  IlmoituksenVastaanottajatInput,
 } from "@services/api";
 import Section from "@components/layout/Section";
 import React, { ReactElement, useEffect, useState, useMemo, useCallback } from "react";
@@ -22,23 +19,20 @@ import log from "loglevel";
 import HassuSpinner from "@components/HassuSpinner";
 import { KeyedMutator } from "swr";
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
-import DatePicker from "@components/form/DatePicker";
-import dayjs from "dayjs";
 import { vuorovaikutusSchema } from "src/schemas/vuorovaikutus";
 import HassuStack from "@components/layout/HassuStack";
-import VuorovaikutusDialog from "./VuorovaikutustilaisuusDialog";
-import { formatDate } from "src/util/dateUtils";
-import capitalize from "lodash/capitalize";
 import { Stack } from "@mui/material";
-import HassuDialog from "@components/HassuDialog";
-import WindowCloseButton from "@components/button/WindowCloseButton";
-import useTranslation from "next-translate/useTranslation";
+import HyvaksymisDialogi from "./HyvaksymisDialogi";
 import { UseFormReturn } from "react-hook-form";
 import EsitettavatYhteystiedot from "./EsitettavatYhteystiedot";
 import LuonnoksetJaAineistot from "./LuonnoksetJaAineistot";
 import IlmoituksenVastaanottajat from "./IlmoituksenVastaanottajat";
 import { removeTypeName } from "src/util/removeTypeName";
 import getIlmoitettavaViranomainen from "src/util/getIlmoitettavaViranomainen";
+import VuorovaikuttamisenInfo from "./VuorovaikuttamisenInfo";
+import PaivamaaratJaTiedot from "./PaivamaaratJaTiedot";
+import LukutilaLinkkiJaKutsut from "./LukutilaLinkkiJaKutsut";
+import VuorovaikutusMahdollisuudet from "./VuorovaikutusMahdollisuudet";
 
 type ProjektiFields = Pick<TallennaProjektiInput, "oid">;
 type RequiredProjektiFields = Required<{
@@ -74,9 +68,7 @@ type FormValuesForEsitettavatYhteystiedot = RequiredProjektiFields & {
   suunnitteluVaihe: {
     vuorovaikutus: Pick<
       VuorovaikutusInput,
-      | "vuorovaikutusNumero"
-      | "esitettavatYhteystiedot"
-      | "vuorovaikutusYhteysHenkilot"
+      "vuorovaikutusNumero" | "esitettavatYhteystiedot" | "vuorovaikutusYhteysHenkilot"
     >;
   };
 };
@@ -86,78 +78,86 @@ interface Props {
   reloadProjekti?: KeyedMutator<ProjektiLisatiedolla | null>;
   isDirtyHandler: (isDirty: boolean) => void;
   vuorovaikutusnro: number;
-  kirjaamoOsoitteet: ViranomaisVastaanottajaInput[] | null
+  kirjaamoOsoitteet: ViranomaisVastaanottajaInput[] | null;
 }
 
-const defaultListWithEmptyLink = (list : (LinkkiInput[] | null | undefined)) : LinkkiInput[] => {
+const defaultListWithEmptyLink = (list: LinkkiInput[] | null | undefined): LinkkiInput[] => {
   if (!list || !list.length) {
     return [{ url: "", nimi: "" }];
   }
-  return list.map(link => ({ nimi: link.nimi, url: link.url }));
+  return list.map((link) => ({ nimi: link.nimi, url: link.url }));
 };
 
-const defaultVastaanottajat = (projekti: Projekti | null | undefined, vuorovaikutusnro: number, kirjaamoOsoitteet: ViranomaisVastaanottajaInput[] | null) : IlmoituksenVastaanottajatInput => {
+const defaultVastaanottajat = (
+  projekti: Projekti | null | undefined,
+  vuorovaikutusnro: number,
+  kirjaamoOsoitteet: ViranomaisVastaanottajaInput[] | null
+): IlmoituksenVastaanottajatInput => {
   const v = projekti?.suunnitteluVaihe?.vuorovaikutukset?.find((v) => {
     return v.vuorovaikutusNumero === vuorovaikutusnro;
   });
   let kunnat: KuntaVastaanottajaInput[];
   let viranomaiset: ViranomaisVastaanottajaInput[];
   if (v?.ilmoituksenVastaanottajat?.kunnat) {
-    kunnat = v?.ilmoituksenVastaanottajat?.kunnat.map(kunta => {
+    kunnat = v?.ilmoituksenVastaanottajat?.kunnat.map((kunta) => {
       kunta = removeTypeName(kunta);
       delete kunta.lahetetty;
       return kunta;
     });
   } else {
-    kunnat = projekti?.velho?.kunnat?.map(s => {
-      return {
-      nimi: s,
-      sahkoposti: ""
-    } as KuntaVastaanottajaInput; }) || []
+    kunnat =
+      projekti?.velho?.kunnat?.map((s) => {
+        return {
+          nimi: s,
+          sahkoposti: "",
+        } as KuntaVastaanottajaInput;
+      }) || [];
   }
   if (v?.ilmoituksenVastaanottajat?.viranomaiset) {
-    viranomaiset = v?.ilmoituksenVastaanottajat?.viranomaiset.map(kunta => {
+    viranomaiset = v?.ilmoituksenVastaanottajat?.viranomaiset.map((kunta) => {
       kunta = removeTypeName(kunta);
       delete kunta.lahetetty;
       return kunta;
     });
   } else {
-    viranomaiset = projekti?.velho?.suunnittelustaVastaavaViranomainen === "VAYLAVIRASTO"
-    ? (projekti?.velho?.maakunnat?.map(maakunta => {
-        const ely : IlmoitettavaViranomainen = getIlmoitettavaViranomainen(maakunta);
-        return kirjaamoOsoitteet?.find(osoite => osoite.nimi == ely)
-          || { nimi: maakunta, sahkoposti: "" } as ViranomaisVastaanottajaInput;
-      })  || [])
-    : [
-        kirjaamoOsoitteet?.find(osoite => osoite.nimi == "VAYLAVIRASTO")
-        || { nimi: "VAYLAVIRASTO" as IlmoitettavaViranomainen, sahkoposti: "" } as ViranomaisVastaanottajaInput
-      ]
+    viranomaiset =
+      projekti?.velho?.suunnittelustaVastaavaViranomainen === "VAYLAVIRASTO"
+        ? projekti?.velho?.maakunnat?.map((maakunta) => {
+            const ely: IlmoitettavaViranomainen = getIlmoitettavaViranomainen(maakunta);
+            return (
+              kirjaamoOsoitteet?.find((osoite) => osoite.nimi == ely) ||
+              ({ nimi: maakunta, sahkoposti: "" } as ViranomaisVastaanottajaInput)
+            );
+          }) || []
+        : [
+            kirjaamoOsoitteet?.find((osoite) => osoite.nimi == "VAYLAVIRASTO") ||
+              ({ nimi: "VAYLAVIRASTO" as IlmoitettavaViranomainen, sahkoposti: "" } as ViranomaisVastaanottajaInput),
+          ];
   }
   return {
     kunnat,
-    viranomaiset
+    viranomaiset,
   };
-}
+};
 
 export default function SuunnitteluvaiheenVuorovaikuttaminen({
   projekti,
   reloadProjekti,
   isDirtyHandler,
   vuorovaikutusnro,
-  kirjaamoOsoitteet
+  kirjaamoOsoitteet,
 }: Props): ReactElement {
-
-  const [openVuorovaikutustilaisuus, setOpenVuorovaikutustilaisuus] = useState(false);
   const [isFormSubmitting, setIsFormSubmitting] = useState(false);
   const [openHyvaksy, setOpenHyvaksy] = useState(false);
   const { showSuccessMessage, showErrorMessage } = useSnackbars();
-  const today = dayjs().format();
-  const { t } = useTranslation();
 
-  const defaultValues : Omit<VuorovaikutusFormValues, "oid"> = useMemo(() => {
-    const v = projekti?.suunnitteluVaihe?.vuorovaikutukset?.find((v) => {
+  const v = useMemo(() => {
+    return projekti?.suunnitteluVaihe?.vuorovaikutukset?.find((v) => {
       return v.vuorovaikutusNumero === vuorovaikutusnro;
     });
+  }, [projekti, vuorovaikutusnro]);
+
+  const defaultValues: Omit<VuorovaikutusFormValues, "oid"> = useMemo(() => {
     return {
       suunnitteluVaihe: {
         vuorovaikutus: {
@@ -168,8 +168,7 @@ export default function SuunnitteluvaiheenVuorovaikuttaminen({
             projekti?.kayttoOikeudet
               ?.filter(({ kayttajatunnus }) => v?.vuorovaikutusYhteysHenkilot?.includes(kayttajatunnus))
               .map(({ kayttajatunnus }) => kayttajatunnus) || [],
-          esitettavatYhteystiedot:
-            v?.esitettavatYhteystiedot?.map((yhteystieto) => removeTypeName(yhteystieto)) || [],
+          esitettavatYhteystiedot: v?.esitettavatYhteystiedot?.map((yhteystieto) => removeTypeName(yhteystieto)) || [],
           ilmoituksenVastaanottajat: defaultVastaanottajat(projekti, vuorovaikutusnro, kirjaamoOsoitteet),
           vuorovaikutusTilaisuudet:
             v?.vuorovaikutusTilaisuudet?.map((tilaisuus) => {
@@ -178,18 +177,18 @@ export default function SuunnitteluvaiheenVuorovaikuttaminen({
             }) || [],
           julkinen: v?.julkinen,
           videot: defaultListWithEmptyLink(v?.videot as LinkkiInput[]),
-          suunnittelumateriaali: removeTypeName(v?.suunnittelumateriaali) as LinkkiInput || { nimi: "", url: "" }
+          suunnittelumateriaali: (removeTypeName(v?.suunnittelumateriaali) as LinkkiInput) || { nimi: "", url: "" },
         },
-      }
+      },
     };
-  }, [projekti, vuorovaikutusnro, kirjaamoOsoitteet]);
+  }, [projekti, vuorovaikutusnro, kirjaamoOsoitteet, v]);
 
   const formOptions: UseFormProps<VuorovaikutusFormValues> = useMemo(() => {
     return {
       resolver: yupResolver(vuorovaikutusSchema, { abortEarly: false, recursive: true }),
       mode: "onChange",
       reValidateMode: "onChange",
-      defaultValues
+      defaultValues,
     };
   }, [defaultValues]);
 
@@ -198,7 +197,7 @@ export default function SuunnitteluvaiheenVuorovaikuttaminen({
     register,
     reset,
     handleSubmit,
-    formState: { errors, isDirty },
+    formState: { isDirty },
     getValues,
   } = useFormReturn;
 
@@ -231,7 +230,6 @@ export default function SuunnitteluvaiheenVuorovaikuttaminen({
       setIsFormSubmitting(true);
       try {
         formData.suunnitteluVaihe.vuorovaikutus.julkinen = true;
-        console.log(formData);
         await saveSunnitteluvaihe(formData);
         showSuccessMessage("Tallennus onnistui!");
       } catch (e) {
@@ -243,6 +241,10 @@ export default function SuunnitteluvaiheenVuorovaikuttaminen({
     },
     [saveSunnitteluvaihe, showErrorMessage, showSuccessMessage]
   );
+
+  const saveForm = useMemo(() => {
+    return handleSubmit(saveAndPublish);
+  }, [handleSubmit, saveAndPublish]);
 
   useEffect(() => {
     isDirtyHandler(isDirty);
@@ -266,269 +268,81 @@ export default function SuunnitteluvaiheenVuorovaikuttaminen({
     setOpenHyvaksy(false);
   };
 
-  if (!projekti) {
+  if (!projekti || !v) {
     return <></>;
   }
 
   const ilmoituksenVastaanottajat = getValues("suunnitteluVaihe.vuorovaikutus.ilmoituksenVastaanottajat");
-  const vuorovaikutusTilaisuudet = getValues("suunnitteluVaihe.vuorovaikutus.vuorovaikutusTilaisuudet");
-
-  const isVerkkotilaisuuksia = !!vuorovaikutusTilaisuudet?.find(
-    (t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.VERKOSSA
-  );
-  const isFyysisiatilaisuuksia = !!vuorovaikutusTilaisuudet?.find(
-    (t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.PAIKALLA
-  );
-  const isSoittoaikoja = !!vuorovaikutusTilaisuudet?.find((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.SOITTOAIKA);
-
   return (
     <>
       <FormProvider {...useFormReturn}>
         <form>
           <fieldset>
-            <Section>
+            <Section className="mb-4">
               <SectionContent>
-                <h4 className="vayla-small-title">Vuorovaikuttaminen</h4>
-                <p>
-                  Kansalainen pääsee vaikuttamaan väylähankkeen tai väylän suunnitteluun siinä vaiheessa. kun tehdään
-                  yleissuunnitelmaa ja kun edetään tie- tai ratasuunnitelmaan. Kaikista suunnittelun vaiheista
-                  kuulutetaan tai ilmoitetaan, jotta asianosaisilla on mahdollisuus kommentoida suunnitelmia.
-                </p>
+                <h3 className="vayla-small-title">Vuorovaikuttaminen</h3>
+                <VuorovaikuttamisenInfo vuorovaikutus={v} />
               </SectionContent>
-              <SectionContent>
-                <h4 className="vayla-small-title">Julkaisupäivä</h4>
-                <p>
-                  Anna päivämäärä, jolloin vuorovaikutusosio palvelun julkisella puolella ja kutsu vuorovaikutukseen
-                  muilla ilmoituskanavilla julkaistaan.
-                </p>
-                <DatePicker
-                  label="Julkaisupäivä *"
-                  className="md:max-w-min"
-                  {...register("suunnitteluVaihe.vuorovaikutus.vuorovaikutusJulkaisuPaiva")}
-                  min={today}
-                  error={errors.suunnitteluVaihe?.vuorovaikutus?.vuorovaikutusJulkaisuPaiva}
-                />
-              </SectionContent>
-              <SectionContent>
-                <h4 className="vayla-small-title">Kysymyksien esittäminen ja palautteiden antaminen</h4>
-                <p>Anna päivämäärä, johon mennessä kansalaisten toivotaan esittävän kysymykset ja palautteet.</p>
-                <DatePicker
-                  label="Kysymykset ja palautteet viimeistään *"
-                  className="md:max-w-min"
-                  {...register("suunnitteluVaihe.vuorovaikutus.kysymyksetJaPalautteetViimeistaan")}
-                  min={today}
-                  error={errors.suunnitteluVaihe?.vuorovaikutus?.kysymyksetJaPalautteetViimeistaan}
-                />
-              </SectionContent>
+              <PaivamaaratJaTiedot projekti={projekti} vuorovaikutusnro={vuorovaikutusnro} />
             </Section>
-            <Section>
-              <h4 className="vayla-small-title">Vuorovaikutusmahdollisuudet palautteiden ja kysymyksien lisäksi</h4>
-              <SectionContent>
-                {isVerkkotilaisuuksia && (
-                  <>
-                    <p>
-                      <b>Live-tilaisuudet verkossa</b>
-                    </p>
-                    {vuorovaikutusTilaisuudet
-                      ?.filter((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.VERKOSSA)
-                      .map((tilaisuus, index) => {
-                        return (
-                          <div key={index}>
-                            <p>
-                              {capitalize(tilaisuus.nimi)},{" "}
-                              {t(`common:viikonpaiva_${dayjs(tilaisuus.paivamaara).day()}`)}{" "}
-                              {formatDate(tilaisuus.paivamaara)} klo {tilaisuus.alkamisAika}-{tilaisuus.paattymisAika},
-                              Linkki tilaisuuteen: {tilaisuus.linkki}
-                            </p>
-                          </div>
-                        );
-                      })}
-                  </>
-                )}
-                {isFyysisiatilaisuuksia && (
-                  <>
-                    <p>
-                      <b>Fyysiset tilaisuudet</b>
-                    </p>
-                    {vuorovaikutusTilaisuudet
-                      ?.filter((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.PAIKALLA)
-                      .map((tilaisuus, index) => {
-                        return (
-                          <div key={index}>
-                            <p>
-                              {capitalize(tilaisuus.nimi)},{" "}
-                              {t(`common:viikonpaiva_${dayjs(tilaisuus.paivamaara).day()}`)}{" "}
-                              {formatDate(tilaisuus.paivamaara)} klo {tilaisuus.alkamisAika}-{tilaisuus.paattymisAika},
-                              Osoite: {tilaisuus.paikka}, {tilaisuus.osoite} {tilaisuus.postinumero}{" "}
-                              {tilaisuus.postitoimipaikka}
-                            </p>
-                          </div>
-                        );
-                      })}
-                  </>
-                )}
-                {isSoittoaikoja && (
-                  <>
-                    <p>
-                      <b>Soittoajat</b>
-                    </p>
-                    {vuorovaikutusTilaisuudet
-                      ?.filter((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.SOITTOAIKA)
-                      .map((tilaisuus, index) => {
-                        return (
-                          <div key={index}>
-                            <p>
-                              {capitalize(tilaisuus.nimi)},{" "}
-                              {t(`common:viikonpaiva_${dayjs(tilaisuus.paivamaara).day()}`)}{" "}
-                              {formatDate(tilaisuus.paivamaara)} klo {tilaisuus.alkamisAika}-{tilaisuus.paattymisAika}
-                            </p>
-                            <div>
-                              {tilaisuus.esitettavatYhteystiedot?.map((yhteystieto, index) => {
-                                return <SoittoajanYhteystieto key={index} yhteystieto={yhteystieto} />;
-                              })}
-                            </div>
-                          </div>
-                        );
-                      })}
-                  </>
-                )}
-
-                <Button
-                  onClick={(e) => {
-                    setOpenVuorovaikutustilaisuus(true);
-                    e.preventDefault();
-                  }}
-                >
-                  {isFyysisiatilaisuuksia || isVerkkotilaisuuksia || isSoittoaikoja
-                    ? "Muokkaa tilaisuuksia"
-                    : "Lisää tilaisuus"}
-                </Button>
-              </SectionContent>
-            </Section>
-            <LuonnoksetJaAineistot useFormReturn={useFormReturn as UseFormReturn<FormValuesForLuonnoksetJaAineistot, object>} />
-            <EsitettavatYhteystiedot useFormReturn={useFormReturn as UseFormReturn<FormValuesForEsitettavatYhteystiedot, object>} projekti={projekti} />
-            <IlmoituksenVastaanottajat kirjaamoOsoitteet={kirjaamoOsoitteet} />
-            <Section>
-              <h4 className="vayla-small-title">Kutsun ja ilmoituksen esikatselu</h4>
-              <SectionContent>
-                <HassuStack direction={["column", "column", "row"]}>
-                  <Button type="submit" onClick={() => console.log("kutsun esikatselu")} disabled>
-                    Kutsun esikatselu
+            <VuorovaikutusMahdollisuudet projekti={projekti} vuorovaikutus={v} avaaHyvaksymisDialogi={() => setOpenHyvaksy(true)} />
+            <LuonnoksetJaAineistot
+              avaaHyvaksymisDialogi={() => setOpenHyvaksy(true)}
+              vuorovaikutus={v}
+              useFormReturn={useFormReturn as UseFormReturn<FormValuesForLuonnoksetJaAineistot, object>}
+            />
+            <EsitettavatYhteystiedot
+              useFormReturn={useFormReturn as UseFormReturn<FormValuesForEsitettavatYhteystiedot, object>}
+              projekti={projekti}
+              vuorovaikutusnro={vuorovaikutusnro}
+            />
+            {v?.julkinen &&
+              <LukutilaLinkkiJaKutsut vuorovaikutus={v} projekti={projekti} />
+            }
+            <IlmoituksenVastaanottajat kirjaamoOsoitteet={kirjaamoOsoitteet} vuorovaikutus={v} />
+            {!v?.julkinen &&
+              <Section>
+                <h4 className="vayla-small-title">Kutsun ja ilmoituksen esikatselu</h4>
+                <SectionContent>
+                  <HassuStack direction={["column", "column", "row"]}>
+                    <Button type="submit" onClick={() => console.log("kutsun esikatselu")} disabled>
+                      Kutsun esikatselu
+                    </Button>
+                    <Button type="submit" onClick={() => console.log("ilmoituksen esikatselu")} disabled>
+                      Ilmoituksen esikatselu
+                    </Button>
+                  </HassuStack>
+                </SectionContent>
+              </Section>
+            }
+            {!v?.julkinen &&
+              <Section noDivider>
+                <Stack justifyContent={[undefined, undefined, "flex-end"]} direction={["column", "column", "row"]}>
+                  {!v?.julkinen && <Button onClick={handleSubmit(saveDraft)}>Tallenna luonnos</Button>}
+                  <Button
+                    primary
+                    onClick={(event) => {
+                      handleClickOpenHyvaksy();
+                      event.preventDefault();
+                    }}
+                  >
+                    Tallenna julkaistavaksi
                   </Button>
-                  <Button type="submit" onClick={() => console.log("ilmoituksen esikatselu")} disabled>
-                    Ilmoituksen esikatselu
-                  </Button>
-                </HassuStack>
-              </SectionContent>
-            </Section>
-            <Section noDivider>
-              <Stack justifyContent={[undefined, undefined, "flex-end"]} direction={["column", "column", "row"]}>
-                <Button onClick={handleSubmit(saveDraft)}>Tallenna luonnos</Button>
-                <Button
-                  primary
-                  onClick={(event) => {
-                    handleClickOpenHyvaksy();
-                    event.preventDefault();
-                  }}
-                >
-                  Tallenna julkaistavaksi
-                </Button>
-              </Stack>
-            </Section>
+                </Stack>
+              </Section>
+            }
           </fieldset>
-          <VuorovaikutusDialog
-            open={openVuorovaikutustilaisuus}
-            windowHandler={setOpenVuorovaikutustilaisuus}
-            tilaisuudet={vuorovaikutusTilaisuudet}
-            kayttoOikeudet={projekti.kayttoOikeudet}
-          ></VuorovaikutusDialog>
           <input type="hidden" {...register("suunnitteluVaihe.vuorovaikutus.julkinen")} />
         </form>
       </FormProvider>
-      <div>
-        <HassuDialog open={openHyvaksy} onClose={handleClickCloseHyvaksy}>
-          <Section noDivider smallGaps>
-            <SectionContent>
-              <div className="vayla-dialog-title flex">
-                <div className="flex-grow">Kuulutuksen hyväksyminen ja ilmoituksen lähettäminen</div>
-                <div className="justify-end">
-                  <WindowCloseButton
-                    onClick={() => {
-                      handleClickCloseHyvaksy();
-                    }}
-                  ></WindowCloseButton>
-                </div>
-              </div>
-            </SectionContent>
-            <SectionContent>
-              <div className="vayla-dialog-content">
-                <form>
-                  <p>
-                    Olet tallentamassa vuorovaikutustiedot ja käynnistämässä siihen liittyvän ilmoituksen automaattisen
-                    lähettämisen. Ilmoitus vuorovaikutuksesta lähetetään seuraaville:
-                  </p>
-                  <div className="content">
-                    <p>Viranomaiset</p>
-                    <ul className="vayla-dialog-list">
-                      {ilmoituksenVastaanottajat?.viranomaiset?.map((viranomainen) => (
-                        <li key={viranomainen.nimi}>
-                          {t(`common:viranomainen.${viranomainen.nimi}`)}, {viranomainen.sahkoposti}
-                        </li>
-                      ))}
-                    </ul>
-                    <p>Kunnat</p>
-                    <ul className="vayla-dialog-list">
-                      {ilmoituksenVastaanottajat?.kunnat?.map((kunta) => (
-                        <li key={kunta.nimi}>
-                          {kunta.nimi}, {kunta.sahkoposti}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                  <div className="content">
-                    <p>
-                      Klikkaamalla Tallenna ja lähetä -painiketta vahvistat vuorovaikutustiedot tarkastetuksi ja
-                      hyväksyt sen julkaisun asetettuna julkaisupäivänä sekä ilmoituksien lähettämisen. Ilmoitukset
-                      lähetetään automaattisesti painikkeen klikkaamisen jälkeen.
-                    </p>
-                  </div>
-                  <HassuStack
-                    direction={["column", "column", "row"]}
-                    justifyContent={[undefined, undefined, "flex-end"]}
-                    paddingTop={"1rem"}
-                  >
-                    <Button primary onClick={handleSubmit(saveAndPublish)}>
-                      Hyväksy ja lähetä
-                    </Button>
-                    <Button
-                      onClick={(e) => {
-                        handleClickCloseHyvaksy();
-                        e.preventDefault();
-                      }}
-                    >
-                      Peruuta
-                    </Button>
-                  </HassuStack>
-                </form>
-              </div>
-            </SectionContent>
-          </Section>
-        </HassuDialog>
-      </div>
+      <HyvaksymisDialogi
+        ilmoituksenVastaanottajat={ilmoituksenVastaanottajat}
+        dialogiOnAuki={openHyvaksy}
+        onClose={handleClickCloseHyvaksy}
+        tallenna={saveForm}
+        julkinen={v?.julkinen || false}
+      />
       <HassuSpinner open={isFormSubmitting} />
     </>
   );
 }
-export const SoittoajanYhteystieto = React.memo((props: { yhteystieto: Yhteystieto | YhteystietoInput }) => {
-  return (
-    <>
-      <p>
-        {props.yhteystieto.etunimi} {props.yhteystieto.sukunimi}
-        {props.yhteystieto.titteli ? `, ${props.yhteystieto.titteli}` : null}
-        {props.yhteystieto.organisaatio ? ` (${props.yhteystieto.organisaatio})` : null}:{" "}
-        {props.yhteystieto.puhelinnumero}
-      </p>
-    </>
-  );
-});
-SoittoajanYhteystieto.displayName = "SoittoajanYhteystieto";

--- a/src/components/projekti/suunnitteluvaihe/VuorovaikuttamisenInfo.tsx
+++ b/src/components/projekti/suunnitteluvaihe/VuorovaikuttamisenInfo.tsx
@@ -1,0 +1,44 @@
+import {
+  Vuorovaikutus
+} from "@services/api";
+import React, { ReactElement } from "react";
+import Notification, { NotificationType } from "@components/notification/Notification";
+import { examineJulkaisuPaiva } from "src/util/dateUtils";
+
+interface Props {
+  vuorovaikutus: Vuorovaikutus | undefined;
+}
+
+
+export default function SuunnitteluvaiheenVuorovaikuttaminen({
+  vuorovaikutus
+}: Props): ReactElement {
+
+  const julkinen = !!vuorovaikutus?.julkinen;
+
+  if (!julkinen) {
+    return (
+      <p>
+        Kansalainen pääsee vaikuttamaan väylähankkeen tai väylän suunnitteluun siinä vaiheessa. kun tehdään
+        yleissuunnitelmaa ja kun edetään tie- tai ratasuunnitelmaan. Kaikista suunnittelun vaiheista
+        kuulutetaan tai ilmoitetaan, jotta asianosaisilla on mahdollisuus kommentoida suunnitelmia.
+      </p>
+    );
+  }
+
+  let { julkaisuPaiva, published } = examineJulkaisuPaiva(julkinen, vuorovaikutus.vuorovaikutusJulkaisuPaiva);
+
+  if (published) {
+    return (
+      <Notification type={NotificationType.INFO_GREEN}>
+        Vuorovaikutus on julkaistu {julkaisuPaiva}.
+      </Notification>
+    );
+  }
+
+  return (
+    <Notification type={NotificationType.WARN}>
+      Vuorovaikutusta ei ole vielä julkaistu palvelun julkisella puolella. Julkaisu {julkaisuPaiva}.
+    </Notification>
+  );
+}

--- a/src/components/projekti/suunnitteluvaihe/VuorovaikutusMahdollisuudet.tsx
+++ b/src/components/projekti/suunnitteluvaihe/VuorovaikutusMahdollisuudet.tsx
@@ -1,0 +1,188 @@
+import { useFormContext } from "react-hook-form";
+import SectionContent from "@components/layout/SectionContent";
+import {
+  Projekti,
+  VuorovaikutusTilaisuusTyyppi,
+  Yhteystieto,
+  YhteystietoInput,
+  VuorovaikutusTilaisuusInput,
+  Vuorovaikutus
+} from "@services/api";
+import Section from "@components/layout/Section";
+import React, { ReactElement, useState } from "react";
+import Button from "@components/button/Button";
+
+import dayjs from "dayjs";
+import { formatDate } from "src/util/dateUtils";
+import capitalize from "lodash/capitalize";
+import useTranslation from "next-translate/useTranslation";
+import VuorovaikutustilaisuusDialog from "./VuorovaikutustilaisuusDialog";
+
+interface Props {
+  projekti: Projekti;
+  vuorovaikutus: Vuorovaikutus;
+  avaaHyvaksymisDialogi: () => void;
+}
+
+type FormFields = {
+  suunnitteluVaihe: {
+    vuorovaikutus: {
+      vuorovaikutusTilaisuudet: Array<VuorovaikutusTilaisuusInput> | null
+    }
+  };
+};
+
+export default function SuunnitteluvaiheenVuorovaikuttaminen({
+  projekti,
+  vuorovaikutus,
+  avaaHyvaksymisDialogi
+}: Props): ReactElement {
+  const { t } = useTranslation();
+  const [openVuorovaikutustilaisuus, setOpenVuorovaikutustilaisuus] = useState(false);
+
+  const {
+    getValues,
+  } = useFormContext<FormFields>();
+
+  if (!projekti) {
+    return <></>;
+  }
+
+  const vuorovaikutusTilaisuudet = vuorovaikutus.julkinen
+    ? vuorovaikutus.vuorovaikutusTilaisuudet
+    : getValues("suunnitteluVaihe.vuorovaikutus.vuorovaikutusTilaisuudet");
+
+  const isVerkkotilaisuuksia = !!vuorovaikutusTilaisuudet?.find(
+    (t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.VERKOSSA
+  );
+  const isFyysisiatilaisuuksia = !!vuorovaikutusTilaisuudet?.find(
+    (t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.PAIKALLA
+  );
+  const isSoittoaikoja = !!vuorovaikutusTilaisuudet?.find((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.SOITTOAIKA);
+
+  return (
+    <>
+      <VuorovaikutustilaisuusDialog
+        open={openVuorovaikutustilaisuus}
+        windowHandler={setOpenVuorovaikutustilaisuus}
+        tilaisuudet={vuorovaikutusTilaisuudet}
+        kayttoOikeudet={projekti.kayttoOikeudet}
+        julkinen={vuorovaikutus.julkinen || false}
+        avaaHyvaksymisDialogi={avaaHyvaksymisDialogi}
+      />
+      <Section>
+        {vuorovaikutus.julkinen
+          ? <>
+              <Button
+                style={{ float: "right" }}
+                onClick={(e) => {
+                  setOpenVuorovaikutustilaisuus(true);
+                  e.preventDefault();
+                }}
+              >
+                Muokkaa
+              </Button>
+              <p className="vayla-label">Vuorovaikutusmahdollisuudet palautteiden ja kysymyksien lisäksi</p>
+              <p>Verkossa jaettavien tilaisuuksien liittymislinkit julkaistaan palvelun julkisella puolella kaksi (2) tuntia ennen tilaisuuden alkua.</p>
+            </>
+          : <h4 className="vayla-small-title">Vuorovaikutusmahdollisuudet palautteiden ja kysymyksien lisäksi</h4>
+        }
+        <SectionContent>
+          {isVerkkotilaisuuksia && (
+            <>
+              <p>
+                <b>Live-tilaisuudet verkossa</b>
+              </p>
+              {vuorovaikutusTilaisuudet
+                ?.filter((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.VERKOSSA)
+                .map((tilaisuus, index) => {
+                  return (
+                    <div key={index}>
+                      <p>
+                        {capitalize(tilaisuus.nimi)},{" "}
+                        {t(`common:viikonpaiva_${dayjs(tilaisuus.paivamaara).day()}`)}{" "}
+                        {formatDate(tilaisuus.paivamaara)} klo {tilaisuus.alkamisAika}-{tilaisuus.paattymisAika},
+                        Linkki tilaisuuteen: {tilaisuus.linkki}
+                      </p>
+                    </div>
+                  );
+                })}
+            </>
+          )}
+          {isFyysisiatilaisuuksia && (
+            <>
+              <p>
+                <b>Fyysiset tilaisuudet</b>
+              </p>
+              {vuorovaikutusTilaisuudet
+                ?.filter((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.PAIKALLA)
+                .map((tilaisuus, index) => {
+                  return (
+                    <div key={index}>
+                      <p>
+                        {capitalize(tilaisuus.nimi)},{" "}
+                        {t(`common:viikonpaiva_${dayjs(tilaisuus.paivamaara).day()}`)}{" "}
+                        {formatDate(tilaisuus.paivamaara)} klo {tilaisuus.alkamisAika}-{tilaisuus.paattymisAika},
+                        Osoite: {tilaisuus.paikka}, {tilaisuus.osoite} {tilaisuus.postinumero}{" "}
+                        {tilaisuus.postitoimipaikka}
+                      </p>
+                    </div>
+                  );
+                })}
+            </>
+          )}
+          {isSoittoaikoja && (
+            <>
+              <p>
+                <b>Soittoajat</b>
+              </p>
+              {vuorovaikutusTilaisuudet
+                ?.filter((t) => t.tyyppi === VuorovaikutusTilaisuusTyyppi.SOITTOAIKA)
+                .map((tilaisuus, index) => {
+                  return (
+                    <div key={index}>
+                      <p>
+                        {capitalize(tilaisuus.nimi)},{" "}
+                        {t(`common:viikonpaiva_${dayjs(tilaisuus.paivamaara).day()}`)}{" "}
+                        {formatDate(tilaisuus.paivamaara)} klo {tilaisuus.alkamisAika}-{tilaisuus.paattymisAika}
+                      </p>
+                      <div>
+                        {tilaisuus.esitettavatYhteystiedot?.map((yhteystieto, index) => {
+                          return <SoittoajanYhteystieto key={index} yhteystieto={yhteystieto} />;
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+            </>
+          )}
+          {!vuorovaikutus.julkinen &&
+            <Button
+              onClick={(e) => {
+                setOpenVuorovaikutustilaisuus(true);
+                e.preventDefault();
+              }}
+            >
+              {isFyysisiatilaisuuksia || isVerkkotilaisuuksia || isSoittoaikoja
+                ? "Muokkaa tilaisuuksia"
+                : "Lisää tilaisuus"}
+            </Button>
+          }
+        </SectionContent>
+      </Section>
+    </>
+  );
+}
+export const SoittoajanYhteystieto = React.memo((props: { yhteystieto: Yhteystieto | YhteystietoInput }) => {
+  return (
+    <>
+      <p>
+        {props.yhteystieto.etunimi} {props.yhteystieto.sukunimi}
+        {props.yhteystieto.titteli ? `, ${props.yhteystieto.titteli}` : null}
+        {props.yhteystieto.organisaatio ? ` (${props.yhteystieto.organisaatio})` : null}:{" "}
+        {props.yhteystieto.puhelinnumero}
+      </p>
+    </>
+  );
+});
+SoittoajanYhteystieto.displayName = "SoittoajanYhteystieto";

--- a/src/components/projekti/suunnitteluvaihe/VuorovaikutustilaisuusDialog.tsx
+++ b/src/components/projekti/suunnitteluvaihe/VuorovaikutustilaisuusDialog.tsx
@@ -59,9 +59,11 @@ interface Props {
   windowHandler: (isOpen: boolean) => void;
   tilaisuudet: VuorovaikutusTilaisuusInput[] | null | undefined;
   kayttoOikeudet: ProjektiKayttaja[] | null | undefined;
+  julkinen: boolean;
+  avaaHyvaksymisDialogi: () => void;
 }
 
-export default function VuorovaikutusDialog({ open, windowHandler, tilaisuudet, kayttoOikeudet }: Props): ReactElement {
+export default function VuorovaikutusDialog({ open, windowHandler, tilaisuudet, kayttoOikeudet, julkinen, avaaHyvaksymisDialogi }: Props): ReactElement {
   const formOptions: UseFormProps<VuorovaikutustilaisuusFormValues> = {
     resolver: yupResolver(vuorovaikutustilaisuudetSchema, { abortEarly: false, recursive: true }),
     mode: "onChange",
@@ -464,7 +466,14 @@ export default function VuorovaikutusDialog({ open, windowHandler, tilaisuudet, 
       </DialogContent>
 
       <DialogActions>
-        <Button primary onClick={handleSubmit(saveTilaisuudet)}>
+        <Button primary onClick={() => {
+          if (julkinen) {
+            handleSubmit(saveTilaisuudet)();
+            avaaHyvaksymisDialogi();
+          } else {
+            handleSubmit(saveTilaisuudet)();
+          }
+        }}>
           Tallenna
         </Button>
         <Button

--- a/src/pages/suunnitelma/[oid]/suunnittelu.tsx
+++ b/src/pages/suunnitelma/[oid]/suunnittelu.tsx
@@ -14,7 +14,7 @@ import LocationCityIcon from "@mui/icons-material/LocationCity";
 import LocalPhoneIcon from "@mui/icons-material/LocalPhone";
 import { VuorovaikutusTilaisuus, VuorovaikutusTilaisuusTyyppi } from "@services/api";
 import capitalize from "lodash/capitalize";
-import { SoittoajanYhteystieto } from "@components/projekti/suunnitteluvaihe/SuunnitteluvaiheenVuorovaikuttaminen";
+import { SoittoajanYhteystieto } from "@components/projekti/suunnitteluvaihe/VuorovaikutusMahdollisuudet";
 import { PageProps } from "@pages/_app";
 import ExtLink from "@components/ExtLink";
 import { parseVideoURL } from "src/util/videoParser";

--- a/src/util/dateUtils.ts
+++ b/src/util/dateUtils.ts
@@ -16,3 +16,20 @@ export const formatDateTime = (date: string | number | Date | dayjs.Dayjs | null
 export const isValidDate = (date: string | number | Date | dayjs.Dayjs | null | undefined) => {
   return dayjs(date).isValid();
 };
+
+export function examineJulkaisuPaiva(published: boolean, date: string | null | undefined) {
+  let julkaisuPaiva: string | undefined;
+  if (date) {
+    let parsedDate = dayjs(date);
+    if (date.length == 10) {
+      julkaisuPaiva = parsedDate.format("DD.MM.YYYY");
+    } else {
+      julkaisuPaiva = parsedDate.format("DD.MM.YYYY HH:mm");
+    }
+    published = parsedDate.isBefore(dayjs());
+  } else {
+    published = false;
+    julkaisuPaiva = undefined;
+  }
+  return { julkaisuPaiva, published };
+}


### PR DESCRIPTION
Refaktoroi SuunnitteluvaiheenVuorovaikuttamista ja lisää defaultValuesiin kuntavastaanottajat

Näytä ilmoituksen lähetystiedot, jos vuorovaikutus on tallennettu (on julkinen)

Eriytä komponentti, jossa valitaan päivämäärät tai joka näyttää ne.

Tee read only näkymä vuorovaikutuksen yhteyshenkilöihin

Julkaistu tila luonnoksille ja aineistoille

Refaktoroi dialogi omaksi komponentiksi ja tee read only kutsuhommat

Laita aineistojen ja vuorovaikutustilaisuuksien tallennus julkaisun jälkeen toimimaan

Refaktoroi vuorovaikutustilaisuuksien lisääminen omaksi komponentiksi