### PR TITLE
feat: toteuta testaukseen tapa siirtää nähtävilläolokuulutuksen päättymisaika välittömästi menneisyyteen

### DIFF
--- a/backend/src/database/dynamoDB.ts
+++ b/backend/src/database/dynamoDB.ts
@@ -6,7 +6,7 @@ let client: DynamoDB.DocumentClient;
 
 function getDynamoDBDocumentClient(): DynamoDB.DocumentClient {
   if (!client) {
-    client = new DynamoDB.DocumentClient({ apiVersion: "2012-08-10" });
+    client = new DynamoDB.DocumentClient({ apiVersion: "2012-08-10", region: "eu-west-1" });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     AWSXRay.captureAWSClient((client as any).service); // NOSONAR
   }

--- a/deployment/bin/hassu.ts
+++ b/deployment/bin/hassu.ts
@@ -26,7 +26,10 @@ async function main() {
     console.log("Deployment of HassuBackendStack failed:", e);
     process.exit(1);
   });
-  const hassuFrontendStack = new HassuFrontendStack(app, { internalBucket: hassuDatabaseStack.internalBucket });
+  const hassuFrontendStack = new HassuFrontendStack(app, {
+    internalBucket: hassuDatabaseStack.internalBucket,
+    projektiTable: hassuDatabaseStack.projektiTable,
+  });
   await hassuFrontendStack.process().catch((e) => {
     console.log("Deployment of HassuFrontendStack failed:", e);
     process.exit(1);

--- a/deployment/bin/setupEnvironment.ts
+++ b/deployment/bin/setupEnvironment.ts
@@ -217,6 +217,7 @@ async function main() {
     SONARQUBE_HOST_URL: variables.SonarQubeHostURL,
     SONARQUBE_ACCESS_TOKEN: variables.SonarQubeAccessToken,
     SEARCH_DOMAIN: searchStackOutputs.SearchDomainEndpointOutput,
+    TABLE_PROJEKTI: Config.projektiTableName
   });
 
   const testUsers = await readParametersByPath("/testusers/", Region.EU_WEST_1);

--- a/next.config.js
+++ b/next.config.js
@@ -93,6 +93,16 @@ module.exports = (phase) => {
   let config = {
     reactStrictMode: true,
     // trailingSlash: true,
+
+    // .dev.ts, .dev.tsx", .dev.js, and .dev.jsx are only available in non-prod environments
+    pageExtensions: ["ts", "tsx", "js", "jsx"]
+      .map((extension) => {
+        const isDevServer = BaseConfig.env !== "prod";
+        const prodExtension = `(?<!dev\.)${extension}`;
+        const devExtension = `dev\.${extension}`;
+        return isDevServer ? [devExtension, extension] : prodExtension;
+      })
+      .flat(),
   };
   if (phase === PHASE_DEVELOPMENT_SERVER) {
     config = setupLocalDevelopmentMode(config, env);

--- a/src/pages/api/test/[oid]/nahtavillaolomenneisyyteen.dev.ts
+++ b/src/pages/api/test/[oid]/nahtavillaolomenneisyyteen.dev.ts
@@ -1,0 +1,36 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { projektiDatabase } from "../../../../../backend/src/database/projektiDatabase";
+import { validateCredentials } from "../../../../util/basicAuthentication";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  let environment = process.env.ENVIRONMENT;
+  if ((environment == "dev" || environment == "test") && !(await validateCredentials(req.headers.authorization))) {
+    res.status(401);
+    res.setHeader("www-authenticate", "Basic");
+
+    res.send("");
+    return;
+  }
+
+  const oid = req.query["oid"];
+  if (oid instanceof Array || !oid || oid.length == 0) {
+    res.status(400);
+    res.send("");
+    return;
+  }
+
+  res.setHeader("Content-Type", "text/plain; charset=UTF-8");
+
+  let dbProjekti = await projektiDatabase.loadProjektiByOid(oid);
+  if (!dbProjekti) {
+    res.send("Projektia ei löydy");
+    return;
+  }
+  if (dbProjekti?.nahtavillaoloVaiheJulkaisut) {
+    for (const julkaisu of dbProjekti.nahtavillaoloVaiheJulkaisut) {
+      julkaisu.kuulutusVaihePaattyyPaiva = "2022-01-01";
+      await projektiDatabase.updateNahtavillaoloVaiheJulkaisu(dbProjekti, julkaisu);
+    }
+  }
+  res.send("OK");
+}


### PR DESCRIPTION
polulla /api/test/[projektin oid]/nahtavillaolomenneisyyteen saa vaihdettua kuulutuksen nähtävilläolon vaihdettua päättymään 1.1.2022.
Onnistuin säätämään sen niin, että sitä ei bundlata mukaan prod-asennukseen.