### PR TITLE
fix: viranomaisvastaanottajien olemassaolon validointi

### DIFF
--- a/backend/src/handler/projektiAdapter.ts
+++ b/backend/src/handler/projektiAdapter.ts
@@ -332,6 +332,7 @@ function adaptVuorovaikutusToSave(
         projekti,
         vuorovaikutusInput.vuorovaikutusTilaisuudet
       ),
+      //Jos vuorovaikutuksen ilmoituksella ei tarvitse olla viranomaisvastaanottajia, muokkaa adaptIlmoituksenVastaanottajatToSavea
       ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajatToSave(vuorovaikutusInput.ilmoituksenVastaanottajat),
       esitettavatYhteystiedot: adaptYhteystiedotToSave(vuorovaikutusInput.esitettavatYhteystiedot),
       aineistot: adaptAineistotToSave(projektiAdaptationResult, vuorovaikutusInput, dbVuorovaikutus),
@@ -436,13 +437,13 @@ function adaptVuorovaikutukset(vuorovaikutukset: Array<Vuorovaikutus>): API.Vuor
     return vuorovaikutukset.map(
       (vuorovaikutus) =>
         ({
-        ...vuorovaikutus,
-        vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(vuorovaikutus.vuorovaikutusTilaisuudet),
-        suunnittelumateriaali: adaptLinkki(vuorovaikutus.suunnittelumateriaali),
-        videot: adaptLinkkiList(vuorovaikutus.videot),
-        aineistot: adaptAineistot(vuorovaikutus.aineistot),
-        __typename: "Vuorovaikutus",
-      } as API.Vuorovaikutus)
+          ...vuorovaikutus,
+          vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(vuorovaikutus.vuorovaikutusTilaisuudet),
+          suunnittelumateriaali: adaptLinkki(vuorovaikutus.suunnittelumateriaali),
+          videot: adaptLinkkiList(vuorovaikutus.videot),
+          aineistot: adaptAineistot(vuorovaikutus.aineistot),
+          __typename: "Vuorovaikutus",
+        } as API.Vuorovaikutus)
     );
   }
   return vuorovaikutukset as undefined;
@@ -465,8 +466,8 @@ export function adaptLinkki(link: Linkki): API.Linkki {
   if (link) {
     return {
       ...link,
-      __typename: "Linkki"
-    }
+      __typename: "Linkki",
+    };
   }
   return link as undefined;
 }
@@ -507,6 +508,9 @@ function adaptIlmoituksenVastaanottajatToSave(
   }
   const kunnat: API.KuntaVastaanottaja[] =
     vastaanottajat?.kunnat?.map((kunta) => ({ __typename: "KuntaVastaanottaja", ...kunta })) || null;
+  if (!vastaanottajat?.viranomaiset || vastaanottajat.viranomaiset.length === 0) {
+    throw new Error("Viranomaisvastaanottajia pitää olla vähintään yksi.");
+  }
   const viranomaiset: API.ViranomaisVastaanottaja[] =
     vastaanottajat?.viranomaiset?.map((viranomainen) => ({
       __typename: "ViranomaisVastaanottaja",

--- a/src/components/projekti/aloituskuulutus/IlmoituksenVastaanottajat.tsx
+++ b/src/components/projekti/aloituskuulutus/IlmoituksenVastaanottajat.tsx
@@ -2,7 +2,7 @@ import Button from "@components/button/Button";
 import Select from "@components/form/Select";
 import TextInput from "@components/form/TextInput";
 import React, { ReactElement } from "react";
-import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { Controller, useFieldArray, useFormContext, FieldError } from "react-hook-form";
 import { formatProperNoun } from "common/util/formatProperNoun";
 import useTranslation from "next-translate/useTranslation";
 import IconButton from "@components/button/IconButton";
@@ -17,6 +17,10 @@ import Section from "@components/layout/Section";
 import SectionContent from "@components/layout/SectionContent";
 import HassuGrid from "@components/HassuGrid";
 
+interface HelperType {
+  kunnat?: FieldError | { nimi?: FieldError | undefined; sahkoposti?: FieldError | undefined }[] | undefined;
+  viranomaiset?: FieldError | null | undefined;
+}
 interface Props {
   isLoading: boolean;
   kirjaamoOsoitteet: ViranomaisVastaanottajaInput[];
@@ -102,6 +106,11 @@ export default function IlmoituksenVastaanottajat({
         <>
           <SectionContent>
             <h6 className="font-bold">Viranomaiset</h6>
+            {(errors.aloitusKuulutus?.ilmoituksenVastaanottajat as HelperType)?.viranomaiset && (
+              <p className="text-red">
+                {(errors.aloitusKuulutus?.ilmoituksenVastaanottajat as HelperType).viranomaiset?.message}
+              </p>
+            )}
             {viranomaisFields.map((viranomainen, index) => (
               <HassuGrid key={viranomainen.id} cols={{ lg: 3 }}>
                 <Select

--- a/src/schemas/aloituskuulutus.ts
+++ b/src/schemas/aloituskuulutus.ts
@@ -94,7 +94,15 @@ export const aloituskuulutusSchema = Yup.object().shape({
               })
               .required()
           )
-          .notRequired(),
+          .test("length", "Vähintään yksi viranomainen valittava", (arr, testContext) => {
+            if (arr && arr.length >= 1) {
+              return true;
+            }
+            return testContext.createError({
+              path: `${testContext.path}`,
+              message: "Vähintään yksi viranomainen on valittava",
+            });
+          }),
       })
       .required(),
   }),

--- a/src/schemas/vuorovaikutus.ts
+++ b/src/schemas/vuorovaikutus.ts
@@ -14,23 +14,23 @@ export const palauteSchema = Yup.object().shape({
   kysymysTaiPalaute: Yup.string().required("palaute_on_jatettava").max(2000),
   yhteydenottotapaEmail: Yup.boolean().notRequired().nullable(),
   yhteydenottotapaPuhelin: Yup.boolean().notRequired().nullable(),
-  liite: Yup.string().notRequired().nullable()
+  liite: Yup.string()
+    .notRequired()
+    .nullable()
     .test({
-      message: 'vain_kuva_tai_pdf',
+      message: "vain_kuva_tai_pdf",
       test: (file, context) => {
         const isValid = !file || /.*\.[(jpg)|(jpeg)|(png)|(pdf)]/.test(file);
         if (!isValid) context?.createError();
         return isValid;
-      }
-    })
+      },
+    }),
 });
 
 export const vuorovaikutustilaisuudetSchema = Yup.object().shape({
   vuorovaikutusTilaisuudet: Yup.array().of(
     Yup.object().shape({
-      tyyppi: Yup.mixed<VuorovaikutusTilaisuusTyyppi>()
-        .oneOf(Object.values(VuorovaikutusTilaisuusTyyppi))
-        .required(),
+      tyyppi: Yup.mixed<VuorovaikutusTilaisuusTyyppi>().oneOf(Object.values(VuorovaikutusTilaisuusTyyppi)).required(),
       nimi: Yup.string().nullable(),
       paivamaara: Yup.string()
         .required("Vuorovaikutustilaisuuden päivämäärä täytyy antaa")
@@ -180,7 +180,15 @@ export const vuorovaikutusSchema = Yup.object().shape({
             .compact(function (viranomainen) {
               return !viranomainen.nimi && !viranomainen.sahkoposti;
             })
-            .notRequired(),
+            .test("length", "Vähintään yksi viranomainen valittava", (arr, testContext) => {
+              if (arr && arr.length >= 1) {
+                return true;
+              }
+              return testContext.createError({
+                path: `${testContext.path}`,
+                message: "Vähintään yksi viranomainen on valittava",
+              });
+            }),
         })
         .required(),
     }),


### PR DESCRIPTION
Tähän on tehty myös BE-toteutus, jossa BE heittää hallitsemattoman virheen, jos viranomaisvastanottaja puuttuu. Huom! BE-muutos voi aiheuttaa ongemia, jos tietokannassa on jo projekteja, joilta puuttuu viranomaisvastaanottaja joko aloituskuulutuksesta tai vuorovaikutuksesta!! Sellainen projekti ei välttämättä enää päivity ollenkaan, ellei viranomaisvastaanottajaa laiteta.