### PR TITLE
Uusi tyypitys aloituskuulutuksen yhteystiedoille

### DIFF
--- a/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusHandler.test.ts.snap
+++ b/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusHandler.test.ts.snap
@@ -3,21 +3,23 @@
 exports[`AloitusKuulutus should create and manipulate projekti successfully 1`] = `
 Object {
   "aloitusKuulutus": Object {
-    "esitettavatYhteystiedot": Array [
-      Object {
-        "etunimi": "Marko",
-        "organisaatio": "Kajaani",
-        "puhelinnumero": "0293121213",
-        "sahkoposti": "markku.koi@koi.com",
-        "sukunimi": "Koi",
-      },
-    ],
     "hankkeenKuvaus": Object {
       "RUOTSI": "På svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
     "kuulutusPaiva": "2022-01-02",
+    "kuulutusYhteystiedot": Object {
+      "yhteysTiedot": Array [
+        Object {
+          "etunimi": "Marko",
+          "organisaatio": "Kajaani",
+          "puhelinnumero": "0293121213",
+          "sahkoposti": "markku.koi@koi.com",
+          "sukunimi": "Koi",
+        },
+      ],
+    },
     "siirtyySuunnitteluVaiheeseen": "2022-01-01",
   },
   "aloitusKuulutusJulkaisut": undefined,
@@ -27,21 +29,23 @@ Object {
 exports[`AloitusKuulutus should create and manipulate projekti successfully 2`] = `
 Object {
   "aloitusKuulutus": Object {
-    "esitettavatYhteystiedot": Array [
-      Object {
-        "etunimi": "Marko",
-        "organisaatio": "Kajaani",
-        "puhelinnumero": "0293121213",
-        "sahkoposti": "markku.koi@koi.com",
-        "sukunimi": "Koi",
-      },
-    ],
     "hankkeenKuvaus": Object {
       "RUOTSI": "På svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
     "kuulutusPaiva": "2022-01-02",
+    "kuulutusYhteystiedot": Object {
+      "yhteysTiedot": Array [
+        Object {
+          "etunimi": "Marko",
+          "organisaatio": "Kajaani",
+          "puhelinnumero": "0293121213",
+          "sahkoposti": "markku.koi@koi.com",
+          "sukunimi": "Koi",
+        },
+      ],
+    },
     "siirtyySuunnitteluVaiheeseen": "2022-01-01",
   },
   "aloitusKuulutusJulkaisut": Array [
@@ -97,6 +101,13 @@ Object {
       },
       "yhteystiedot": Array [
         Object {
+          "etunimi": "Pekka",
+          "organisaatio": "Väylävirasto",
+          "puhelinnumero": "123456789",
+          "sahkoposti": "pekka.projari@vayla.fi",
+          "sukunimi": "Projari",
+        },
+        Object {
           "etunimi": "Marko",
           "organisaatio": "Kajaani",
           "puhelinnumero": "0293121213",
@@ -112,21 +123,23 @@ Object {
 exports[`AloitusKuulutus should create and manipulate projekti successfully 3`] = `
 Object {
   "aloitusKuulutus": Object {
-    "esitettavatYhteystiedot": Array [
-      Object {
-        "etunimi": "Marko",
-        "organisaatio": "Kajaani",
-        "puhelinnumero": "0293121213",
-        "sahkoposti": "markku.koi@koi.com",
-        "sukunimi": "Koi",
-      },
-    ],
     "hankkeenKuvaus": Object {
       "RUOTSI": "På svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
     "kuulutusPaiva": "2022-01-02",
+    "kuulutusYhteystiedot": Object {
+      "yhteysTiedot": Array [
+        Object {
+          "etunimi": "Marko",
+          "organisaatio": "Kajaani",
+          "puhelinnumero": "0293121213",
+          "sahkoposti": "markku.koi@koi.com",
+          "sukunimi": "Koi",
+        },
+      ],
+    },
     "palautusSyy": "Korjaa teksti",
     "siirtyySuunnitteluVaiheeseen": "2022-01-01",
   },
@@ -137,21 +150,23 @@ Object {
 exports[`AloitusKuulutus should create and manipulate projekti successfully 4`] = `
 Object {
   "aloitusKuulutus": Object {
-    "esitettavatYhteystiedot": Array [
-      Object {
-        "etunimi": "Marko",
-        "organisaatio": "Kajaani",
-        "puhelinnumero": "0293121213",
-        "sahkoposti": "markku.koi@koi.com",
-        "sukunimi": "Koi",
-      },
-    ],
     "hankkeenKuvaus": Object {
       "RUOTSI": "På svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
     "kuulutusPaiva": "2022-01-02",
+    "kuulutusYhteystiedot": Object {
+      "yhteysTiedot": Array [
+        Object {
+          "etunimi": "Marko",
+          "organisaatio": "Kajaani",
+          "puhelinnumero": "0293121213",
+          "sahkoposti": "markku.koi@koi.com",
+          "sukunimi": "Koi",
+        },
+      ],
+    },
     "palautusSyy": null,
     "siirtyySuunnitteluVaiheeseen": "2022-01-01",
   },
@@ -208,6 +223,13 @@ Object {
       },
       "yhteystiedot": Array [
         Object {
+          "etunimi": "Pekka",
+          "organisaatio": "Väylävirasto",
+          "puhelinnumero": "123456789",
+          "sahkoposti": "pekka.projari@vayla.fi",
+          "sukunimi": "Projari",
+        },
+        Object {
           "etunimi": "Marko",
           "organisaatio": "Kajaani",
           "puhelinnumero": "0293121213",
@@ -223,21 +245,23 @@ Object {
 exports[`AloitusKuulutus should create and manipulate projekti successfully 5`] = `
 Object {
   "aloitusKuulutus": Object {
-    "esitettavatYhteystiedot": Array [
-      Object {
-        "etunimi": "Marko",
-        "organisaatio": "Kajaani",
-        "puhelinnumero": "0293121213",
-        "sahkoposti": "markku.koi@koi.com",
-        "sukunimi": "Koi",
-      },
-    ],
     "hankkeenKuvaus": Object {
       "RUOTSI": "På svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
     "kuulutusPaiva": "2022-01-02",
+    "kuulutusYhteystiedot": Object {
+      "yhteysTiedot": Array [
+        Object {
+          "etunimi": "Marko",
+          "organisaatio": "Kajaani",
+          "puhelinnumero": "0293121213",
+          "sahkoposti": "markku.koi@koi.com",
+          "sukunimi": "Koi",
+        },
+      ],
+    },
     "palautusSyy": null,
     "siirtyySuunnitteluVaiheeseen": "2022-01-01",
   },
@@ -294,6 +318,13 @@ Object {
         ],
       },
       "yhteystiedot": Array [
+        Object {
+          "etunimi": "Pekka",
+          "organisaatio": "Väylävirasto",
+          "puhelinnumero": "123456789",
+          "sahkoposti": "pekka.projari@vayla.fi",
+          "sukunimi": "Projari",
+        },
         Object {
           "etunimi": "Marko",
           "organisaatio": "Kajaani",

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -68,7 +68,8 @@ Lorem Ipsum
 Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkilötietoja. Halutessasi tietää tarkemmin väyläsuunnittelun tietosuojakäytänteistä, tutustu verkkosivujen tietosuojaosioon osoitteessa https://vayla.fi/tietosuoja.
 
 Lisätietoja antaa
-CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com",
+CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
+Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
     "to": Array [],
   },
 ]
@@ -2886,7 +2887,8 @@ Lorem Ipsum
 Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkilötietoja. Halutessasi tietää tarkemmin väyläsuunnittelun tietosuojakäytänteistä, tutustu verkkosivujen tietosuojaosioon osoitteessa https://vayla.fi/tietosuoja.
 
 Lisätietoja antaa
-CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com",
+CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
+Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
     "to": Array [],
   },
 ]
@@ -3349,7 +3351,8 @@ Lorem Ipsum
 Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkilötietoja. Halutessasi tietää tarkemmin väyläsuunnittelun tietosuojakäytänteistä, tutustu verkkosivujen tietosuojaosioon osoitteessa https://vayla.fi/tietosuoja.
 
 Lisätietoja antaa
-CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com",
+CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
+Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
     "to": Array [],
   },
 ]

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -68,8 +68,7 @@ Lorem Ipsum
 Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkilötietoja. Halutessasi tietää tarkemmin väyläsuunnittelun tietosuojakäytänteistä, tutustu verkkosivujen tietosuojaosioon osoitteessa https://vayla.fi/tietosuoja.
 
 Lisätietoja antaa
-CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
-Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
+CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com",
     "to": Array [],
   },
 ]
@@ -2887,8 +2886,7 @@ Lorem Ipsum
 Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkilötietoja. Halutessasi tietää tarkemmin väyläsuunnittelun tietosuojakäytänteistä, tutustu verkkosivujen tietosuojaosioon osoitteessa https://vayla.fi/tietosuoja.
 
 Lisätietoja antaa
-CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
-Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
+CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com",
     "to": Array [],
   },
 ]
@@ -3351,8 +3349,7 @@ Lorem Ipsum
 Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkilötietoja. Halutessasi tietää tarkemmin väyläsuunnittelun tietosuojakäytänteistä, tutustu verkkosivujen tietosuojaosioon osoitteessa https://vayla.fi/tietosuoja.
 
 Lisätietoja antaa
-CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
-Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
+CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com",
     "to": Array [],
   },
 ]

--- a/backend/integrationtest/api/apiTestFixture.ts
+++ b/backend/integrationtest/api/apiTestFixture.ts
@@ -37,7 +37,7 @@ class ApiTestFixture {
     kunta: "Nokia",
   };
 
-  esitettavatYhteystiedot: Yhteystieto[] = [
+  yhteystietoLista: Yhteystieto[] = [
     {
       __typename: "Yhteystieto",
       etunimi: "Marko",
@@ -48,7 +48,7 @@ class ApiTestFixture {
     },
   ];
 
-  esitettavatYhteystiedotInput: YhteystietoInput[] = [
+  yhteystietoInputLista: YhteystietoInput[] = [
     {
       etunimi: "Etunimi",
       sukunimi: "Sukunimi",
@@ -77,7 +77,11 @@ class ApiTestFixture {
       SAAME: "Saameksi",
     },
     siirtyySuunnitteluVaiheeseen: "2022-01-01",
-    esitettavatYhteystiedot: this.esitettavatYhteystiedot,
+    kuulutusYhteystiedot: {
+      __typename: "KuulutusYhteystiedot",
+      yhteysTiedot: this.yhteystietoLista,
+      yhteysHenkilot: [],
+    },
   };
 
   kielitiedotInput: KielitiedotInput = {
@@ -137,7 +141,7 @@ class ApiTestFixture {
       vuorovaikutusJulkaisuPaiva: "2022-03-23",
       videot: [{ nimi: "Esittely " + vuorovaikutusNumero, url: "https://video" }],
       kysymyksetJaPalautteetViimeistaan: "2022-03-23T23:48",
-      esitettavatYhteystiedot: apiTestFixture.esitettavatYhteystiedot,
+      esitettavatYhteystiedot: apiTestFixture.yhteystietoLista,
       ilmoituksenVastaanottajat: apiTestFixture.ilmoituksenVastaanottajat,
       vuorovaikutusYhteysHenkilot,
       vuorovaikutusTilaisuudet: [
@@ -169,7 +173,7 @@ class ApiTestFixture {
           alkamisAika: "10:00",
           paattymisAika: "11:00",
           projektiYhteysHenkilot: vuorovaikutusYhteysHenkilot,
-          esitettavatYhteystiedot: this.esitettavatYhteystiedotInput,
+          esitettavatYhteystiedot: this.yhteystietoInputLista,
         },
         {
           tyyppi: VuorovaikutusTilaisuusTyyppi.SOITTOAIKA,
@@ -177,7 +181,7 @@ class ApiTestFixture {
           paivamaara: "2033-04-05",
           alkamisAika: "12:00",
           paattymisAika: "13:00",
-          esitettavatYhteystiedot: this.esitettavatYhteystiedotInput,
+          esitettavatYhteystiedot: this.yhteystietoInputLista,
         },
       ],
     },
@@ -193,7 +197,7 @@ class ApiTestFixture {
     muistutusoikeusPaattyyPaiva: "2042-06-08",
     kuulutusYhteysHenkilot,
     ilmoituksenVastaanottajat: this.ilmoituksenVastaanottajat,
-    kuulutusYhteystiedot: this.esitettavatYhteystiedotInput,
+    kuulutusYhteystiedot: this.yhteystietoInputLista,
   });
 }
 

--- a/backend/integrationtest/api/testUtil/hyvaksymisPaatosVaihe.ts
+++ b/backend/integrationtest/api/testUtil/hyvaksymisPaatosVaihe.ts
@@ -8,7 +8,7 @@ import {
   TilasiirtymaToiminto,
   TilasiirtymaTyyppi,
   VelhoAineisto,
-  VelhoAineistoKategoria
+  VelhoAineistoKategoria,
 } from "../../../../common/graphql/apiModel";
 import { UserFixture } from "../../../test/fixture/userFixture";
 import { expect } from "chai";
@@ -17,10 +17,13 @@ import { adaptAineistoToInput, expectToMatchSnapshot } from "./util";
 import { apiTestFixture } from "../apiTestFixture";
 import {
   cleanupHyvaksymisPaatosVaiheJulkaisuJulkinenTimestamps,
-  cleanupHyvaksymisPaatosVaiheTimestamps
+  cleanupHyvaksymisPaatosVaiheTimestamps,
 } from "./cleanUpFunctions";
 
-export async function testHyvaksymisPaatosVaiheHyvaksymismenettelyssa(oid: string, userFixture: UserFixture): Promise<void> {
+export async function testHyvaksymisPaatosVaiheHyvaksymismenettelyssa(
+  oid: string,
+  userFixture: UserFixture
+): Promise<void> {
   const dbProjekti = await projektiDatabase.loadProjektiByOid(oid);
   const julkaisu = dbProjekti.nahtavillaoloVaiheJulkaisut[0];
   julkaisu.kuulutusVaihePaattyyPaiva = "2022-06-08";
@@ -30,7 +33,7 @@ export async function testHyvaksymisPaatosVaiheHyvaksymismenettelyssa(oid: strin
   await api.tallennaProjekti({
     oid,
     kasittelynTila: {
-      hyvaksymispaatos: { asianumero: "asianro123", paatoksenPvm: "2022-06-09" }
+      hyvaksymispaatos: { asianumero: "asianro123", paatoksenPvm: "2022-06-09" },
     },
   });
 
@@ -47,7 +50,8 @@ export async function testHyvaksymisPaatosVaiheHyvaksymismenettelyssa(oid: strin
 
 export async function testImportHyvaksymisPaatosAineistot(
   oid: string,
-  velhoAineistoKategorias: VelhoAineistoKategoria[], projektiPaallikko: string
+  velhoAineistoKategorias: VelhoAineistoKategoria[],
+  projektiPaallikko: string
 ): Promise<void> {
   const lisaAineisto = velhoAineistoKategorias
     .reduce((documents, aineistoKategoria) => {
@@ -63,7 +67,7 @@ export async function testImportHyvaksymisPaatosAineistot(
       aineistoNahtavilla: adaptAineistoToInput(lisaAineisto.slice(2, 3)),
 
       ilmoituksenVastaanottajat: apiTestFixture.ilmoituksenVastaanottajat,
-      kuulutusYhteystiedot: apiTestFixture.esitettavatYhteystiedotInput,
+      kuulutusYhteystiedot: apiTestFixture.yhteystietoInputLista,
       kuulutusYhteysHenkilot: [projektiPaallikko],
       hallintoOikeus: HallintoOikeus.HAMEENLINNA,
 
@@ -77,7 +81,7 @@ export async function testImportHyvaksymisPaatosAineistot(
   const kasittelynTila = projekti.kasittelynTila;
   expectToMatchSnapshot("testImportHyvaksymisPaatosAineistot", {
     hyvaksymisPaatosVaihe,
-    kasittelynTila
+    kasittelynTila,
   });
 }
 
@@ -95,12 +99,14 @@ export async function testHyvaksymisPaatosVaiheApproval(
 
   const projektiHyvaksyttavaksi = await loadProjektiFromDatabase(oid, Status.HYVAKSYMISMENETTELYSSA);
   expect(projektiHyvaksyttavaksi.hyvaksymisPaatosVaiheJulkaisut).to.have.length(1);
-  expect(projektiHyvaksyttavaksi.hyvaksymisPaatosVaiheJulkaisut[0].tila).to.eq(HyvaksymisPaatosVaiheTila.ODOTTAA_HYVAKSYNTAA);
+  expect(projektiHyvaksyttavaksi.hyvaksymisPaatosVaiheJulkaisut[0].tila).to.eq(
+    HyvaksymisPaatosVaiheTila.ODOTTAA_HYVAKSYNTAA
+  );
 
   await api.siirraTila({
     oid,
     tyyppi: TilasiirtymaTyyppi.HYVAKSYMISPAATOSVAIHE,
-    toiminto: TilasiirtymaToiminto.HYVAKSY
+    toiminto: TilasiirtymaToiminto.HYVAKSY,
   });
   const projekti = await loadProjektiFromDatabase(oid, Status.HYVAKSYMISMENETTELYSSA);
   expectToMatchSnapshot("testHyvaksymisPaatosVaiheAfterApproval", {

--- a/backend/integrationtest/api/testUtil/tests.ts
+++ b/backend/integrationtest/api/testUtil/tests.ts
@@ -128,8 +128,6 @@ export async function testProjektinTiedot(oid: string): Promise<void> {
 
   // Check that the saved projekti is what it is supposed to be
   const updatedProjekti = await loadProjektiFromDatabase(oid, Status.ALOITUSKUULUTUS);
-  delete updatedProjekti.aloitusKuulutus.esitettavatYhteystiedot;
-  //^ TODO: Korjaa siten, että DB:ssä ei edes ole esitettavatYhteystiedot-kenttää
   expect(updatedProjekti.muistiinpano).to.be.equal(apiTestFixture.newNote);
   expect(updatedProjekti.aloitusKuulutus).eql(apiTestFixture.aloitusKuulutus);
   expect(updatedProjekti.suunnitteluSopimus).include(apiTestFixture.suunnitteluSopimus);

--- a/backend/integrationtest/api/testUtil/tests.ts
+++ b/backend/integrationtest/api/testUtil/tests.ts
@@ -128,6 +128,8 @@ export async function testProjektinTiedot(oid: string): Promise<void> {
 
   // Check that the saved projekti is what it is supposed to be
   const updatedProjekti = await loadProjektiFromDatabase(oid, Status.ALOITUSKUULUTUS);
+  delete updatedProjekti.aloitusKuulutus.esitettavatYhteystiedot;
+  //^ TODO: Korjaa siten, että DB:ssä ei edes ole esitettavatYhteystiedot-kenttää
   expect(updatedProjekti.muistiinpano).to.be.equal(apiTestFixture.newNote);
   expect(updatedProjekti.aloitusKuulutus).eql(apiTestFixture.aloitusKuulutus);
   expect(updatedProjekti.suunnitteluSopimus).include(apiTestFixture.suunnitteluSopimus);

--- a/backend/src/asiakirja/suunnittelunAloitus/KutsuAdapter.ts
+++ b/backend/src/asiakirja/suunnittelunAloitus/KutsuAdapter.ts
@@ -5,6 +5,7 @@ import { translate } from "../../util/localization";
 import { linkHyvaksymisPaatos, linkSuunnitteluVaihe } from "../../../../common/links";
 import { formatProperNoun } from "../../../../common/util/formatProperNoun";
 import union from "lodash/union";
+import { vaylaUserToYhteystieto } from "../../util/vaylaUserToYhteystieto";
 
 export type KutsuAdapterProps = {
   oid?: string;
@@ -241,14 +242,7 @@ export class KutsuAdapter {
         yhteysHenkilot
       );
       this.getUsersForUsernames(yhteysHenkilotWithProjectManager).forEach((user) => {
-        const [sukunimi, etunimi] = user.nimi.split(/, /g);
-        yt.push({
-          etunimi,
-          sukunimi,
-          organisaatio: user.organisaatio,
-          sahkoposti: user.email,
-          puhelinnumero: user.puhelinnumero,
-        });
+        yt.push(vaylaUserToYhteystieto(user));
       });
     }
     if (suunnitteluSopimus) {

--- a/backend/src/database/model/common.ts
+++ b/backend/src/database/model/common.ts
@@ -26,3 +26,8 @@ export type Aineisto = {
   jarjestys?: number | null;
   tila: AineistoTila;
 };
+
+export type KuulutusYhteystiedot = {
+  yhteysTiedot?: Yhteystieto[];
+  yhteysHenkilot?: string[];
+};

--- a/backend/src/database/model/projekti.ts
+++ b/backend/src/database/model/projekti.ts
@@ -9,7 +9,7 @@ import {
 import { Palaute, SuunnitteluVaihe, Vuorovaikutus } from "./suunnitteluVaihe";
 import { NahtavillaoloVaihe, NahtavillaoloVaiheJulkaisu } from "./nahtavillaoloVaihe";
 import { HyvaksymisPaatosVaihe, HyvaksymisPaatosVaiheJulkaisu } from "./hyvaksymisPaatosVaihe";
-import { LocalizedMap, Yhteystieto } from "./common";
+import { LocalizedMap, Yhteystieto, KuulutusYhteystiedot } from "./common";
 
 export type DBVaylaUser = {
   rooli: ProjektiRooli;
@@ -26,7 +26,8 @@ export type AloitusKuulutus = {
   kuulutusPaiva?: string | null;
   siirtyySuunnitteluVaiheeseen?: string | null;
   hankkeenKuvaus?: LocalizedMap<string>;
-  esitettavatYhteystiedot?: Yhteystieto[] | null;
+  esitettavatYhteystiedot?: Yhteystieto[] | null; // deprikoituu
+  kuulutusYhteystiedot?: KuulutusYhteystiedot;
   ilmoituksenVastaanottajat?: IlmoituksenVastaanottajat | null;
   palautusSyy?: string | null;
 };

--- a/backend/src/database/model/projekti.ts
+++ b/backend/src/database/model/projekti.ts
@@ -19,14 +19,12 @@ export type DBVaylaUser = {
   puhelinnumero: string;
   organisaatio: string;
   nimi: string;
-  esitetaanKuulutuksessa?: boolean | null;
 };
 
 export type AloitusKuulutus = {
   kuulutusPaiva?: string | null;
   siirtyySuunnitteluVaiheeseen?: string | null;
   hankkeenKuvaus?: LocalizedMap<string>;
-  esitettavatYhteystiedot?: Yhteystieto[] | null; // deprikoituu
   kuulutusYhteystiedot?: KuulutusYhteystiedot;
   ilmoituksenVastaanottajat?: IlmoituksenVastaanottajat | null;
   palautusSyy?: string | null;

--- a/backend/src/email/lahetekirje/LahetekirjeAdapter.ts
+++ b/backend/src/email/lahetekirje/LahetekirjeAdapter.ts
@@ -1,5 +1,5 @@
 import log from "loglevel";
-import { Kieli, ProjektiTyyppi, Viranomainen } from "../../../../common/graphql/apiModel";
+import { Kieli, ProjektiRooli, ProjektiTyyppi, Viranomainen } from "../../../../common/graphql/apiModel";
 import { AsiakirjanMuoto, determineAsiakirjaMuoto } from "../../asiakirja/asiakirjaService";
 import { DBProjekti, Yhteystieto } from "../../database/model";
 import { translate } from "../../util/localization";
@@ -188,12 +188,18 @@ export class LahetekirjeAdapter {
   }
 
   private get yhteystiedot() {
-    const esitettavatYhteystiedot = this.projekti?.aloitusKuulutus?.esitettavatYhteystiedot;
+    const kuulutusYhteystiedot = this.projekti?.aloitusKuulutus?.kuulutusYhteystiedot;
+    const esitettavatYhteystiedot = kuulutusYhteystiedot?.yhteysTiedot;
     const kayttoOikeudet = this.projekti?.kayttoOikeudet;
     const yt: Yhteystieto[] = [];
+
     kayttoOikeudet
-      ?.filter(({ esitetaanKuulutuksessa }) => !!esitetaanKuulutuksessa)
-      ?.forEach((oikeus) => {
+      ?.filter(
+        ({ kayttajatunnus, rooli }) =>
+          rooli === ProjektiRooli.PROJEKTIPAALLIKKO ||
+          kuulutusYhteystiedot?.yhteysHenkilot?.find((yh) => yh === kayttajatunnus)
+      )
+      .forEach((oikeus) => {
         yt.push(vaylaUserToYhteystieto(oikeus));
       });
     esitettavatYhteystiedot?.forEach((yhteystieto) => {

--- a/backend/src/email/lahetekirje/LahetekirjeAdapter.ts
+++ b/backend/src/email/lahetekirje/LahetekirjeAdapter.ts
@@ -3,6 +3,7 @@ import { Kieli, ProjektiTyyppi, Viranomainen } from "../../../../common/graphql/
 import { AsiakirjanMuoto, determineAsiakirjaMuoto } from "../../asiakirja/asiakirjaService";
 import { DBProjekti, Yhteystieto } from "../../database/model";
 import { translate } from "../../util/localization";
+import { vaylaUserToYhteystieto } from "../../util/vaylaUserToYhteystieto";
 
 type SuunnitelmaTyyppi = "tiesuunnitelma" | "ratasuunnitelma" | "yleissuunnitelma";
 
@@ -193,14 +194,7 @@ export class LahetekirjeAdapter {
     kayttoOikeudet
       ?.filter(({ esitetaanKuulutuksessa }) => !!esitetaanKuulutuksessa)
       ?.forEach((oikeus) => {
-        const [sukunimi, etunimi] = oikeus.nimi.split(/, /g);
-        yt.push({
-          etunimi,
-          sukunimi,
-          puhelinnumero: oikeus.puhelinnumero,
-          sahkoposti: oikeus.email,
-          organisaatio: oikeus.organisaatio,
-        });
+        yt.push(vaylaUserToYhteystieto(oikeus));
       });
     esitettavatYhteystiedot?.forEach((yhteystieto) => {
       yt.push(yhteystieto);

--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -5,19 +5,21 @@ import {
   adaptKielitiedotByAddingTypename,
   adaptVelhoByAddingTypename,
   adaptYhteystiedotByAddingTypename,
+  adaptKuulutusYhteystiedotByAddingTypename,
 } from "../common";
 import { adaptSuunnitteluSopimus } from "./adaptSuunitteluSopimus";
 import { fileService } from "../../../files/fileService";
 
 export function adaptAloitusKuulutus(kuulutus?: AloitusKuulutus | null): API.AloitusKuulutus | undefined {
   if (kuulutus) {
-    const { esitettavatYhteystiedot, ...otherKuulutusFields } = kuulutus;
+    const { esitettavatYhteystiedot, kuulutusYhteystiedot, ...otherKuulutusFields } = kuulutus;
     const yhteystiedot = adaptYhteystiedotByAddingTypename(esitettavatYhteystiedot);
     return {
       __typename: "AloitusKuulutus",
       ...otherKuulutusFields,
       esitettavatYhteystiedot: yhteystiedot,
       hankkeenKuvaus: adaptHankkeenKuvaus(kuulutus.hankkeenKuvaus),
+      kuulutusYhteystiedot: adaptKuulutusYhteystiedotByAddingTypename(kuulutusYhteystiedot),
     };
   }
   return kuulutus as undefined;

--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -12,12 +12,10 @@ import { fileService } from "../../../files/fileService";
 
 export function adaptAloitusKuulutus(kuulutus?: AloitusKuulutus | null): API.AloitusKuulutus | undefined {
   if (kuulutus) {
-    const { esitettavatYhteystiedot, kuulutusYhteystiedot, ...otherKuulutusFields } = kuulutus;
-    const yhteystiedot = adaptYhteystiedotByAddingTypename(esitettavatYhteystiedot);
+    const { kuulutusYhteystiedot, ...otherKuulutusFields } = kuulutus;
     return {
       __typename: "AloitusKuulutus",
       ...otherKuulutusFields,
-      esitettavatYhteystiedot: yhteystiedot,
       hankkeenKuvaus: adaptHankkeenKuvaus(kuulutus.hankkeenKuvaus),
       kuulutusYhteystiedot: adaptKuulutusYhteystiedotByAddingTypename(kuulutusYhteystiedot),
     };

--- a/backend/src/projekti/adapter/adaptToDB/adaptAloitusKuulutusToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptAloitusKuulutusToSave.ts
@@ -1,16 +1,18 @@
 import * as API from "../../../../../common/graphql/apiModel";
 import { AloitusKuulutus } from "../../../database/model";
 import { adaptHankkeenKuvausToSave, adaptIlmoituksenVastaanottajatToSave } from "./common";
+import { adaptKuulutusYhteystiedotByAddingTypename } from "../common/lisaaTypename";
 
 export function adaptAloitusKuulutusToSave(
   aloitusKuulutus: API.AloitusKuulutusInput
 ): AloitusKuulutus | null | undefined {
   if (aloitusKuulutus) {
-    const { hankkeenKuvaus, ilmoituksenVastaanottajat, ...rest } = aloitusKuulutus;
+    const { hankkeenKuvaus, ilmoituksenVastaanottajat, kuulutusYhteystiedot, ...rest } = aloitusKuulutus;
     return {
       ...rest,
+      ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajatToSave(ilmoituksenVastaanottajat), //pakko tukea vielä tätä
       hankkeenKuvaus: adaptHankkeenKuvausToSave(hankkeenKuvaus),
-      ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajatToSave(ilmoituksenVastaanottajat),
+      kuulutusYhteystiedot: adaptKuulutusYhteystiedotByAddingTypename(kuulutusYhteystiedot),
     };
   }
   return aloitusKuulutus as undefined;

--- a/backend/src/projekti/adapter/adaptToDB/adaptAloitusKuulutusToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptAloitusKuulutusToSave.ts
@@ -1,7 +1,7 @@
 import * as API from "../../../../../common/graphql/apiModel";
 import { AloitusKuulutus } from "../../../database/model";
 import { adaptHankkeenKuvausToSave, adaptIlmoituksenVastaanottajatToSave } from "./common";
-import { adaptKuulutusYhteystiedotByAddingTypename } from "../common/lisaaTypename";
+import { adaptKuulutusYhteystiedotByAddingTypename } from "../common";
 
 export function adaptAloitusKuulutusToSave(
   aloitusKuulutus: API.AloitusKuulutusInput

--- a/backend/src/projekti/adapter/adaptToDB/common.ts
+++ b/backend/src/projekti/adapter/adaptToDB/common.ts
@@ -29,6 +29,19 @@ export function adaptYhteystiedotToSave(
   return yhteystietoInputs?.length > 0 ? yhteystietoInputs.map((yt) => ({ ...yt })) : undefined;
 }
 
+export function adaptYhteysHenkilotToSave(yhteystiedot: string[]): string[] {
+  return yhteystiedot.filter((yt, index) => yhteystiedot.indexOf(yt) === index);
+}
+
+export function adaptKuulutusYhteystiedot(
+  kuulutusYhteystiedot: API.KuulutusYhteystiedotInput
+): API.KuulutusYhteystiedotInput {
+  return {
+    yhteysTiedot: adaptYhteystiedotToSave(kuulutusYhteystiedot.yhteysTiedot),
+    yhteysHenkilot: adaptYhteysHenkilotToSave(kuulutusYhteystiedot.yhteysHenkilot),
+  };
+}
+
 export function adaptHankkeenKuvausToSave(hankkeenKuvaus: API.HankkeenKuvauksetInput): LocalizedMap<string> {
   if (!hankkeenKuvaus) {
     return undefined;

--- a/backend/src/projekti/adapter/common/lisaaTypename.ts
+++ b/backend/src/projekti/adapter/common/lisaaTypename.ts
@@ -1,4 +1,4 @@
-import { Kielitiedot, Linkki, Suunnitelma, Velho, Yhteystieto } from "../../../database/model";
+import { Kielitiedot, KuulutusYhteystiedot, Linkki, Suunnitelma, Velho, Yhteystieto } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 
 export function adaptLiittyvatSuunnitelmatByAddingTypename(
@@ -56,4 +56,17 @@ export function adaptYhteystiedotByAddingTypename(yhteystiedot: Yhteystieto[]): 
     return yhteystiedot.map((yt) => ({ __typename: "Yhteystieto", ...yt }));
   }
   return yhteystiedot as undefined | null;
+}
+
+export function adaptKuulutusYhteystiedotByAddingTypename(
+  kuulutusYhteystiedot: KuulutusYhteystiedot
+): API.KuulutusYhteystiedot | undefined | null {
+  if (kuulutusYhteystiedot) {
+    return {
+      __typename: "KuulutusYhteystiedot",
+      yhteysHenkilot: kuulutusYhteystiedot.yhteysHenkilot,
+      yhteysTiedot: adaptYhteystiedotByAddingTypename(kuulutusYhteystiedot.yhteysTiedot),
+    };
+  }
+  return kuulutusYhteystiedot as undefined;
 }

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -97,6 +97,7 @@ class ProjektiAdapterJulkinen {
   public adaptProjekti(dbProjekti: DBProjekti): API.ProjektiJulkinen | undefined {
     const aloitusKuulutusJulkaisut = this.adaptAloitusKuulutusJulkaisut(
       dbProjekti.oid,
+      dbProjekti.kayttoOikeudet,
       dbProjekti.aloitusKuulutusJulkaisut
     );
 
@@ -133,6 +134,7 @@ class ProjektiAdapterJulkinen {
 
   adaptAloitusKuulutusJulkaisut(
     oid: string,
+    kayttoOikeudet: DBVaylaUser[],
     aloitusKuulutusJulkaisut?: AloitusKuulutusJulkaisu[] | null
   ): API.AloitusKuulutusJulkaisuJulkinen[] | undefined {
     if (aloitusKuulutusJulkaisut) {

--- a/backend/src/projekti/kayttoOikeudetManager.ts
+++ b/backend/src/projekti/kayttoOikeudetManager.ts
@@ -25,12 +25,11 @@ export class KayttoOikeudetManager {
     const resultUsers: DBVaylaUser[] = this.users.reduce((resultingUsers: DBVaylaUser[], currentUser) => {
       const inputUser = changes.find((user) => user.kayttajatunnus === currentUser.kayttajatunnus);
       if (inputUser) {
-        // Update only puhelinnumero and force esitetaanKuulutuksessa to be true if projektipaallikko
+        // Update only puhelinnumero if projektipaallikko
         if (inputUser.rooli === ProjektiRooli.PROJEKTIPAALLIKKO) {
           resultingUsers.push({
             ...currentUser,
             puhelinnumero: inputUser.puhelinnumero,
-            esitetaanKuulutuksessa: true,
           });
         } else {
           // Update rest of fields
@@ -95,7 +94,6 @@ export class KayttoOikeudetManager {
       user: {
         rooli: ProjektiRooli.PROJEKTIPAALLIKKO,
         email: vastuuhenkiloEmail,
-        esitetaanKuulutuksessa: true,
       },
       searchMode: SearchMode.EMAIL,
     });

--- a/backend/src/util/vaylaUserToYhteystieto.ts
+++ b/backend/src/util/vaylaUserToYhteystieto.ts
@@ -1,0 +1,13 @@
+import { DBVaylaUser } from "../database/model/projekti";
+import { Yhteystieto } from "../database/model/common";
+
+export function vaylaUserToYhteystieto(vaylaUser: DBVaylaUser): Yhteystieto {
+  const [sukunimi, etunimi] = vaylaUser.nimi.split(/, /g);
+  return {
+    etunimi,
+    sukunimi,
+    puhelinnumero: vaylaUser.puhelinnumero,
+    sahkoposti: vaylaUser.email,
+    organisaatio: vaylaUser.organisaatio,
+  };
+}

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -7,7 +7,6 @@ Object {
     Object {
       "__typename": "ProjektiKayttaja",
       "email": "pekka.projari@vayla.fi",
-      "esitetaanKuulutuksessa": true,
       "kayttajatunnus": "A123",
       "nimi": "Projari, Pekka",
       "organisaatio": "Väylävirasto",
@@ -42,7 +41,6 @@ Array [
     Object {
       "__typename": "ProjektiKayttaja",
       "email": "pekka.projari@vayla.fi",
-      "esitetaanKuulutuksessa": true,
       "kayttajatunnus": "A123",
       "nimi": "Projari, Pekka",
       "organisaatio": "Väylävirasto",
@@ -376,7 +374,6 @@ Array [
     "__typename": "Projekti",
     "aloitusKuulutus": Object {
       "__typename": "AloitusKuulutus",
-      "esitettavatYhteystiedot": undefined,
       "hankkeenKuvaus": Object {
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
@@ -635,7 +632,6 @@ Object {
   "__typename": "Projekti",
   "aloitusKuulutus": Object {
     "__typename": "AloitusKuulutus",
-    "esitettavatYhteystiedot": undefined,
     "hankkeenKuvaus": Object {
       "RUOTSI": "På Svenska",
       "SAAME": "Saameksi",

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -290,15 +290,6 @@ Array [
   "Save projekti having while adding one muokkaaja more. There should be three persons in the projekti now",
   Object {
     "aloitusKuulutus": Object {
-      "esitettavatYhteystiedot": Array [
-        Object {
-          "etunimi": "Marko",
-          "organisaatio": "Kajaani",
-          "puhelinnumero": "0293121213",
-          "sahkoposti": "markku.koi@koi.com",
-          "sukunimi": "Koi",
-        },
-      ],
       "hankkeenKuvaus": Object {
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
@@ -306,6 +297,20 @@ Array [
       },
       "ilmoituksenVastaanottajat": undefined,
       "kuulutusPaiva": "2022-01-02",
+      "kuulutusYhteystiedot": Object {
+        "__typename": "KuulutusYhteystiedot",
+        "yhteysHenkilot": undefined,
+        "yhteysTiedot": Array [
+          Object {
+            "__typename": "Yhteystieto",
+            "etunimi": "Marko",
+            "organisaatio": "Kajaani",
+            "puhelinnumero": "0293121213",
+            "sahkoposti": "markku.koi@koi.com",
+            "sukunimi": "Koi",
+          },
+        ],
+      },
       "siirtyySuunnitteluVaiheeseen": "2999-01-01",
     },
     "euRahoitus": false,
@@ -371,16 +376,7 @@ Array [
     "__typename": "Projekti",
     "aloitusKuulutus": Object {
       "__typename": "AloitusKuulutus",
-      "esitettavatYhteystiedot": Array [
-        Object {
-          "__typename": "Yhteystieto",
-          "etunimi": "Marko",
-          "organisaatio": "Kajaani",
-          "puhelinnumero": "0293121213",
-          "sahkoposti": "markku.koi@koi.com",
-          "sukunimi": "Koi",
-        },
-      ],
+      "esitettavatYhteystiedot": undefined,
       "hankkeenKuvaus": Object {
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
@@ -389,6 +385,20 @@ Array [
       },
       "ilmoituksenVastaanottajat": undefined,
       "kuulutusPaiva": "2022-01-02",
+      "kuulutusYhteystiedot": Object {
+        "__typename": "KuulutusYhteystiedot",
+        "yhteysHenkilot": undefined,
+        "yhteysTiedot": Array [
+          Object {
+            "__typename": "Yhteystieto",
+            "etunimi": "Marko",
+            "organisaatio": "Kajaani",
+            "puhelinnumero": "0293121213",
+            "sahkoposti": "markku.koi@koi.com",
+            "sukunimi": "Koi",
+          },
+        ],
+      },
       "siirtyySuunnitteluVaiheeseen": "2999-01-01",
     },
     "euRahoitus": false,
@@ -625,16 +635,7 @@ Object {
   "__typename": "Projekti",
   "aloitusKuulutus": Object {
     "__typename": "AloitusKuulutus",
-    "esitettavatYhteystiedot": Array [
-      Object {
-        "__typename": "Yhteystieto",
-        "etunimi": "Marko",
-        "organisaatio": "Kajaani",
-        "puhelinnumero": "0293121213",
-        "sahkoposti": "markku.koi@koi.com",
-        "sukunimi": "Koi",
-      },
-    ],
+    "esitettavatYhteystiedot": undefined,
     "hankkeenKuvaus": Object {
       "RUOTSI": "På Svenska",
       "SAAME": "Saameksi",
@@ -643,6 +644,20 @@ Object {
     },
     "ilmoituksenVastaanottajat": undefined,
     "kuulutusPaiva": "2022-01-02",
+    "kuulutusYhteystiedot": Object {
+      "__typename": "KuulutusYhteystiedot",
+      "yhteysHenkilot": undefined,
+      "yhteysTiedot": Array [
+        Object {
+          "__typename": "Yhteystieto",
+          "etunimi": "Marko",
+          "organisaatio": "Kajaani",
+          "puhelinnumero": "0293121213",
+          "sahkoposti": "markku.koi@koi.com",
+          "sukunimi": "Koi",
+        },
+      ],
+    },
     "palautusSyy": null,
     "siirtyySuunnitteluVaiheeseen": "2999-01-01",
   },

--- a/backend/test/asiakirja/__snapshots__/asiakirjaService.test.ts.snap
+++ b/backend/test/asiakirja/__snapshots__/asiakirjaService.test.ts.snap
@@ -1205,6 +1205,13 @@ Object {
   },
   "yhteystiedot": Array [
     Object {
+      "etunimi": "Pekka",
+      "organisaatio": "Väylävirasto",
+      "puhelinnumero": "123456789",
+      "sahkoposti": "pekka.projari@vayla.fi",
+      "sukunimi": "Projari",
+    },
+    Object {
       "etunimi": "Marko",
       "organisaatio": "Kajaani",
       "puhelinnumero": "0293121213",
@@ -1234,6 +1241,7 @@ Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkil
 
 
 Lisätietoja antavat 
+Väylävirasto, Pekka Projari, puh. 123456789, pekka.projari(at)vayla.fi 
 Kajaani, Marko Koi, puh. 0293121213, markku.koi(at)koi.com 
 Nokia, Joku Jossain, puh. 123, Joku.Jossain(at)vayla.fi 
 Nokia
@@ -1250,6 +1258,7 @@ Testiprojekti 1
 Väylävirasto julkaisee tietoverkossaan liikennejärjestelmästä ja maanteistä annetun lain (503/2005) sekä hallintolain 62 a §:n mukaisesti kuulutuksen, joka koskee otsikossa mainitun tiesuunnitelman suunnittelun ja maastotöiden aloittamista. Väylävirasto saattaa asian tiedoksi julkisesti kuuluttamalla siten, kuin julkisesta kuulutuksesta säädetään hallintolaissa, sekä julkaisemalla kuulutuksen yhdessä tai useammassa alueella yleisesti ilmestyvässä sanomalehdessä.
 Kuulutus julkaistaan 2.1.2022, Uudenmaan ELY-keskuksen tietoverkossa osoitteessa https://www.ely-keskus.fi/kuulutukset. 
 Lisätietoja antavat 
+Väylävirasto, Pekka Projari, puh. 123456789, pekka.projari(at)vayla.fi 
 Kajaani, Marko Koi, puh. 0293121213, markku.koi(at)koi.com 
 Nokia, Joku Jossain, puh. 123, Joku.Jossain(at)vayla.fi 
 LUONNOS",
@@ -1275,6 +1284,7 @@ RUOTSIKSI Väylävirasto behandlar personuppgifter som är nödvändiga för uta
 
 
 Mer information om planen 
+Väylävirasto, Pekka Projari, tel. 123456789, pekka.projari(at)vayla.fi 
 Kajaani, Marko Koi, tel. 0293121213, markku.koi(at)koi.com 
 Nokia, Joku Jossain, tel. 123, Joku.Jossain(at)vayla.fi 
 Nokia
@@ -1291,6 +1301,7 @@ Namnet på svenska
 RUOTSIKSI RUOTSIKSI Väylävirasto julkaisee tietoverkossaan liikennejärjestelmästä ja maanteistä annetun lain (503/2005) sekä hallintolain 62 a §:n mukaisesti kuulutuksen, joka koskee otsikossa mainitun vägplanen suunnittelun ja maastotöiden aloittamista. RUOTSIKSI Väylävirasto saattaa asian tiedoksi julkisesti kuuluttamalla siten, kuin julkisesta kuulutuksesta säädetään hallintolaissa, sekä julkaisemalla kuulutuksen yhdessä tai useammassa alueella yleisesti ilmestyvässä sanomalehdessä.
 RUOTSIKSI Kuulutus julkaistaan 2.1.2022, RUOTSIKSI Uudenmaan ELY-keskuksen tietoverkossa osoitteessa https://www.ely-keskus.fi/kuulutukset. 
 Mer information om planen 
+Väylävirasto, Pekka Projari, tel. 123456789, pekka.projari(at)vayla.fi 
 Kajaani, Marko Koi, tel. 0293121213, markku.koi(at)koi.com 
 Nokia, Joku Jossain, tel. 123, Joku.Jossain(at)vayla.fi 
 LUONNOS",

--- a/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
+++ b/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
@@ -39,7 +39,6 @@ Object {
     ":kayttoOikeudet": Array [
       Object {
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": null,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -48,7 +47,6 @@ Object {
       },
       Object {
         "email": "Matti.Meikalainen@vayla.fi",
-        "esitetaanKuulutuksessa": null,
         "kayttajatunnus": "A000111",
         "nimi": "Meikalainen, Matti",
         "organisaatio": "Väylävirasto",

--- a/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
+++ b/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
@@ -15,21 +15,23 @@ Object {
   },
   "ExpressionAttributeValues": Object {
     ":aloitusKuulutus": Object {
-      "esitettavatYhteystiedot": Array [
-        Object {
-          "etunimi": "Marko",
-          "organisaatio": "Kajaani",
-          "puhelinnumero": "0293121213",
-          "sahkoposti": "markku.koi@koi.com",
-          "sukunimi": "Koi",
-        },
-      ],
       "hankkeenKuvaus": Object {
         "RUOTSI": "På svenska",
         "SAAME": "Saameksi",
         "SUOMI": "Lorem Ipsum",
       },
       "kuulutusPaiva": "2022-01-02",
+      "kuulutusYhteystiedot": Object {
+        "yhteysTiedot": Array [
+          Object {
+            "etunimi": "Marko",
+            "organisaatio": "Kajaani",
+            "puhelinnumero": "0293121213",
+            "sahkoposti": "markku.koi@koi.com",
+            "sukunimi": "Koi",
+          },
+        ],
+      },
       "siirtyySuunnitteluVaiheeseen": "2022-01-01",
     },
     ":emptyList": Array [],

--- a/backend/test/fixture/projektiFixture.ts
+++ b/backend/test/fixture/projektiFixture.ts
@@ -33,7 +33,7 @@ export class ProjektiFixture {
   public PROJEKTI4_NIMI = "Testiprojekti 4";
   public PROJEKTI4_OID = "4";
 
-  private esitettavatYhteystiedot = [
+  private yhteystietoLista = [
     {
       etunimi: "Marko",
       sukunimi: "Koi",
@@ -75,7 +75,7 @@ export class ProjektiFixture {
     ],
   };
 
-  private esitettavatYhteystiedot2: Yhteystieto[] = [
+  private yhteystietoLista2: Yhteystieto[] = [
     {
       __typename: "Yhteystieto",
       etunimi: "Etunimi",
@@ -181,7 +181,9 @@ export class ProjektiFixture {
     hankkeenKuvaus: { SUOMI: "Lorem Ipsum", RUOTSI: "På Svenska", SAAME: "Saameksi" },
 
     siirtyySuunnitteluVaiheeseen: "2999-01-01",
-    esitettavatYhteystiedot: this.esitettavatYhteystiedot,
+    kuulutusYhteystiedot: {
+      yhteysTiedot: this.yhteystietoLista,
+    },
   };
 
   dbProjekti1(): DBProjekti {
@@ -232,7 +234,9 @@ export class ProjektiFixture {
           SAAME: "Saameksi",
         },
         siirtyySuunnitteluVaiheeseen: "2022-01-01",
-        esitettavatYhteystiedot: this.esitettavatYhteystiedot,
+        kuulutusYhteystiedot: {
+          yhteysTiedot: this.yhteystietoLista,
+        },
       },
       kielitiedot: {
         ensisijainenKieli: Kieli.SUOMI,
@@ -385,7 +389,7 @@ export class ProjektiFixture {
         muistutusoikeusPaattyyPaiva: "2042-06-08",
         kuulutusYhteysHenkilot: [ProjektiFixture.mattiMeikalainenProjektiKayttaja.kayttajatunnus],
         ilmoituksenVastaanottajat: this.ilmoituksenVastaanottajat,
-        kuulutusYhteystiedot: this.esitettavatYhteystiedot,
+        kuulutusYhteystiedot: this.yhteystietoLista,
       },
       kielitiedot: {
         ensisijainenKieli: Kieli.SUOMI,
@@ -406,7 +410,7 @@ export class ProjektiFixture {
         id: 1,
         hallintoOikeus: HallintoOikeus.HAMEENLINNA,
         ilmoituksenVastaanottajat: this.ilmoituksenVastaanottajat,
-        kuulutusYhteystiedot: this.esitettavatYhteystiedot,
+        kuulutusYhteystiedot: this.yhteystietoLista,
         kuulutusPaiva: "2022-01-02",
         kuulutusVaihePaattyyPaiva: "2022-01-03",
         kuulutusYhteysHenkilot: [
@@ -568,7 +572,7 @@ export class ProjektiFixture {
         ProjektiFixture.mattiMeikalainenProjektiKayttaja.kayttajatunnus,
       ],
       ilmoituksenVastaanottajat: this.ilmoituksenVastaanottajat,
-      kuulutusYhteystiedot: this.esitettavatYhteystiedot,
+      kuulutusYhteystiedot: this.yhteystietoLista,
     },
     nahtavillaoloVaiheJulkaisut: [
       {
@@ -806,7 +810,7 @@ export class ProjektiFixture {
         paivamaara: "2022-04-05",
         alkamisAika: "10:00",
         paattymisAika: "11:00",
-        esitettavatYhteystiedot: this.esitettavatYhteystiedot2,
+        esitettavatYhteystiedot: this.yhteystietoLista2,
         projektiYhteysHenkilot: [
           ProjektiFixture.pekkaProjariProjektiKayttaja.kayttajatunnus,
           ProjektiFixture.mattiMeikalainenProjektiKayttaja.kayttajatunnus,
@@ -818,7 +822,7 @@ export class ProjektiFixture {
         paivamaara: "2033-04-05",
         alkamisAika: "12:00",
         paattymisAika: "13:00",
-        esitettavatYhteystiedot: this.esitettavatYhteystiedot2,
+        esitettavatYhteystiedot: this.yhteystietoLista2,
       },
     ],
   };

--- a/backend/test/fixture/projektiFixture.ts
+++ b/backend/test/fixture/projektiFixture.ts
@@ -104,7 +104,6 @@ export class ProjektiFixture {
     email: "pekka.projari@vayla.fi",
     organisaatio: "Väylävirasto",
     puhelinnumero: "123456789",
-    esitetaanKuulutuksessa: null,
   };
 
   private static mattiMeikalainenProjektiKayttaja: ProjektiKayttaja = {
@@ -115,7 +114,6 @@ export class ProjektiFixture {
     email: "Matti.Meikalainen@vayla.fi",
     organisaatio: "Väylävirasto",
     puhelinnumero: "123456789",
-    esitetaanKuulutuksessa: null,
   };
 
   tallennaProjektiInput: TallennaProjektiInput = {
@@ -170,7 +168,6 @@ export class ProjektiFixture {
           email: "pekka.projari@vayla.fi",
           organisaatio: "Väylävirasto",
           puhelinnumero: "123456789",
-          esitetaanKuulutuksessa: null,
         },
       ],
     };
@@ -196,7 +193,6 @@ export class ProjektiFixture {
           nimi: ProjektiFixture.pekkaProjariProjektiKayttaja.nimi,
           puhelinnumero: ProjektiFixture.pekkaProjariProjektiKayttaja.puhelinnumero || "",
           organisaatio: ProjektiFixture.pekkaProjariProjektiKayttaja.organisaatio,
-          esitetaanKuulutuksessa: ProjektiFixture.pekkaProjariProjektiKayttaja.esitetaanKuulutuksessa,
         },
         {
           rooli: ProjektiRooli.MUOKKAAJA,
@@ -205,7 +201,6 @@ export class ProjektiFixture {
           nimi: ProjektiFixture.mattiMeikalainenProjektiKayttaja.nimi,
           puhelinnumero: ProjektiFixture.mattiMeikalainenProjektiKayttaja.puhelinnumero || "",
           organisaatio: ProjektiFixture.mattiMeikalainenProjektiKayttaja.organisaatio,
-          esitetaanKuulutuksessa: ProjektiFixture.mattiMeikalainenProjektiKayttaja.esitetaanKuulutuksessa,
         },
       ],
       oid: this.PROJEKTI1_OID,
@@ -264,7 +259,6 @@ export class ProjektiFixture {
           nimi: ProjektiFixture.pekkaProjariProjektiKayttaja.nimi,
           puhelinnumero: ProjektiFixture.pekkaProjariProjektiKayttaja.puhelinnumero || "",
           organisaatio: ProjektiFixture.pekkaProjariProjektiKayttaja.organisaatio,
-          esitetaanKuulutuksessa: ProjektiFixture.pekkaProjariProjektiKayttaja.esitetaanKuulutuksessa,
         },
         {
           rooli: ProjektiRooli.MUOKKAAJA,
@@ -273,7 +267,6 @@ export class ProjektiFixture {
           nimi: ProjektiFixture.mattiMeikalainenProjektiKayttaja.nimi,
           puhelinnumero: ProjektiFixture.mattiMeikalainenProjektiKayttaja.puhelinnumero || "",
           organisaatio: ProjektiFixture.mattiMeikalainenProjektiKayttaja.organisaatio,
-          esitetaanKuulutuksessa: ProjektiFixture.mattiMeikalainenProjektiKayttaja.esitetaanKuulutuksessa,
         },
       ],
       oid: this.PROJEKTI2_OID,
@@ -376,7 +369,6 @@ export class ProjektiFixture {
         },
         kuulutusPaiva: "2022-03-28T14:28",
         siirtyySuunnitteluVaiheeseen: "2022-04-28T14:28",
-        esitettavatYhteystiedot: [],
       },
       nahtavillaoloVaihe: {
         id: 1,
@@ -433,7 +425,6 @@ export class ProjektiFixture {
         nimi: ProjektiFixture.pekkaProjariProjektiKayttaja.nimi,
         puhelinnumero: ProjektiFixture.pekkaProjariProjektiKayttaja.puhelinnumero || "",
         organisaatio: ProjektiFixture.pekkaProjariProjektiKayttaja.organisaatio,
-        esitetaanKuulutuksessa: ProjektiFixture.pekkaProjariProjektiKayttaja.esitetaanKuulutuksessa,
       },
       {
         rooli: ProjektiRooli.MUOKKAAJA,
@@ -442,7 +433,6 @@ export class ProjektiFixture {
         nimi: ProjektiFixture.mattiMeikalainenProjektiKayttaja.nimi,
         puhelinnumero: ProjektiFixture.mattiMeikalainenProjektiKayttaja.puhelinnumero || "",
         organisaatio: ProjektiFixture.mattiMeikalainenProjektiKayttaja.organisaatio,
-        esitetaanKuulutuksessa: ProjektiFixture.mattiMeikalainenProjektiKayttaja.esitetaanKuulutuksessa,
       },
     ],
     oid: this.PROJEKTI3_OID,
@@ -544,7 +534,6 @@ export class ProjektiFixture {
       },
       kuulutusPaiva: "2022-03-28T14:28",
       siirtyySuunnitteluVaiheeseen: "2022-04-28T14:28",
-      esitettavatYhteystiedot: [],
     },
     suunnitteluVaihe: {
       arvioSeuraavanVaiheenAlkamisesta: "Syksy 2024",

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -43,8 +43,13 @@ input AloitusKuulutusInput {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
   hankkeenKuvaus: HankkeenKuvauksetInput
-  esitettavatYhteystiedot: [YhteystietoInput!]
+  kuulutusYhteystiedot: KuulutusYhteystiedotInput
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajatInput
+}
+
+input KuulutusYhteystiedotInput {
+  yhteysTiedot: [YhteystietoInput!]
+  yhteysHenkilot: [String!]
 }
 
 input IlmoituksenVastaanottajatInput {

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -528,9 +528,18 @@ type AloitusKuulutus {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
   hankkeenKuvaus: HankkeenKuvaukset
+  """
+  Tama alla oleva poistuu kaytosta
+  """
   esitettavatYhteystiedot: [Yhteystieto!]
+  kuulutusYhteystiedot: KuulutusYhteystiedot
   palautusSyy: String
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajat
+}
+
+type KuulutusYhteystiedot {
+  yhteysTiedot: [Yhteystieto!]
+  yhteysHenkilot: [String!]
 }
 
 type AloitusKuulutusJulkaisu {

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -528,10 +528,6 @@ type AloitusKuulutus {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
   hankkeenKuvaus: HankkeenKuvaukset
-  """
-  Tama alla oleva poistuu kaytosta
-  """
-  esitettavatYhteystiedot: [Yhteystieto!]
   kuulutusYhteystiedot: KuulutusYhteystiedot
   palautusSyy: String
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajat

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -22,6 +22,7 @@ import {
   TilasiirtymaToiminto,
   TilasiirtymaTyyppi,
   AsiakirjaTyyppi,
+  Yhteystieto,
 } from "@services/api";
 import log from "loglevel";
 import { PageProps } from "@pages/_app";
@@ -56,7 +57,7 @@ type RequiredProjektiFields = Required<{
 type FormValues = RequiredProjektiFields & {
   aloitusKuulutus: Pick<
     AloitusKuulutusInput,
-    | "esitettavatYhteystiedot"
+    | "kuulutusYhteystiedot"
     | "kuulutusPaiva"
     | "hankkeenKuvaus"
     | "siirtyySuunnitteluVaiheeseen"
@@ -131,6 +132,11 @@ export default function Aloituskuulutus({ setRouteLabels }: PageProps): ReactEle
         ]),
       ];
 
+      const yhteysTiedot: Yhteystieto[] =
+        projekti?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysTiedot?.filter((yt) => yt as Yhteystieto) || [];
+      const yhteysHenkilot: string[] =
+        projekti?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysHenkilot?.filter((yt) => yt) || [];
+
       const tallentamisTiedot: FormValues = {
         oid: projekti.oid,
         kayttoOikeudet:
@@ -157,13 +163,10 @@ export default function Aloituskuulutus({ setRouteLabels }: PageProps): ReactEle
           hankkeenKuvaus: removeTypeName(projekti?.aloitusKuulutus?.hankkeenKuvaus),
           kuulutusPaiva: projekti?.aloitusKuulutus?.kuulutusPaiva,
           siirtyySuunnitteluVaiheeseen: projekti?.aloitusKuulutus?.siirtyySuunnitteluVaiheeseen,
-          esitettavatYhteystiedot:
-            projekti?.aloitusKuulutus?.esitettavatYhteystiedot
-              ?.filter((yt) => yt)
-              .map((yhteystieto) => {
-                const { __typename, ...yhteystietoInput } = yhteystieto;
-                return yhteystietoInput;
-              }) || [],
+          kuulutusYhteystiedot: {
+            yhteysTiedot,
+            yhteysHenkilot,
+          },
         },
       };
 
@@ -186,7 +189,8 @@ export default function Aloituskuulutus({ setRouteLabels }: PageProps): ReactEle
 
   const saveAloituskuulutus = useCallback(
     async (formData: FormValues) => {
-      deleteFieldArrayIds(formData?.aloitusKuulutus?.esitettavatYhteystiedot);
+      deleteFieldArrayIds(formData?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysTiedot);
+      deleteFieldArrayIds(formData?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysHenkilot);
       deleteFieldArrayIds(formData?.aloitusKuulutus?.ilmoituksenVastaanottajat?.kunnat);
       deleteFieldArrayIds(formData?.aloitusKuulutus?.ilmoituksenVastaanottajat?.viranomaiset);
       setIsFormSubmitting(true);
@@ -515,7 +519,7 @@ export default function Aloituskuulutus({ setRouteLabels }: PageProps): ReactEle
               getAloituskuulutusjulkaisuByTila(AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA)
             }
             isLoadingProjekti={isLoadingProjekti}
-          ></AloituskuulutusLukunakyma>
+          />
         </FormProvider>
       )}
 

--- a/src/services/api/fragmentTypes.json
+++ b/src/services/api/fragmentTypes.json
@@ -320,6 +320,18 @@
         "__typename": "__Type"
       },
       {
+        "kind": "OBJECT",
+        "name": "KuulutusYhteystiedot",
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "KuulutusYhteystiedotInput",
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
         "kind": "ENUM",
         "name": "LaskuriTyyppi",
         "possibleTypes": null,


### PR DESCRIPTION
Bäkkärin tallennus-adapteri ottaa huomioon uuden inputin. API-adapterit ottavat huomioon uudenlaisen tietorakenteen. Kun tehdään aloitusKuulutusJulkaisu, BE generoi yhteystiedot kuulutusYhteystiedoista ja kayttoOikeuksista. Projektipäällikkö otetaan aina mukaan. FE:n aloituskuulutus-lomake antaa uudenlaista inputia.