### PR TITLE
fix: korjaa ilmoitustaulusyötteisiin oikea hostname

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -118,6 +118,7 @@ module.exports = (phase) => {
     }
     env.REACT_APP_API_KEY = process.env.REACT_APP_API_KEY;
     env.REACT_APP_API_URL = "https://" + process.env.FRONTEND_DOMAIN_NAME + "/graphql";
+    env.FRONTEND_DOMAIN_NAME = process.env.FRONTEND_DOMAIN_NAME;
     env.SEARCH_DOMAIN = process.env.SEARCH_DOMAIN;
 
     config.env = env;


### PR DESCRIPTION
Generoitu hostname tuli mukaan .env.local-tiedostosta, jota ei muualla kuin devaajan ympäristössä tarvita.
Oikea hostname tulee nyt täältä mistä alunperin pitikin: https://github.com/finnishtransportagency/hassu/blob/e1a74fb6be41ad9f38db6b4a8e82451a9265d9ef/deployment/lib/hassu-frontend.ts#L96