### PR TITLE
feat: HASSU-1042 korjaa be tyypitys

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,18 +1,9 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "plugins": [
-    "@typescript-eslint",
-    "mocha-no-only"
-  ],
-  "extends": [
-    "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
-    "prettier"
-  ],
-  "ignorePatterns": [
-    "**/bin/*"
-  ],
+  "plugins": ["@typescript-eslint", "mocha-no-only"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  "ignorePatterns": ["**/bin/*"],
   "rules": {
     "@typescript-eslint/no-var-requires": "warn",
     "object-shorthand": "warn",
@@ -23,8 +14,13 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "mocha-no-only/mocha-no-only": [
-      "error"
+    "mocha-no-only/mocha-no-only": ["error"],
+    "@typescript-eslint/consistent-type-assertions": [
+      "error",
+      {
+        "assertionStyle": "as",
+        "objectLiteralTypeAssertions": "allow-as-parameter"
+      }
     ]
   }
 }

--- a/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusHandler.test.ts.snap
+++ b/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusHandler.test.ts.snap
@@ -101,6 +101,7 @@ Object {
       },
       "yhteystiedot": Array [
         Object {
+          "__typename": "Yhteystieto",
           "etunimi": "Pekka",
           "organisaatio": "Väylävirasto",
           "puhelinnumero": "123456789",
@@ -108,6 +109,7 @@ Object {
           "sukunimi": "Projari",
         },
         Object {
+          "__typename": "Yhteystieto",
           "etunimi": "Marko",
           "organisaatio": "Kajaani",
           "puhelinnumero": "0293121213",
@@ -223,6 +225,7 @@ Object {
       },
       "yhteystiedot": Array [
         Object {
+          "__typename": "Yhteystieto",
           "etunimi": "Pekka",
           "organisaatio": "Väylävirasto",
           "puhelinnumero": "123456789",
@@ -230,6 +233,7 @@ Object {
           "sukunimi": "Projari",
         },
         Object {
+          "__typename": "Yhteystieto",
           "etunimi": "Marko",
           "organisaatio": "Kajaani",
           "puhelinnumero": "0293121213",
@@ -319,6 +323,7 @@ Object {
       },
       "yhteystiedot": Array [
         Object {
+          "__typename": "Yhteystieto",
           "etunimi": "Pekka",
           "organisaatio": "Väylävirasto",
           "puhelinnumero": "123456789",
@@ -326,6 +331,7 @@ Object {
           "sukunimi": "Projari",
         },
         Object {
+          "__typename": "Yhteystieto",
           "etunimi": "Marko",
           "organisaatio": "Kajaani",
           "puhelinnumero": "0293121213",

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -70,7 +70,12 @@ Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkil
 Lisätietoja antaa
 CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
 Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
-    "to": Array [],
+    "to": Array [
+      "mikkeli@mikke.li",
+      "juva@ju.va",
+      "savonlinna@savonlin.na",
+      "kirjaamo.etela-savo@ely-keskus.fi",
+    ],
   },
 ]
 `;
@@ -1426,6 +1431,7 @@ Object {
         ],
         "yhteystiedot": Array [
           Object {
+            "__typename": "Yhteystieto",
             "etunimi": "A-tunnus1",
             "organisaatio": "CGI Suomi Oy",
             "puhelinnumero": "123",
@@ -1550,6 +1556,7 @@ Object {
         ],
         "yhteystiedot": Array [
           Object {
+            "__typename": "Yhteystieto",
             "etunimi": "A-tunnus1",
             "organisaatio": "CGI Suomi Oy",
             "puhelinnumero": "123",
@@ -1557,6 +1564,7 @@ Object {
             "sukunimi": "Hassu",
           },
           Object {
+            "__typename": "Yhteystieto",
             "etunimi": "A-Tunnus",
             "organisaatio": "CGI Suomi Oy",
             "puhelinnumero": "123",
@@ -2758,7 +2766,12 @@ Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkil
 Lisätietoja antaa
 CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
 Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
-    "to": Array [],
+    "to": Array [
+      "mikkeli@mikke.li",
+      "juva@ju.va",
+      "savonlinna@savonlin.na",
+      "kirjaamo.etela-savo@ely-keskus.fi",
+    ],
   },
 ]
 `;
@@ -3256,7 +3269,12 @@ Väylävirasto käsittelee suunnitelman laatimiseen liittyen tarpeellisia henkil
 Lisätietoja antaa
 CGI Suomi Oy, A-tunnus1 Hassu, puh. 123, mikko.haapamki@cgi.com
 Kajaani, Marko Koi, puh. 0293121213, markku.koi@koi.com",
-    "to": Array [],
+    "to": Array [
+      "mikkeli@mikke.li",
+      "juva@ju.va",
+      "savonlinna@savonlin.na",
+      "kirjaamo.etela-savo@ely-keskus.fi",
+    ],
   },
 ]
 `;

--- a/backend/integrationtest/api/api.test.ts
+++ b/backend/integrationtest/api/api.test.ts
@@ -84,6 +84,7 @@ describe("Api", () => {
 
     importAineistoStub = sinon.stub(aineistoImporterClient, "importAineisto");
     importAineistoStub.callsFake(async (event) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       fakeAineistoImportQueue.push({ Records: [{ body: JSON.stringify(event) } as SQSRecord] });
     });
 

--- a/backend/integrationtest/api/apiClient.ts
+++ b/backend/integrationtest/api/apiClient.ts
@@ -13,6 +13,7 @@ class API extends AbstractApi {
   }
 
   async callYllapitoAPI(operation: OperationConfig, variables?: unknown): Promise<unknown> {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const payload = {
       info: { fieldName: operation.name },
       arguments: variables,

--- a/backend/integrationtest/api/apiTestFixture.ts
+++ b/backend/integrationtest/api/apiTestFixture.ts
@@ -48,6 +48,16 @@ class ApiTestFixture {
     },
   ];
 
+  yhteytietoInputLista2: YhteystietoInput[] = [
+    {
+      etunimi: "Marko",
+      sukunimi: "Koi",
+      sahkoposti: "markku.koi@koi.com",
+      organisaatio: "Kajaani",
+      puhelinnumero: "0293121213",
+    },
+  ];
+
   yhteystietoInputLista: YhteystietoInput[] = [
     {
       etunimi: "Etunimi",
@@ -67,36 +77,15 @@ class ApiTestFixture {
     },
   ];
 
-  aloitusKuulutus: AloitusKuulutus = {
-    __typename: "AloitusKuulutus",
-    kuulutusPaiva: "2022-01-02",
-    hankkeenKuvaus: {
-      __typename: "HankkeenKuvaukset",
-      SUOMI: "Lorem Ipsum",
-      RUOTSI: "På Svenska",
-      SAAME: "Saameksi",
+  yhteystietoInputLista3: YhteystietoInput[] = [
+    {
+      etunimi: "Marko",
+      sukunimi: "Koi",
+      sahkoposti: "markku.koi@koi.com",
+      organisaatio: "Kajaani",
+      puhelinnumero: "0293121213",
     },
-    siirtyySuunnitteluVaiheeseen: "2022-01-01",
-    kuulutusYhteystiedot: {
-      __typename: "StandardiYhteystiedot",
-      yhteysTiedot: this.yhteystietoLista,
-      yhteysHenkilot: [],
-    },
-  };
-
-  kielitiedotInput: KielitiedotInput = {
-    ensisijainenKieli: Kieli.SUOMI,
-  };
-
-  kielitiedot: Kielitiedot = {
-    __typename: "Kielitiedot",
-    ensisijainenKieli: Kieli.SUOMI,
-  };
-
-  hankkeenKuvausSuunnittelu: HankkeenKuvauksetInput = {
-    SUOMI: "Lorem Ipsum suunnitteluvaihe",
-    SAAME: "Saameksi suunnitteluvaihe",
-  };
+  ];
 
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajat = {
     __typename: "IlmoituksenVastaanottajat",
@@ -130,6 +119,38 @@ class ApiTestFixture {
     ],
   };
 
+  aloitusKuulutus: AloitusKuulutus = {
+    __typename: "AloitusKuulutus",
+    kuulutusPaiva: "2022-01-02",
+    hankkeenKuvaus: {
+      __typename: "HankkeenKuvaukset",
+      SUOMI: "Lorem Ipsum",
+      RUOTSI: "På Svenska",
+      SAAME: "Saameksi",
+    },
+    siirtyySuunnitteluVaiheeseen: "2022-01-01",
+    kuulutusYhteystiedot: {
+      __typename: "StandardiYhteystiedot",
+      yhteysTiedot: this.yhteystietoLista,
+      yhteysHenkilot: [],
+    },
+    ilmoituksenVastaanottajat: this.ilmoituksenVastaanottajat,
+  };
+
+  kielitiedotInput: KielitiedotInput = {
+    ensisijainenKieli: Kieli.SUOMI,
+  };
+
+  kielitiedot: Kielitiedot = {
+    __typename: "Kielitiedot",
+    ensisijainenKieli: Kieli.SUOMI,
+  };
+
+  hankkeenKuvausSuunnittelu: HankkeenKuvauksetInput = {
+    SUOMI: "Lorem Ipsum suunnitteluvaihe",
+    SAAME: "Saameksi suunnitteluvaihe",
+  };
+
   suunnitteluVaihe = (vuorovaikutusNumero: number, vuorovaikutusYhteysHenkilot?: string[], julkinen?: boolean): SuunnitteluVaiheInput => ({
     vuorovaikutus: {
       vuorovaikutusNumero,
@@ -138,7 +159,7 @@ class ApiTestFixture {
       videot: [{ nimi: "Esittely " + vuorovaikutusNumero, url: "https://video" }],
       kysymyksetJaPalautteetViimeistaan: "2022-03-23T23:48",
       esitettavatYhteystiedot: {
-        yhteysTiedot: apiTestFixture.yhteystietoLista,
+        yhteysTiedot: apiTestFixture.yhteystietoInputLista3,
         yhteysHenkilot: vuorovaikutusYhteysHenkilot,
       },
       ilmoituksenVastaanottajat: apiTestFixture.ilmoituksenVastaanottajat,

--- a/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
+++ b/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
@@ -43,6 +43,36 @@
       "kielitiedot": {
         "ensisijainenKieli": "SUOMI"
       },
+      "ilmoituksenVastaanottajat": {
+        "kunnat": [
+          {
+            "sahkoposti": "mikkeli@mikke.li",
+            "lahetetty": "2022-09-21T13:11",
+            "nimi": "Mikkeli",
+            "__typename": "KuntaVastaanottaja"
+          },
+          {
+            "sahkoposti": "juva@ju.va",
+            "lahetetty": "2022-09-21T13:11",
+            "nimi": " Juva",
+            "__typename": "KuntaVastaanottaja"
+          },
+          {
+            "sahkoposti": "savonlinna@savonlin.na",
+            "lahetetty": "2022-09-21T13:11",
+            "nimi": " Savonlinna",
+            "__typename": "KuntaVastaanottaja"
+          }
+        ],
+        "viranomaiset": [
+          {
+            "sahkoposti": "kirjaamo.etela-savo@ely-keskus.fi",
+            "lahetetty": "2022-09-21T13:11",
+            "nimi": "ETELA_SAVO_ELY",
+            "__typename": "ViranomaisVastaanottaja"
+          }
+        ]
+      },
       "kuulutusPaiva": "2022-01-02",
       "muokkaaja": "A000112",
       "hyvaksyja": "A000112",
@@ -52,7 +82,8 @@
           "sahkoposti": "mikko.haapamki@cgi.com",
           "puhelinnumero": "123",
           "organisaatio": "CGI Suomi Oy",
-          "etunimi": "A-tunnus1"
+          "etunimi": "A-tunnus1",
+          "__typename": "Yhteystieto"
         },
         {
           "sukunimi": "Koi",
@@ -197,7 +228,6 @@
         "ensisijainenKieli": "SUOMI"
       },
       "ilmoituksenVastaanottajat": {
-        "__typename": "IlmoituksenVastaanottajat",
         "kunnat": [
           {
             "sahkoposti": "mikkeli@mikke.li",
@@ -266,7 +296,6 @@
   },
   "hyvaksymisPaatosVaihe": {
     "ilmoituksenVastaanottajat": {
-      "__typename": "IlmoituksenVastaanottajat",
       "kunnat": [
         {
           "sahkoposti": "mikkeli@mikke.li",
@@ -345,7 +374,6 @@
   },
   "nahtavillaoloVaihe": {
     "ilmoituksenVastaanottajat": {
-      "__typename": "IlmoituksenVastaanottajat",
       "kunnat": [
         {
           "sahkoposti": "mikkeli@mikke.li",
@@ -466,7 +494,6 @@
   "kayttoOikeudet": [
     {
       "kayttajatunnus": "A000112",
-      "esitetaanKuulutuksessa": true,
       "nimi": "Hassu, A-tunnus1",
       "rooli": "PROJEKTIPAALLIKKO",
       "organisaatio": "CGI Suomi Oy",
@@ -494,6 +521,36 @@
       "SAAME": "Saameksi",
       "RUOTSI": "På Svenska",
       "__typename": "HankkeenKuvaukset"
+    },
+    "ilmoituksenVastaanottajat": {
+      "kunnat": [
+        {
+          "sahkoposti": "mikkeli@mikke.li",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": "Mikkeli",
+          "__typename": "KuntaVastaanottaja"
+        },
+        {
+          "sahkoposti": "juva@ju.va",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": " Juva",
+          "__typename": "KuntaVastaanottaja"
+        },
+        {
+          "sahkoposti": "savonlinna@savonlin.na",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": " Savonlinna",
+          "__typename": "KuntaVastaanottaja"
+        }
+      ],
+      "viranomaiset": [
+        {
+          "sahkoposti": "kirjaamo.etela-savo@ely-keskus.fi",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": "ETELA_SAVO_ELY",
+          "__typename": "ViranomaisVastaanottaja"
+        }
+      ]
     },
     "kuulutusPaiva": "2022-01-02",
     "siirtyySuunnitteluVaiheeseen": "2022-01-01",
@@ -568,7 +625,6 @@
         "ensisijainenKieli": "SUOMI"
       },
       "ilmoituksenVastaanottajat": {
-        "__typename": "IlmoituksenVastaanottajat",
         "kunnat": [
           {
             "sahkoposti": "mikkeli@mikke.li",
@@ -629,7 +685,6 @@
   "vuorovaikutukset": [
     {
       "ilmoituksenVastaanottajat": {
-        "__typename": "IlmoituksenVastaanottajat",
         "kunnat": [
           {
             "sahkoposti": "mikkeli@mikke.li",
@@ -772,9 +827,6 @@
       "kysymyksetJaPalautteetViimeistaan": "2022-03-23T23:48",
       "julkinen": true,
       "esitettavatYhteystiedot": {
-        "yhteysHenkilot": [
-          "A000112"
-        ],
         "yhteysTiedot": [
           {
             "sukunimi": "Koi",
@@ -785,12 +837,14 @@
             "__typename": "Yhteystieto"
           }
         ],
+        "yhteysHenkilot": [
+          "A000112"
+        ],
         "__typename": "StandardiYhteystiedot"
       }
     },
     {
       "ilmoituksenVastaanottajat": {
-        "__typename": "IlmoituksenVastaanottajat",
         "kunnat": [
           {
             "sahkoposti": "mikkeli@mikke.li",
@@ -909,21 +963,19 @@
       "vuorovaikutusNumero": 2,
       "kysymyksetJaPalautteetViimeistaan": "2022-03-23T23:48",
       "esitettavatYhteystiedot": {
-        "yhteysHenkilot": [
-          "A000112",
-          "A000111"
-        ],
         "yhteysTiedot": [
           {
             "sukunimi": "Koi",
             "sahkoposti": "markku.koi@koi.com",
             "organisaatio": "Kajaani",
             "puhelinnumero": "0293121213",
-            "etunimi": "Marko",
-            "__typename": "Yhteystieto"
+            "etunimi": "Marko"
           }
         ],
-        "__typename": "StandardiYhteystiedot"
+        "yhteysHenkilot": [
+          "A000112",
+          "A000111"
+        ]
       }
     }
   ]

--- a/backend/integrationtest/api/records/NAHTAVILLAOLO.json
+++ b/backend/integrationtest/api/records/NAHTAVILLAOLO.json
@@ -43,6 +43,36 @@
       "kielitiedot": {
         "ensisijainenKieli": "SUOMI"
       },
+      "ilmoituksenVastaanottajat": {
+        "kunnat": [
+          {
+            "sahkoposti": "mikkeli@mikke.li",
+            "lahetetty": "2022-09-21T13:10",
+            "nimi": "Mikkeli",
+            "__typename": "KuntaVastaanottaja"
+          },
+          {
+            "sahkoposti": "juva@ju.va",
+            "lahetetty": "2022-09-21T13:10",
+            "nimi": " Juva",
+            "__typename": "KuntaVastaanottaja"
+          },
+          {
+            "sahkoposti": "savonlinna@savonlin.na",
+            "lahetetty": "2022-09-21T13:10",
+            "nimi": " Savonlinna",
+            "__typename": "KuntaVastaanottaja"
+          }
+        ],
+        "viranomaiset": [
+          {
+            "sahkoposti": "kirjaamo.etela-savo@ely-keskus.fi",
+            "lahetetty": "2022-09-21T13:10",
+            "nimi": "ETELA_SAVO_ELY",
+            "__typename": "ViranomaisVastaanottaja"
+          }
+        ]
+      },
       "kuulutusPaiva": "2022-01-02",
       "muokkaaja": "A000112",
       "hyvaksyja": "A000112",
@@ -52,7 +82,8 @@
           "sahkoposti": "mikko.haapamki@cgi.com",
           "puhelinnumero": "123",
           "organisaatio": "CGI Suomi Oy",
-          "etunimi": "A-tunnus1"
+          "etunimi": "A-tunnus1",
+          "__typename": "Yhteystieto"
         },
         {
           "sukunimi": "Koi",
@@ -116,7 +147,6 @@
   "kayttoOikeudet": [
     {
       "kayttajatunnus": "A000112",
-      "esitetaanKuulutuksessa": true,
       "nimi": "Hassu, A-tunnus1",
       "rooli": "PROJEKTIPAALLIKKO",
       "organisaatio": "CGI Suomi Oy",
@@ -139,6 +169,36 @@
       "RUOTSI": "På Svenska",
       "__typename": "HankkeenKuvaukset"
     },
+    "ilmoituksenVastaanottajat": {
+      "kunnat": [
+        {
+          "sahkoposti": "mikkeli@mikke.li",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": "Mikkeli",
+          "__typename": "KuntaVastaanottaja"
+        },
+        {
+          "sahkoposti": "juva@ju.va",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": " Juva",
+          "__typename": "KuntaVastaanottaja"
+        },
+        {
+          "sahkoposti": "savonlinna@savonlin.na",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": " Savonlinna",
+          "__typename": "KuntaVastaanottaja"
+        }
+      ],
+      "viranomaiset": [
+        {
+          "sahkoposti": "kirjaamo.etela-savo@ely-keskus.fi",
+          "lahetetty": "2022-03-11T14:54",
+          "nimi": "ETELA_SAVO_ELY",
+          "__typename": "ViranomaisVastaanottaja"
+        }
+      ]
+    },
     "kuulutusPaiva": "2022-01-02",
     "siirtyySuunnitteluVaiheeseen": "2022-01-01",
     "kuulutusYhteystiedot": {
@@ -160,7 +220,6 @@
   "vuorovaikutukset": [
     {
       "ilmoituksenVastaanottajat": {
-        "__typename": "IlmoituksenVastaanottajat",
         "kunnat": [
           {
             "sahkoposti": "mikkeli@mikke.li",
@@ -307,9 +366,6 @@
       "vuorovaikutusNumero": 1,
       "kysymyksetJaPalautteetViimeistaan": "2022-03-23T23:48",
       "esitettavatYhteystiedot": {
-        "yhteysHenkilot": [
-          "A000112"
-        ],
         "yhteysTiedot": [
           {
             "sukunimi": "Koi",
@@ -320,12 +376,14 @@
             "__typename": "Yhteystieto"
           }
         ],
+        "yhteysHenkilot": [
+          "A000112"
+        ],
         "__typename": "StandardiYhteystiedot"
       }
     },
     {
       "ilmoituksenVastaanottajat": {
-        "__typename": "IlmoituksenVastaanottajat",
         "kunnat": [
           {
             "sahkoposti": "mikkeli@mikke.li",
@@ -444,21 +502,19 @@
       "vuorovaikutusNumero": 2,
       "kysymyksetJaPalautteetViimeistaan": "2022-03-23T23:48",
       "esitettavatYhteystiedot": {
-        "yhteysHenkilot": [
-          "A000112",
-          "A000111"
-        ],
         "yhteysTiedot": [
           {
             "sukunimi": "Koi",
             "sahkoposti": "markku.koi@koi.com",
             "organisaatio": "Kajaani",
             "puhelinnumero": "0293121213",
-            "etunimi": "Marko",
-            "__typename": "Yhteystieto"
+            "etunimi": "Marko"
           }
         ],
-        "__typename": "StandardiYhteystiedot"
+        "yhteysHenkilot": [
+          "A000112",
+          "A000111"
+        ]
       }
     }
   ]

--- a/backend/integrationtest/api/testUtil/tests.ts
+++ b/backend/integrationtest/api/testUtil/tests.ts
@@ -52,10 +52,7 @@ export async function loadProjektiFromDatabase(oid: string, expectedStatus?: Sta
   return savedProjekti;
 }
 
-export async function loadProjektiJulkinenFromDatabase(
-  oid: string,
-  expectedStatus?: Status
-): Promise<ProjektiJulkinen> {
+export async function loadProjektiJulkinenFromDatabase(oid: string, expectedStatus?: Status): Promise<ProjektiJulkinen> {
   const savedProjekti = await api.lataaProjektiJulkinen(oid);
   if (expectedStatus) {
     expect(savedProjekti.status).to.be.eq(expectedStatus);
@@ -68,6 +65,7 @@ export async function testProjektiHenkilot(projekti: Projekti, oid: string): Pro
     oid,
     kayttoOikeudet: projekti.kayttoOikeudet?.map(
       (value) =>
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         ({
           rooli: value.rooli,
           kayttajatunnus: value.kayttajatunnus,
@@ -104,13 +102,9 @@ export async function tallennaLogo() {
   expect(uploadProperties).to.not.be.empty;
   expect(uploadProperties.latausLinkki).to.not.be.undefined;
   expect(uploadProperties.tiedostoPolku).to.not.be.undefined;
-  const putResponse = await axios.put(
-    uploadProperties.latausLinkki,
-    fs.readFileSync(__dirname + "/../../files/logo.png"),
-    {
-      headers: { "content-type": "image/png" },
-    }
-  );
+  const putResponse = await axios.put(uploadProperties.latausLinkki, fs.readFileSync(__dirname + "/../../files/logo.png"), {
+    headers: { "content-type": "image/png" },
+  });
   expect(putResponse.status).to.be.eq(200);
   return uploadProperties.tiedostoPolku;
 }
@@ -218,10 +212,7 @@ async function doTestSuunnitteluvaiheVuorovaikutusWithoutTilaisuus(
   }
 }
 
-export async function testSuunnitteluvaiheVuorovaikutus(
-  oid: string,
-  projektiPaallikko: ProjektiKayttaja
-): Promise<void> {
+export async function testSuunnitteluvaiheVuorovaikutus(oid: string, projektiPaallikko: ProjektiKayttaja): Promise<void> {
   await doTestSuunnitteluvaiheVuorovaikutusWithoutTilaisuus(oid, 1, [projektiPaallikko.kayttajatunnus]);
   const suunnitteluVaihe1 = await doTestSuunnitteluvaiheVuorovaikutus(oid, 1, [projektiPaallikko.kayttajatunnus]);
   expect(suunnitteluVaihe1.vuorovaikutukset).to.have.length(1);
@@ -234,10 +225,7 @@ export async function testSuunnitteluvaiheVuorovaikutus(
     UserFixture.mattiMeikalainen.uid,
   ]);
   const difference = detailedDiff(suunnitteluVaihe2, suunnitteluVaihe3);
-  expectToMatchSnapshot(
-    "added " + UserFixture.mattiMeikalainen.uid + " to vuorovaikutus and vuorovaikutustilaisuus",
-    difference
-  );
+  expectToMatchSnapshot("added " + UserFixture.mattiMeikalainen.uid + " to vuorovaikutus and vuorovaikutustilaisuus", difference);
 }
 
 export async function testListDocumentsToImport(oid: string): Promise<VelhoAineistoKategoria[]> {
@@ -272,20 +260,14 @@ export async function saveAndVerifyAineistoSave(
   expectToMatchSnapshot(description, vuorovaikutus);
 }
 
-export async function testImportAineistot(
-  oid: string,
-  velhoAineistoKategorias: VelhoAineistoKategoria[]
-): Promise<void> {
-  const originalVuorovaikutus = (await loadProjektiFromDatabase(oid, Status.SUUNNITTELU)).suunnitteluVaihe
-    .vuorovaikutukset[0];
+export async function testImportAineistot(oid: string, velhoAineistoKategorias: VelhoAineistoKategoria[]): Promise<void> {
+  const originalVuorovaikutus = (await loadProjektiFromDatabase(oid, Status.SUUNNITTELU)).suunnitteluVaihe.vuorovaikutukset[0];
 
   const aineistot = velhoAineistoKategorias
     .reduce((documents, aineistoKategoria) => {
       return documents.concat(
         aineistoKategoria.aineistot.filter(
-          (aineisto) =>
-            ["ekatiedosto_eka.pdf", "tokatiedosto_toka.pdf", "karttakuvalla_tiedosto.pdf"].indexOf(aineisto.tiedosto) >=
-            0
+          (aineisto) => ["ekatiedosto_eka.pdf", "tokatiedosto_toka.pdf", "karttakuvalla_tiedosto.pdf"].indexOf(aineisto.tiedosto) >= 0
         )
       );
     }, [])
@@ -336,12 +318,9 @@ export async function testImportAineistot(
 
 export async function testUpdatePublishDateAndDeleteAineisto(oid: string, userFixture: UserFixture): Promise<void> {
   userFixture.loginAs(UserFixture.mattiMeikalainen);
-  const vuorovaikutus = (await loadProjektiFromDatabase(oid, Status.NAHTAVILLAOLO)).suunnitteluVaihe
-    .vuorovaikutukset[0];
+  const vuorovaikutus = (await loadProjektiFromDatabase(oid, Status.NAHTAVILLAOLO)).suunnitteluVaihe.vuorovaikutukset[0];
   vuorovaikutus.suunnitelmaluonnokset?.pop();
-  const updatedVuorovaikutusJulkaisuPaiva = parseDate(vuorovaikutus.vuorovaikutusJulkaisuPaiva)
-    .add(1, "day")
-    .format("YYYY-MM-DD");
+  const updatedVuorovaikutusJulkaisuPaiva = parseDate(vuorovaikutus.vuorovaikutusJulkaisuPaiva).add(1, "day").format("YYYY-MM-DD");
   const input = {
     oid,
     suunnitteluVaihe: {

--- a/backend/src/apiHandler.ts
+++ b/backend/src/apiHandler.ts
@@ -70,13 +70,9 @@ async function executeOperation(event: AppSyncResolverEvent<AppSyncEventArgument
     case apiConfig.listaaVelhoProjektit.name:
       return listaaVelhoProjektit(event.arguments as ListaaVelhoProjektitQueryVariables);
     case apiConfig.listaaVelhoProjektiAineistot.name:
-      return velhoDocumentHandler.listaaVelhoProjektiAineistot(
-        (event.arguments as ListaaVelhoProjektiAineistotQueryVariables).oid
-      );
+      return velhoDocumentHandler.listaaVelhoProjektiAineistot((event.arguments as ListaaVelhoProjektiAineistotQueryVariables).oid);
     case apiConfig.haeVelhoProjektiAineistoLinkki.name:
-      return velhoDocumentHandler.haeVelhoProjektiAineistoLinkki(
-        event.arguments as HaeVelhoProjektiAineistoLinkkiQueryVariables
-      );
+      return velhoDocumentHandler.haeVelhoProjektiAineistoLinkki(event.arguments as HaeVelhoProjektiAineistoLinkkiQueryVariables);
     case apiConfig.haeProjektiMuutoksetVelhosta.name:
       return findUpdatesFromVelho((event.arguments as HaeProjektiMuutoksetVelhostaQueryVariables).oid);
     case apiConfig.synkronoiProjektiMuutoksetVelhosta.name:
@@ -130,7 +126,8 @@ export async function handleEvent(event: AppSyncResolverEvent<AppSyncEventArgume
       try {
         await identifyUser(event);
         const data = await executeOperation(event);
-        return { data, correlationId: getCorrelationId() } as LambdaResult;
+        const lambdaResult: LambdaResult = { data, correlationId: getCorrelationId() };
+        return lambdaResult;
       } catch (e: unknown) {
         log.error(e);
         if (e instanceof Error) {

--- a/backend/src/asiakirja/asiakirjaUtil.ts
+++ b/backend/src/asiakirja/asiakirjaUtil.ts
@@ -1,3 +1,3 @@
-export function formatDate(date: string) {
+export function formatDate(date: string): string {
   return date ? new Date(date).toLocaleDateString("fi") : "DD.MM.YYYY";
 }

--- a/backend/src/database/model/common.ts
+++ b/backend/src/database/model/common.ts
@@ -1,4 +1,4 @@
-import { AineistoTila, Kieli } from "../../../../common/graphql/apiModel";
+import { AineistoTila, Kieli, IlmoitettavaViranomainen } from "../../../../common/graphql/apiModel";
 
 export type LocalizedMap<T> = { [key in Kieli]?: T } | null;
 
@@ -30,4 +30,21 @@ export type Aineisto = {
 export type StandardiYhteystiedot = {
   yhteysTiedot?: Yhteystieto[];
   yhteysHenkilot?: string[];
+};
+
+export type IlmoituksenVastaanottajat = {
+  kunnat?: Array<KuntaVastaanottaja> | null;
+  viranomaiset?: Array<ViranomaisVastaanottaja> | null;
+};
+
+export type KuntaVastaanottaja = {
+  nimi: string;
+  sahkoposti: string;
+  lahetetty?: string | null;
+};
+
+export type ViranomaisVastaanottaja = {
+  nimi: IlmoitettavaViranomainen;
+  sahkoposti: string;
+  lahetetty?: string | null;
 };

--- a/backend/src/database/model/hyvaksymisPaatosVaihe.ts
+++ b/backend/src/database/model/hyvaksymisPaatosVaihe.ts
@@ -1,5 +1,5 @@
-import { Aineisto, LocalizedMap, Yhteystieto } from "./common";
-import { IlmoituksenVastaanottajat, HyvaksymisPaatosVaiheTila, HallintoOikeus } from "../../../../common/graphql/apiModel";
+import { Aineisto, LocalizedMap, Yhteystieto, IlmoituksenVastaanottajat } from "./common";
+import { HyvaksymisPaatosVaiheTila, HallintoOikeus } from "../../../../common/graphql/apiModel";
 import { Kielitiedot, Velho } from "./projekti";
 
 export type HyvaksymisPaatosVaihe = {

--- a/backend/src/database/model/nahtavillaoloVaihe.ts
+++ b/backend/src/database/model/nahtavillaoloVaihe.ts
@@ -1,5 +1,5 @@
-import { Aineisto, LocalizedMap, Yhteystieto } from "./common";
-import { IlmoituksenVastaanottajat, NahtavillaoloVaiheTila } from "../../../../common/graphql/apiModel";
+import { Aineisto, LocalizedMap, Yhteystieto, IlmoituksenVastaanottajat } from "./common";
+import { NahtavillaoloVaiheTila } from "../../../../common/graphql/apiModel";
 import { Kielitiedot, Velho } from "./projekti";
 
 export type NahtavillaoloVaihe = {

--- a/backend/src/database/model/projekti.ts
+++ b/backend/src/database/model/projekti.ts
@@ -1,15 +1,8 @@
-import {
-  AloitusKuulutusTila,
-  IlmoituksenVastaanottajat,
-  Kieli,
-  ProjektiRooli,
-  ProjektiTyyppi,
-  Viranomainen,
-} from "../../../../common/graphql/apiModel";
+import { AloitusKuulutusTila, Kieli, ProjektiRooli, ProjektiTyyppi, Viranomainen } from "../../../../common/graphql/apiModel";
 import { SuunnitteluVaihe, Vuorovaikutus } from "./suunnitteluVaihe";
 import { NahtavillaoloVaihe, NahtavillaoloVaiheJulkaisu } from "./nahtavillaoloVaihe";
 import { HyvaksymisPaatosVaihe, HyvaksymisPaatosVaiheJulkaisu } from "./hyvaksymisPaatosVaihe";
-import { StandardiYhteystiedot, LocalizedMap, Yhteystieto } from "./common";
+import { StandardiYhteystiedot, LocalizedMap, Yhteystieto, IlmoituksenVastaanottajat } from "./common";
 
 export type DBVaylaUser = {
   rooli: ProjektiRooli;

--- a/backend/src/database/model/suunnitteluVaihe.ts
+++ b/backend/src/database/model/suunnitteluVaihe.ts
@@ -1,5 +1,5 @@
-import { IlmoituksenVastaanottajat, KaytettavaPalvelu, VuorovaikutusTilaisuusTyyppi } from "../../../../common/graphql/apiModel";
-import { Aineisto, LocalizedMap, Yhteystieto, StandardiYhteystiedot } from "./common";
+import { KaytettavaPalvelu, VuorovaikutusTilaisuusTyyppi } from "../../../../common/graphql/apiModel";
+import { Aineisto, LocalizedMap, Yhteystieto, StandardiYhteystiedot, IlmoituksenVastaanottajat } from "./common";
 
 export type SuunnitteluVaihe = {
   hankkeenKuvaus?: LocalizedMap<string>;

--- a/backend/src/endDateCalculator/bankHolidays.ts
+++ b/backend/src/endDateCalculator/bankHolidays.ts
@@ -8,7 +8,7 @@ export class BankHolidays {
     this.bankHolidays = bankholidays.map(parseDate);
   }
 
-  isBankHoliday(date: Dayjs) {
+  isBankHoliday(date: Dayjs): boolean {
     const pureDate = date.set("hours", 0).set("minutes", 0);
     const isWeekened = pureDate.day() === 0 || pureDate.day() === 6;
     return isWeekened || !!this.bankHolidays.find((bankHoliday) => bankHoliday.isSame(pureDate));

--- a/backend/src/handler/getCurrentUser.ts
+++ b/backend/src/handler/getCurrentUser.ts
@@ -1,5 +1,6 @@
 import { userService } from "../user";
+import * as API from "../../../common/graphql/apiModel";
 
-export async function getCurrentUser() {
+export async function getCurrentUser(): Promise<API.NykyinenKayttaja> {
   return userService.requireVaylaUser();
 }

--- a/backend/src/personSearch/kayttajas.ts
+++ b/backend/src/personSearch/kayttajas.ts
@@ -41,10 +41,11 @@ export class Kayttajas {
     return new Kayttajas(
       kayttajas.reduce((map, kayttaja) => {
         if (kayttaja.uid) {
-          map[kayttaja.uid] = {
+          const person: Person = {
             ...kayttaja,
             email: [kayttaja.email],
-          } as Person;
+          };
+          map[kayttaja.uid] = person;
         }
         return map;
       }, {} as Record<string, Person>)

--- a/backend/src/personSearch/kayttajas.ts
+++ b/backend/src/personSearch/kayttajas.ts
@@ -37,7 +37,7 @@ export class Kayttajas {
   /**
    * For test usage
    */
-  static fromKayttajaList(kayttajas: Kayttaja[]) {
+  static fromKayttajaList(kayttajas: Kayttaja[]): Kayttajas {
     return new Kayttajas(
       kayttajas.reduce((map, kayttaja) => {
         if (kayttaja.uid) {
@@ -60,7 +60,7 @@ export class Kayttajas {
     return list;
   }
 
-  asMap() {
+  asMap(): Record<string, Person> {
     return this.personMap;
   }
 

--- a/backend/src/personSearch/lambda/personSearchAdapter.ts
+++ b/backend/src/personSearch/lambda/personSearchAdapter.ts
@@ -9,7 +9,7 @@ function adaptAccounttype(accountType: string) {
   }[accountType];
 }
 
-export function adaptPersonSearchResult(responseJson: any, kayttajas: Record<string, Person>) {
+export function adaptPersonSearchResult(responseJson: any, kayttajas: Record<string, Person>): void {
   responseJson.person?.person?.forEach(
     (person: {
       FirstName: string[];

--- a/backend/src/personSearch/lambda/personSearchUpdaterHandler.ts
+++ b/backend/src/personSearch/lambda/personSearchUpdaterHandler.ts
@@ -10,7 +10,7 @@ import { setupLambdaMonitoring, setupLambdaMonitoringMetaData } from "../../aws/
  * Hassu backend for the user lookups.
  * This Lambda is triggered by the Hassu backend if the cached list is considered outdated.
  */
-export async function handleEvent() {
+export async function handleEvent(): Promise<unknown> {
   setupLambdaMonitoring();
 
   return await AWSXRay.captureAsyncFunc("personSearchUpdaterHandler", async (subsegment) => {

--- a/backend/src/personSearch/personAdapter.ts
+++ b/backend/src/personSearch/personAdapter.ts
@@ -4,14 +4,14 @@ import mergeWith from "lodash/mergeWith";
 import { Person } from "./kayttajas";
 import pickBy from "lodash/pickBy";
 
-export function mergeKayttaja(user: Partial<DBVaylaUser>, account: Kayttaja) {
+export function mergeKayttaja(user: Partial<DBVaylaUser>, account: Kayttaja): void {
   const { organisaatio, email } = account;
   const nimi = account.sukuNimi + ", " + account.etuNimi;
   const kayttajatunnus = account.uid;
   mergeWith(user, { organisaatio, email, nimi, kayttajatunnus });
 }
 
-export function adaptKayttaja(account: Kayttaja) {
+export function adaptKayttaja(account: Kayttaja): DBVaylaUser {
   const vaylaUser: DBVaylaUser = {} as any;
   mergeKayttaja(vaylaUser, account);
   return vaylaUser;

--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -55,13 +55,14 @@ function adaptJulkaisuPDFPaths(oid: string, aloitusKuulutusPDFS: LocalizedMap<Al
 
   const result = {};
   for (const kieli in aloitusKuulutusPDFS) {
-    result[kieli] = {
+    const aloitusKuulutusPdf: AloitusKuulutusPDF = {
       aloituskuulutusPDFPath: fileService.getYllapitoPathForProjektiFile(oid, aloitusKuulutusPDFS[kieli].aloituskuulutusPDFPath),
       aloituskuulutusIlmoitusPDFPath: fileService.getYllapitoPathForProjektiFile(
         oid,
         aloitusKuulutusPDFS[kieli].aloituskuulutusIlmoitusPDFPath
       ),
-    } as AloitusKuulutusPDF;
+    };
+    result[kieli] = aloitusKuulutusPdf;
   }
   return { __typename: "AloitusKuulutusPDFt", SUOMI: result[API.Kieli.SUOMI], ...result };
 }

--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -6,6 +6,7 @@ import {
   adaptVelhoByAddingTypename,
   adaptYhteystiedotByAddingTypename,
   adaptStandardiYhteystiedotByAddingTypename,
+  adaptIlmoituksenVastaanottajat,
 } from "../common";
 import { adaptSuunnitteluSopimus } from "./adaptSuunitteluSopimus";
 import { fileService } from "../../../files/fileService";
@@ -16,6 +17,7 @@ export function adaptAloitusKuulutus(kuulutus?: AloitusKuulutus | null): API.Alo
     return {
       __typename: "AloitusKuulutus",
       ...otherKuulutusFields,
+      ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(kuulutus.ilmoituksenVastaanottajat),
       hankkeenKuvaus: adaptHankkeenKuvaus(kuulutus.hankkeenKuvaus),
       kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kuulutusYhteystiedot),
     };
@@ -33,6 +35,7 @@ export function adaptAloitusKuulutusJulkaisut(
       return {
         ...fieldsToCopyAsIs,
         __typename: "AloitusKuulutusJulkaisu",
+        ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(julkaisu.ilmoituksenVastaanottajat),
         hankkeenKuvaus: adaptHankkeenKuvaus(julkaisu.hankkeenKuvaus),
         yhteystiedot: adaptYhteystiedotByAddingTypename(yhteystiedot),
         velho: adaptVelhoByAddingTypename(velho),

--- a/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
@@ -97,7 +97,7 @@ function adaptHyvaksymisPaatosVaihePDFPaths(
 
   for (const kieli in hyvaksymisPaatosVaihePDFs) {
     const pdfs = hyvaksymisPaatosVaihePDFs[kieli];
-    result[kieli] = {
+    const hyvaksymisPaatosVaihePdf: HyvaksymisPaatosVaihePDF = {
       ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath: getYllapitoPathForFile(
         pdfs.ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath
       ),
@@ -107,7 +107,8 @@ function adaptHyvaksymisPaatosVaihePDFPaths(
       ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath: getYllapitoPathForFile(
         pdfs.ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath
       ),
-    } as HyvaksymisPaatosVaihePDF;
+    };
+    result[kieli] = hyvaksymisPaatosVaihePdf;
   }
   return { __typename: "HyvaksymisPaatosVaihePDFt", SUOMI: result[API.Kieli.SUOMI], ...result };
 }

--- a/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
@@ -72,14 +72,15 @@ function adaptNahtavillaoloPDFPaths(oid: string, nahtavillaoloPDFs: LocalizedMap
 
   const result = {};
   for (const kieli in nahtavillaoloPDFs) {
-    result[kieli] = {
+    const nahtavillaoloPdf: NahtavillaoloPDF = {
       nahtavillaoloPDFPath: fileService.getYllapitoPathForProjektiFile(oid, nahtavillaoloPDFs[kieli].nahtavillaoloPDFPath),
       nahtavillaoloIlmoitusPDFPath: fileService.getYllapitoPathForProjektiFile(oid, nahtavillaoloPDFs[kieli].nahtavillaoloIlmoitusPDFPath),
       nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath: fileService.getYllapitoPathForProjektiFile(
         oid,
         nahtavillaoloPDFs[kieli].nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath
       ),
-    } as NahtavillaoloPDF;
+    };
+    result[kieli] = nahtavillaoloPdf;
   }
   return { __typename: "NahtavillaoloPDFt", SUOMI: result[API.Kieli.SUOMI], ...result };
 }

--- a/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
@@ -10,6 +10,7 @@ import * as API from "../../../../../common/graphql/apiModel";
 import {
   adaptAineistot,
   adaptHankkeenKuvaus,
+  adaptIlmoituksenVastaanottajat,
   adaptLinkkiByAddingTypename,
   adaptLinkkiListByAddingTypename,
   adaptStandardiYhteystiedotByAddingProjari,
@@ -44,6 +45,7 @@ function adaptVuorovaikutukset(oid: string, kayttoOikeudet: DBVaylaUser[], vuoro
       (vuorovaikutus) =>
         ({
           ...vuorovaikutus,
+          ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(vuorovaikutus.ilmoituksenVastaanottajat),
           esitettavatYhteystiedot: adaptStandardiYhteystiedotByAddingProjari(kayttoOikeudet, vuorovaikutus.esitettavatYhteystiedot),
           vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(vuorovaikutus.vuorovaikutusTilaisuudet),
           suunnittelumateriaali: adaptLinkkiByAddingTypename(vuorovaikutus.suunnittelumateriaali),

--- a/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
@@ -41,21 +41,21 @@ export function adaptSuunnitteluVaihe(
 
 function adaptVuorovaikutukset(oid: string, kayttoOikeudet: DBVaylaUser[], vuorovaikutukset: Array<Vuorovaikutus>): API.Vuorovaikutus[] {
   if (vuorovaikutukset && vuorovaikutukset.length > 0) {
-    return vuorovaikutukset.map(
-      (vuorovaikutus) =>
-        ({
-          ...vuorovaikutus,
-          ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(vuorovaikutus.ilmoituksenVastaanottajat),
-          esitettavatYhteystiedot: adaptStandardiYhteystiedotByAddingProjari(kayttoOikeudet, vuorovaikutus.esitettavatYhteystiedot),
-          vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(vuorovaikutus.vuorovaikutusTilaisuudet),
-          suunnittelumateriaali: adaptLinkkiByAddingTypename(vuorovaikutus.suunnittelumateriaali),
-          videot: adaptLinkkiListByAddingTypename(vuorovaikutus.videot),
-          esittelyaineistot: adaptAineistot(vuorovaikutus.esittelyaineistot),
-          suunnitelmaluonnokset: adaptAineistot(vuorovaikutus.suunnitelmaluonnokset),
-          vuorovaikutusPDFt: adaptVuorovaikutusPDFPaths(oid, vuorovaikutus.vuorovaikutusPDFt),
-          __typename: "Vuorovaikutus",
-        } as API.Vuorovaikutus)
-    );
+    return vuorovaikutukset.map((vuorovaikutus) => {
+      const apiVuorovaikutus: API.Vuorovaikutus = {
+        ...vuorovaikutus,
+        ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(vuorovaikutus.ilmoituksenVastaanottajat),
+        esitettavatYhteystiedot: adaptStandardiYhteystiedotByAddingProjari(kayttoOikeudet, vuorovaikutus.esitettavatYhteystiedot),
+        vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(vuorovaikutus.vuorovaikutusTilaisuudet),
+        suunnittelumateriaali: adaptLinkkiByAddingTypename(vuorovaikutus.suunnittelumateriaali),
+        videot: adaptLinkkiListByAddingTypename(vuorovaikutus.videot),
+        esittelyaineistot: adaptAineistot(vuorovaikutus.esittelyaineistot),
+        suunnitelmaluonnokset: adaptAineistot(vuorovaikutus.suunnitelmaluonnokset),
+        vuorovaikutusPDFt: adaptVuorovaikutusPDFPaths(oid, vuorovaikutus.vuorovaikutusPDFt),
+        __typename: "Vuorovaikutus",
+      };
+      return apiVuorovaikutus;
+    });
   }
   return vuorovaikutukset as undefined;
 }

--- a/backend/src/projekti/adapter/adaptToDB/adaptNahtavillaoloVaiheToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptNahtavillaoloVaiheToSave.ts
@@ -42,7 +42,7 @@ export function adaptNahtavillaoloVaiheToSave(
     }
   }
 
-  return mergeWith({}, dbNahtavillaoloVaihe, {
+  const uusiNahtavillaolovaihe: NahtavillaoloVaihe = {
     kuulutusPaiva,
     kuulutusVaihePaattyyPaiva,
     muistutusoikeusPaattyyPaiva,
@@ -53,5 +53,7 @@ export function adaptNahtavillaoloVaiheToSave(
     kuulutusYhteystiedot: adaptYhteystiedotToSave(kuulutusYhteystiedot),
     ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajatToSave(ilmoituksenVastaanottajat),
     hankkeenKuvaus: adaptHankkeenKuvausToSave(hankkeenKuvaus),
-  } as NahtavillaoloVaihe);
+  };
+
+  return mergeWith({}, dbNahtavillaoloVaihe, uusiNahtavillaolovaihe);
 }

--- a/backend/src/projekti/adapter/adaptToDB/adaptVuorovaikutusToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptVuorovaikutusToSave.ts
@@ -5,7 +5,6 @@ import { AineistoChangedEvent, ProjektiAdaptationResult, ProjektiEventType, Vuor
 import { IllegalArgumentError } from "../../../error/IllegalArgumentError";
 import { adaptKayttajatunnusList } from "./adaptKayttajatunnusList";
 import { adaptAineistotToSave, adaptIlmoituksenVastaanottajatToSave, adaptYhteystiedotToSave } from "./common";
-import { adaptStandardiYhteystiedotByAddingTypename } from "../common";
 
 export function adaptVuorovaikutusToSave(
   projekti: DBProjekti,
@@ -42,7 +41,6 @@ export function adaptVuorovaikutusToSave(
       vuorovaikutusTilaisuudet,
       // Jos vuorovaikutuksen ilmoituksella ei tarvitse olla viranomaisvastaanottajia, muokkaa adaptIlmoituksenVastaanottajatToSavea
       ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajatToSave(vuorovaikutusInput.ilmoituksenVastaanottajat),
-      esitettavatYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(vuorovaikutusInput.esitettavatYhteystiedot),
       esittelyaineistot,
       suunnitelmaluonnokset,
     };

--- a/backend/src/projekti/adapter/adaptToDB/adaptVuorovaikutusToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptVuorovaikutusToSave.ts
@@ -73,16 +73,18 @@ function checkIfAineistoJulkinenChanged(
   }
 
   if (vuorovaikutusPublished() || vuorovaikutusNotPublicAnymore()) {
-    projektiAdaptationResult.pushEvent({
+    const newEvent: VuorovaikutusPublishedEvent = {
       eventType: ProjektiEventType.VUOROVAIKUTUS_PUBLISHED,
       vuorovaikutusNumero: vuorovaikutusToSave.vuorovaikutusNumero,
-    } as VuorovaikutusPublishedEvent);
+    };
+    projektiAdaptationResult.pushEvent(newEvent);
   }
 
   if (vuorovaikutusPublished() || vuorovaikutusNotPublicAnymore() || vuorovaikutusJulkaisuPaivaChanged()) {
-    projektiAdaptationResult.pushEvent({
+    const newEvent: AineistoChangedEvent = {
       eventType: ProjektiEventType.AINEISTO_CHANGED,
-    } as AineistoChangedEvent);
+    };
+    projektiAdaptationResult.pushEvent(newEvent);
   }
 }
 

--- a/backend/src/projekti/adapter/adaptToDB/common.ts
+++ b/backend/src/projekti/adapter/adaptToDB/common.ts
@@ -3,23 +3,20 @@ import { IllegalArgumentError } from "../../../error/IllegalArgumentError";
 import { Aineisto, LocalizedMap } from "../../../database/model";
 import { AineistoChangedEvent, ProjektiAdaptationResult, ProjektiEventType } from "../projektiAdapter";
 import remove from "lodash/remove";
+import { IlmoituksenVastaanottajat, ViranomaisVastaanottaja, KuntaVastaanottaja } from "../../../database/model";
 
 export function adaptIlmoituksenVastaanottajatToSave(
   vastaanottajat: API.IlmoituksenVastaanottajatInput | null | undefined
-): API.IlmoituksenVastaanottajat {
+): IlmoituksenVastaanottajat {
   if (!vastaanottajat) {
     return vastaanottajat as null | undefined;
   }
-  const kunnat: API.KuntaVastaanottaja[] = vastaanottajat?.kunnat?.map((kunta) => ({ __typename: "KuntaVastaanottaja", ...kunta })) || null;
+  const kunnat: KuntaVastaanottaja[] = vastaanottajat?.kunnat;
   if (!vastaanottajat?.viranomaiset || vastaanottajat.viranomaiset.length === 0) {
     throw new IllegalArgumentError("Viranomaisvastaanottajia pitää olla vähintään yksi.");
   }
-  const viranomaiset: API.ViranomaisVastaanottaja[] =
-    vastaanottajat?.viranomaiset?.map((viranomainen) => ({
-      __typename: "ViranomaisVastaanottaja",
-      ...viranomainen,
-    })) || null;
-  return { __typename: "IlmoituksenVastaanottajat", kunnat, viranomaiset };
+  const viranomaiset: ViranomaisVastaanottaja[] = vastaanottajat?.viranomaiset;
+  return { kunnat, viranomaiset };
 }
 
 export function adaptYhteystiedotToSave(yhteystietoInputs: Array<API.YhteystietoInput>): API.YhteystietoInput[] | undefined {
@@ -101,4 +98,15 @@ function pickAineistoFromInputByDocumenttiOid(aineistotInput: API.AineistoInput[
     return matchedElements[0];
   }
   return undefined;
+}
+
+type General<T> = { __typename: string } & T;
+
+export function removeTypeName<Type>(o: General<Type> | null | undefined): Type | null | undefined {
+  if (!o) {
+    return o;
+  }
+  const result = { ...o };
+  delete result["__typename"];
+  return result;
 }

--- a/backend/src/projekti/adapter/common/adaptIlmoituksenVastaanottajat.ts
+++ b/backend/src/projekti/adapter/common/adaptIlmoituksenVastaanottajat.ts
@@ -1,7 +1,8 @@
+import { IlmoituksenVastaanottajat } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 
 export function adaptIlmoituksenVastaanottajat(
-  vastaanottajat: API.IlmoituksenVastaanottajat | null | undefined
+  vastaanottajat: IlmoituksenVastaanottajat | null | undefined
 ): API.IlmoituksenVastaanottajat {
   if (!vastaanottajat) {
     return vastaanottajat as null | undefined;

--- a/backend/src/projekti/adapter/common/adaptStandardiYhteystiedotByAddingProjari.ts
+++ b/backend/src/projekti/adapter/common/adaptStandardiYhteystiedotByAddingProjari.ts
@@ -1,10 +1,12 @@
+import * as API from "../../../../../common/graphql/apiModel";
 import { ProjektiRooli } from "../../../../../common/graphql/apiModel";
 import { StandardiYhteystiedot, DBVaylaUser } from "../../../database/model";
+import { adaptYhteystiedotByAddingTypename } from "./lisaaTypename";
 
 export function adaptStandardiYhteystiedotByAddingProjari(
   kayttoOikeudet: DBVaylaUser[],
   yhteystiedot: StandardiYhteystiedot
-): StandardiYhteystiedot {
+): API.StandardiYhteystiedot {
   if (yhteystiedot) {
     const yhteysHenkilot = yhteystiedot.yhteysHenkilot;
     const projari = kayttoOikeudet.find(({ rooli }) => rooli === ProjektiRooli.PROJEKTIPAALLIKKO);
@@ -12,7 +14,8 @@ export function adaptStandardiYhteystiedotByAddingProjari(
       yhteysHenkilot.push(projari.kayttajatunnus);
     }
     return {
-      ...yhteystiedot,
+      __typename: "StandardiYhteystiedot",
+      yhteysTiedot: adaptYhteystiedotByAddingTypename(yhteystiedot.yhteysTiedot),
       yhteysHenkilot,
     };
   }

--- a/backend/src/projekti/adapter/common/lisaaTypename.ts
+++ b/backend/src/projekti/adapter/common/lisaaTypename.ts
@@ -3,13 +3,13 @@ import * as API from "../../../../../common/graphql/apiModel";
 
 export function adaptLiittyvatSuunnitelmatByAddingTypename(suunnitelmat?: Suunnitelma[] | null): API.Suunnitelma[] | undefined | null {
   if (suunnitelmat) {
-    const liittyvatSuunnitelmat = suunnitelmat.map(
-      (suunnitelma) =>
-        ({
-          __typename: "Suunnitelma",
-          ...suunnitelma,
-        } as Suunnitelma)
-    );
+    const liittyvatSuunnitelmat = suunnitelmat.map((suunnitelma) => {
+      const s: API.Suunnitelma = {
+        __typename: "Suunnitelma",
+        ...suunnitelma,
+      };
+      return s;
+    });
     return liittyvatSuunnitelmat as API.Suunnitelma[];
   }
   return suunnitelmat as undefined | null;

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -197,8 +197,8 @@ export class ProjektiAdapter {
   }
 }
 
-function removeUndefinedFields(object: API.Projekti): Partial<API.Projekti> {
-  return pickBy(object, (value) => value !== undefined);
+function removeUndefinedFields(object: API.Projekti): API.Projekti {
+  return { __typename: "Projekti", oid: object.oid, velho: object.velho, ...pickBy(object, (value) => value !== undefined) };
 }
 
 export const projektiAdapter = new ProjektiAdapter();

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -93,7 +93,7 @@ export class ProjektiAdapter {
       ...fieldsToCopyAsIs
     } = dbProjekti;
 
-    const apiProjekti = removeUndefinedFields({
+    const apiProjekti: API.Projekti = removeUndefinedFields({
       __typename: "Projekti",
       tallennettu: !!dbProjekti.tallennettu,
       kayttoOikeudet: KayttoOikeudetManager.adaptAPIKayttoOikeudet(kayttoOikeudet),
@@ -131,7 +131,7 @@ export class ProjektiAdapter {
       virhetiedot,
       kasittelynTila: adaptKasittelynTila(kasittelynTila),
       ...fieldsToCopyAsIs,
-    }) as API.Projekti;
+    });
     if (apiProjekti.tallennettu) {
       applyProjektiStatus(apiProjekti);
     }
@@ -163,7 +163,7 @@ export class ProjektiAdapter {
     kayttoOikeudetManager.applyChanges(kayttoOikeudet);
     const vuorovaikutukset = adaptVuorovaikutusToSave(projekti, projektiAdaptationResult, suunnitteluVaihe?.vuorovaikutus);
     const aloitusKuulutusToSave = adaptAloitusKuulutusToSave(aloitusKuulutus);
-    const dbProjekti = mergeWith(
+    const dbProjekti: DBProjekti = mergeWith(
       {},
       {
         oid,
@@ -191,7 +191,7 @@ export class ProjektiAdapter {
         salt: projekti.salt || lisaAineistoService.generateSalt(),
         kasittelynTila,
       }
-    ) as DBProjekti;
+    );
     projektiAdaptationResult.setProjekti(dbProjekti);
     return projektiAdaptationResult;
   }

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -139,13 +139,14 @@ class ProjektiAdapterJulkinen {
 
     const result = {};
     for (const kieli in aloitusKuulutusPDFS) {
-      result[kieli] = {
+      const aloituskuulutusPdf: AloitusKuulutusPDF = {
         aloituskuulutusPDFPath: fileService.getPublicPathForProjektiFile(oid, aloitusKuulutusPDFS[kieli].aloituskuulutusPDFPath),
         aloituskuulutusIlmoitusPDFPath: fileService.getPublicPathForProjektiFile(
           oid,
           aloitusKuulutusPDFS[kieli].aloituskuulutusIlmoitusPDFPath
         ),
-      } as AloitusKuulutusPDF;
+      };
+      result[kieli] = aloituskuulutusPdf;
     }
     return { __typename: "AloitusKuulutusPDFt", SUOMI: result[API.Kieli.SUOMI], ...result };
   }
@@ -322,7 +323,7 @@ function adaptVuorovaikutukset(dbProjekti: DBProjekti, projektiHenkilot: Projekt
       .map((vuorovaikutus) => {
         const julkaisuPaiva = parseDate(vuorovaikutus.vuorovaikutusJulkaisuPaiva);
         if (julkaisuPaiva.isBefore(dayjs())) {
-          return {
+          const vuorovaikutusJulkinen: API.VuorovaikutusJulkinen = {
             __typename: "VuorovaikutusJulkinen",
             vuorovaikutusNumero: vuorovaikutus.vuorovaikutusNumero,
             vuorovaikutusJulkaisuPaiva: vuorovaikutus.vuorovaikutusJulkaisuPaiva,
@@ -334,7 +335,8 @@ function adaptVuorovaikutukset(dbProjekti: DBProjekti, projektiHenkilot: Projekt
             suunnitelmaluonnokset: adaptAineistotJulkinen(dbProjekti.oid, vuorovaikutus.suunnitelmaluonnokset, undefined, julkaisuPaiva),
             yhteystiedot: adaptStandardiYhteystiedot(dbProjekti, vuorovaikutus.esitettavatYhteystiedot),
             vuorovaikutusPDFt: adaptVuorovaikutusPDFPaths(dbProjekti.oid, vuorovaikutus.vuorovaikutusPDFt),
-          } as API.VuorovaikutusJulkinen;
+          };
+          return vuorovaikutusJulkinen;
         }
         return undefined;
       })

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -83,7 +83,7 @@ class ProjektiAdapterJulkinen {
       jatkoPaatos1Vaihe,
       jatkoPaatos2Vaihe,
     };
-    const projektiJulkinen = removeUndefinedFields(projekti) as API.ProjektiJulkinen;
+    const projektiJulkinen: API.ProjektiJulkinen = removeUndefinedFields(projekti);
     applyProjektiJulkinenStatus(projektiJulkinen);
     if (projektiJulkinen.status != Status.EI_JULKAISTU && projektiJulkinen.status != Status.EPAAKTIIVINEN) {
       return projektiJulkinen;
@@ -346,7 +346,7 @@ function adaptVuorovaikutukset(dbProjekti: DBProjekti, projektiHenkilot: Projekt
 function adaptVuorovaikutusTilaisuudet(
   vuorovaikutusTilaisuudet: Array<VuorovaikutusTilaisuus>,
   projektiHenkilot: ProjektiHenkilot
-): VuorovaikutusTilaisuus[] {
+): API.VuorovaikutusTilaisuus[] {
   if (vuorovaikutusTilaisuudet) {
     return vuorovaikutusTilaisuudet.map((vuorovaikutusTilaisuus) => ({
       ...vuorovaikutusTilaisuus,
@@ -415,8 +415,8 @@ function adaptVuorovaikutusPDFPaths(oid: string, pdfs: LocalizedMap<Vuorovaikutu
   return { __typename: "VuorovaikutusPDFt", SUOMI: result[API.Kieli.SUOMI], ...result };
 }
 
-function removeUndefinedFields(object: API.ProjektiJulkinen): Partial<API.ProjektiJulkinen> {
-  return pickBy(object, (value) => value !== undefined);
+function removeUndefinedFields(object: API.ProjektiJulkinen): API.ProjektiJulkinen {
+  return { __typename: "ProjektiJulkinen", oid: object.oid, velho: object.velho, ...pickBy(object, (value) => value !== undefined) };
 }
 
 export function adaptVelho(velho: Velho): API.VelhoJulkinen {

--- a/backend/src/projekti/kayttoOikeudetManager.ts
+++ b/backend/src/projekti/kayttoOikeudetManager.ts
@@ -50,13 +50,11 @@ export class KayttoOikeudetManager {
     // Add new users
     const newUsers = differenceWith(changes, resultUsers, (u1, u2) => u1.kayttajatunnus === u2.kayttajatunnus);
     newUsers.map((newUser) => {
-      const userToAdd = {
+      const userToAdd: Partial<DBVaylaUser> = {
         puhelinnumero: newUser.puhelinnumero,
         kayttajatunnus: newUser.kayttajatunnus,
         rooli: newUser.rooli,
-        esitetaanKuulutuksessa:
-          newUser.rooli === ProjektiRooli.PROJEKTIPAALLIKKO ? true : newUser.esitetaanKuulutuksessa,
-      } as Partial<DBVaylaUser>;
+      };
       try {
         const userWithAllInfo = this.fillInUserInfoFromUserManagement({
           user: userToAdd,
@@ -104,8 +102,9 @@ export class KayttoOikeudetManager {
   }
 
   addUserByKayttajatunnus(kayttajatunnus: string, rooli: ProjektiRooli): DBVaylaUser | undefined {
+    const partialUser: Partial<DBVaylaUser> = { kayttajatunnus, rooli };
     const user = this.fillInUserInfoFromUserManagement({
-      user: { kayttajatunnus, rooli } as Partial<DBVaylaUser>,
+      user: partialUser,
       searchMode: SearchMode.UID,
     });
     if (user) {

--- a/backend/src/projektiSearch/projektiSearchAdapter.ts
+++ b/backend/src/projektiSearch/projektiSearchAdapter.ts
@@ -34,8 +34,7 @@ export type ProjektiDocument = {
 export function adaptProjektiToIndex(projekti: DBProjekti): Partial<ProjektiDocument> {
   projekti.tallennettu = true;
   const apiProjekti = projektiAdapter.adaptProjekti(projekti);
-
-  return {
+  const partialDoc: Partial<ProjektiDocument> = {
     nimi: safeTrim(projekti.velho.nimi),
     asiatunnus: safeTrim(projekti.velho.asiatunnusELY || projekti.velho.asiatunnusVayla || ""),
     projektiTyyppi: projekti.velho.tyyppi,
@@ -49,7 +48,9 @@ export function adaptProjektiToIndex(projekti: DBProjekti): Partial<ProjektiDocu
       .pop(),
     paivitetty: projekti.paivitetty || dayjs().format(),
     muokkaajat: projekti.kayttoOikeudet.map((value) => value.kayttajatunnus),
-  } as Partial<ProjektiDocument>;
+  };
+
+  return partialDoc;
 }
 
 export function adaptProjektiToJulkinenIndex(projekti: ProjektiJulkinen, kieli: Kieli): Omit<ProjektiDocument, "oid"> | undefined {
@@ -95,7 +96,7 @@ export function adaptProjektiToJulkinenIndex(projekti: ProjektiJulkinen, kieli: 
       });
     }
 
-    return {
+    const docWihtoutOid: Omit<ProjektiDocument, "oid"> = {
       nimi: safeTrim(nimi),
       hankkeenKuvaus,
       projektiTyyppi: projekti.velho.tyyppi,
@@ -106,7 +107,8 @@ export function adaptProjektiToJulkinenIndex(projekti: ProjektiJulkinen, kieli: 
       vaylamuoto: projekti.velho.vaylamuoto?.map(safeTrim),
       paivitetty: projekti.paivitetty || dayjs().format(),
       publishTimestamp,
-    } as Omit<ProjektiDocument, "oid">;
+    };
+    return docWihtoutOid;
   }
 }
 
@@ -115,6 +117,7 @@ export function adaptSearchResultsToProjektiDocuments(results: any): ProjektiDoc
     return [];
   }
   return results.hits.hits.map((hit: any) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return { ...hit._source, oid: hit._id } as ProjektiDocument;
   });
 }
@@ -126,15 +129,14 @@ export function adaptSearchResultsToProjektiHakutulosDokumenttis(results: any): 
   }
   return (
     results.hits?.hits?.map((hit: any) => {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       return { ...hit._source, oid: hit._id, __typename: "ProjektiHakutulosDokumentti" } as ProjektiHakutulosDokumentti;
     }) || []
   );
 }
 
-function safeTrim(s: string): string | unknown {
-  if (s) {
-    return s.trim();
-  }
+function safeTrim(s: string): string {
+  return s.trim();
 }
 
 function selectNimi(nimi: string, kielitiedot: Kielitiedot, kieli: Kieli): string {

--- a/backend/src/user/userService.ts
+++ b/backend/src/user/userService.ts
@@ -26,11 +26,11 @@ function parseRoles(roles: string): string[] | undefined {
 }
 
 function adaptKayttajaTyyppi(roolit: string[] | null | undefined): VaylaKayttajaTyyppi | undefined {
-  const roleToTypeMap = {
+  const roleToTypeMap: Record<string, VaylaKayttajaTyyppi> = {
     Atunnukset: VaylaKayttajaTyyppi.A_TUNNUS,
     Ltunnukset: VaylaKayttajaTyyppi.L_TUNNUS,
     LXtunnukset: VaylaKayttajaTyyppi.LX_TUNNUS,
-  } as Record<string, VaylaKayttajaTyyppi>;
+  };
   if (roolit) {
     for (const role of roolit) {
       const type = roleToTypeMap[role];
@@ -164,7 +164,7 @@ export function requirePermissionMuokkaa(projekti: DBProjekti): NykyinenKayttaja
   return kayttaja;
 }
 
-export function requireAdmin(description?:string): NykyinenKayttaja {
+export function requireAdmin(description?: string): NykyinenKayttaja {
   const kayttaja = requireVaylaUser();
   if (isHassuAdmin(kayttaja)) {
     return kayttaja;
@@ -182,9 +182,7 @@ export function requireProjektiPaallikko(projekti: DBProjekti): NykyinenKayttaja
     .filter((user) => user.kayttajatunnus === kayttaja.uid && user.rooli == ProjektiRooli.PROJEKTIPAALLIKKO)
     .pop();
   if (!projektiUser) {
-    throw new IllegalAccessError(
-      "Sinulla ei ole käyttöoikeutta muokata projektia, koska et ole projektin projektipäällikkö."
-    );
+    throw new IllegalAccessError("Sinulla ei ole käyttöoikeutta muokata projektia, koska et ole projektin projektipäällikkö.");
   }
   return kayttaja;
 }

--- a/backend/src/util/adaptStandardiYhteystiedot.ts
+++ b/backend/src/util/adaptStandardiYhteystiedot.ts
@@ -1,27 +1,27 @@
-import { DBProjekti, StandardiYhteystiedot, Yhteystieto } from "../database/model";
-import { ProjektiRooli } from "../../../common/graphql/apiModel";
+import { DBProjekti, StandardiYhteystiedot } from "../database/model";
+import * as API from "../../../common/graphql/apiModel";
 import { vaylaUserToYhteystieto } from "../util/vaylaUserToYhteystieto";
 
 export default function adaptStandardiYhteystiedot(
   dbProjekti: DBProjekti,
   kuulutusYhteystiedot: StandardiYhteystiedot | null
-): Yhteystieto[] {
-  const yt: Yhteystieto[] = [];
+): API.Yhteystieto[] {
+  const yt: API.Yhteystieto[] = [];
   const sahkopostit: string[] = [];
   dbProjekti.kayttoOikeudet
     .filter(
       ({ kayttajatunnus, rooli }) =>
-        rooli === ProjektiRooli.PROJEKTIPAALLIKKO || kuulutusYhteystiedot?.yhteysHenkilot?.find((yh) => yh === kayttajatunnus)
+        rooli === API.ProjektiRooli.PROJEKTIPAALLIKKO || kuulutusYhteystiedot?.yhteysHenkilot?.find((yh) => yh === kayttajatunnus)
     )
     .forEach((oikeus) => {
-      yt.push(vaylaUserToYhteystieto(oikeus));
+      yt.push({ __typename: "Yhteystieto", ...vaylaUserToYhteystieto(oikeus) });
       sahkopostit.push(oikeus.email); //Kerää sähköpostit myöhempää duplikaattien tarkistusta varten.
     });
   if (kuulutusYhteystiedot.yhteysTiedot) {
     kuulutusYhteystiedot.yhteysTiedot.forEach((yhteystieto) => {
       if (!sahkopostit.find((email) => email === yhteystieto.sahkoposti)) {
         //Varmista, ettei ole duplikaatteja
-        yt.push(yhteystieto);
+        yt.push({ __typename: "Yhteystieto", ...yhteystieto });
         sahkopostit.push(yhteystieto.sahkoposti);
       }
     });

--- a/backend/src/velho/velhoAdapter.ts
+++ b/backend/src/velho/velhoAdapter.ts
@@ -112,13 +112,14 @@ export function adaptSearchResults(searchResults: ProjektiSearchResult[], kaytta
       const projektiPaallikkoNimi =
         projektiPaallikko && userService.hasPermissionLuonti(projektiPaallikko) ? adaptKayttaja(projektiPaallikko).nimi : undefined;
       const tyyppi = getProjektiTyyppi(result.ominaisuudet.vaihe);
-      return {
+      const hakutulos: VelhoHakuTulos = {
         __typename: "VelhoHakuTulos",
         oid: result.oid,
         nimi: result.ominaisuudet.nimi,
         tyyppi,
         projektiPaallikko: projektiPaallikkoNimi,
-      } as VelhoHakuTulos;
+      };
+      return hakutulos;
     });
   }
   return [];

--- a/backend/src/velho/velhoAdapter.ts
+++ b/backend/src/velho/velhoAdapter.ts
@@ -110,11 +110,10 @@ export function adaptSearchResults(searchResults: ProjektiSearchResult[], kaytta
     return searchResults.map((result) => {
       const projektiPaallikko = kayttajas.findByEmail(getVastuuhenkiloEmail(result.ominaisuudet.vastuuhenkilo));
       const projektiPaallikkoNimi =
-        projektiPaallikko && userService.hasPermissionLuonti(projektiPaallikko)
-          ? adaptKayttaja(projektiPaallikko).nimi
-          : undefined;
+        projektiPaallikko && userService.hasPermissionLuonti(projektiPaallikko) ? adaptKayttaja(projektiPaallikko).nimi : undefined;
       const tyyppi = getProjektiTyyppi(result.ominaisuudet.vaihe);
       return {
+        __typename: "VelhoHakuTulos",
         oid: result.oid,
         nimi: result.ominaisuudet.nimi,
         tyyppi,

--- a/backend/src/vuorovaikutus/vuorovaikutusService.ts
+++ b/backend/src/vuorovaikutus/vuorovaikutusService.ts
@@ -1,5 +1,6 @@
 import { findVuorovaikutusByNumber } from "../util/findVuorovaikutusByNumber";
-import { IlmoituksenVastaanottajat, Kieli } from "../../../common/graphql/apiModel";
+import * as API from "../../../common/graphql/apiModel";
+import { IlmoituksenVastaanottajat } from "../database/model";
 import { asiakirjaService } from "../asiakirja/asiakirjaService";
 import { fileService } from "../files/fileService";
 import { projektiDatabase } from "../database/projektiDatabase";
@@ -13,7 +14,7 @@ class VuorovaikutusService {
     const vuorovaikutus = findVuorovaikutusByNumber(projektiInDB, vuorovaikutusNumero);
     const vuorovaikutusKutsuPath = new ProjektiPaths(oid).vuorovaikutus(vuorovaikutus).yllapitoPath + "/kutsu";
 
-    async function generateKutsuPDF(kieli: Kieli) {
+    async function generateKutsuPDF(kieli: API.Kieli) {
       const pdf = await asiakirjaService.createYleisotilaisuusKutsuPdf({
         projekti: projektiInDB,
         vuorovaikutus,

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -65,7 +65,6 @@ Array [
     "kayttoOikeudet": Array [
       Object {
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -74,7 +73,6 @@ Array [
       },
       Object {
         "email": "matti.meikalainen@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A000111",
         "nimi": "Meikäläinen, Matti",
         "organisaatio": "ELY",
@@ -103,7 +101,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -113,7 +110,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "matti.meikalainen@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A000111",
         "nimi": "Meikäläinen, Matti",
         "organisaatio": "ELY",
@@ -147,7 +143,6 @@ Array [
     "kayttoOikeudet": Array [
       Object {
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -177,7 +172,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -211,7 +205,6 @@ Array [
     "kayttoOikeudet": Array [
       Object {
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -220,7 +213,6 @@ Array [
       },
       Object {
         "email": "matti.meikalainen@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A000111",
         "nimi": "Meikäläinen, Matti",
         "organisaatio": "ELY",
@@ -250,7 +242,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -260,7 +251,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "matti.meikalainen@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A000111",
         "nimi": "Meikäläinen, Matti",
         "organisaatio": "ELY",
@@ -317,7 +307,6 @@ Array [
     "kayttoOikeudet": Array [
       Object {
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -326,7 +315,6 @@ Array [
       },
       Object {
         "email": "matti.meikalainen@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A000111",
         "nimi": "Meikäläinen, Matti",
         "organisaatio": "ELY",
@@ -335,7 +323,6 @@ Array [
       },
       Object {
         "email": "A2@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A2",
         "nimi": "SukunimiA2, EtunimiA2",
         "organisaatio": "Väylävirasto",
@@ -403,7 +390,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "pekka.projari@vayla.fi",
-        "esitetaanKuulutuksessa": true,
         "kayttajatunnus": "A123",
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
@@ -413,7 +399,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "matti.meikalainen@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A000111",
         "nimi": "Meikäläinen, Matti",
         "organisaatio": "ELY",
@@ -423,7 +408,6 @@ Array [
       Object {
         "__typename": "ProjektiKayttaja",
         "email": "A2@vayla.fi",
-        "esitetaanKuulutuksessa": undefined,
         "kayttajatunnus": "A2",
         "nimi": "SukunimiA2, EtunimiA2",
         "organisaatio": "Väylävirasto",
@@ -730,7 +714,6 @@ Object {
     Object {
       "__typename": "ProjektiKayttaja",
       "email": "pekka.projari@vayla.fi",
-      "esitetaanKuulutuksessa": true,
       "kayttajatunnus": "A123",
       "nimi": "Projari, Pekka",
       "organisaatio": "Väylävirasto",
@@ -740,7 +723,6 @@ Object {
     Object {
       "__typename": "ProjektiKayttaja",
       "email": "matti.meikalainen@vayla.fi",
-      "esitetaanKuulutuksessa": undefined,
       "kayttajatunnus": "A000111",
       "nimi": "Meikäläinen, Matti",
       "organisaatio": "ELY",
@@ -750,7 +732,6 @@ Object {
     Object {
       "__typename": "ProjektiKayttaja",
       "email": "A2@vayla.fi",
-      "esitetaanKuulutuksessa": undefined,
       "kayttajatunnus": "A2",
       "nimi": "SukunimiA2, EtunimiA2",
       "organisaatio": "Väylävirasto",

--- a/backend/test/asiakirja/__snapshots__/asiakirjaService.test.ts.snap
+++ b/backend/test/asiakirja/__snapshots__/asiakirjaService.test.ts.snap
@@ -1205,6 +1205,7 @@ Object {
   },
   "yhteystiedot": Array [
     Object {
+      "__typename": "Yhteystieto",
       "etunimi": "Pekka",
       "organisaatio": "Väylävirasto",
       "puhelinnumero": "123456789",
@@ -1212,6 +1213,7 @@ Object {
       "sukunimi": "Projari",
     },
     Object {
+      "__typename": "Yhteystieto",
       "etunimi": "Marko",
       "organisaatio": "Kajaani",
       "puhelinnumero": "0293121213",

--- a/backend/test/asiakirja/asiakirjaService.test.ts
+++ b/backend/test/asiakirja/asiakirjaService.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/asiakirja/asiakirjaService";
 import {
   AsiakirjaTyyppi,
+  IlmoitettavaViranomainen,
   Kieli,
   KirjaamoOsoite,
   PDF,
@@ -86,9 +87,7 @@ describe("asiakirjaService", async () => {
       async (type) => await testKuulutusWithLanguage(aloitusKuulutusJulkaisu, Kieli.RUOTSI, type)
     );
 
-    await assert.isRejected(
-      testKuulutusWithLanguage(aloitusKuulutusJulkaisu, Kieli.SAAME, AsiakirjaTyyppi.ALOITUSKUULUTUS)
-    );
+    await assert.isRejected(testKuulutusWithLanguage(aloitusKuulutusJulkaisu, Kieli.SAAME, AsiakirjaTyyppi.ALOITUSKUULUTUS));
   });
 
   async function testKutsuWithLanguage(
@@ -171,13 +170,12 @@ describe("asiakirjaService", async () => {
   }
 
   it("should generate kuulutukset for Nahtavillaolo succesfully", async () => {
-    kirjaamoOsoitteetStub.resolves([
-      {
-        __typename: "KirjaamoOsoite",
-        sahkoposti: "uudenmaan_kirjaamo@uudenmaan.ely",
-        nimi: "UUDENMAAN_ELY",
-      } as KirjaamoOsoite,
-    ]);
+    const osoite: KirjaamoOsoite = {
+      __typename: "KirjaamoOsoite",
+      sahkoposti: "uudenmaan_kirjaamo@uudenmaan.ely",
+      nimi: IlmoitettavaViranomainen.UUDENMAAN_ELY,
+    };
+    kirjaamoOsoitteetStub.resolves([osoite]);
     const projekti: DBProjekti = projektiFixture.dbProjekti2();
     projekti.velho.tyyppi = ProjektiTyyppi.TIE;
     projekti.velho.vaylamuoto = ["tie"];
@@ -190,24 +188,21 @@ describe("asiakirjaService", async () => {
 
     await runTestWithTypes(
       nahtavillaoloKuulutusTypes,
-      async (type) =>
-        await testNahtavillaoloKuulutusWithLanguage(projekti, projekti.nahtavillaoloVaihe, Kieli.SUOMI, type)
+      async (type) => await testNahtavillaoloKuulutusWithLanguage(projekti, projekti.nahtavillaoloVaihe, Kieli.SUOMI, type)
     );
 
     projekti.velho.tyyppi = ProjektiTyyppi.RATA;
     projekti.velho.vaylamuoto = ["rata"];
     await runTestWithTypes(
       nahtavillaoloKuulutusTypes,
-      async (type) =>
-        await testNahtavillaoloKuulutusWithLanguage(projekti, projekti.nahtavillaoloVaihe, Kieli.SUOMI, type)
+      async (type) => await testNahtavillaoloKuulutusWithLanguage(projekti, projekti.nahtavillaoloVaihe, Kieli.SUOMI, type)
     );
 
     projekti.velho.tyyppi = ProjektiTyyppi.YLEINEN;
     projekti.velho.vaylamuoto = ["rata"];
     await runTestWithTypes(
       nahtavillaoloKuulutusTypes,
-      async (type) =>
-        await testNahtavillaoloKuulutusWithLanguage(projekti, projekti.nahtavillaoloVaihe, Kieli.SUOMI, type)
+      async (type) => await testNahtavillaoloKuulutusWithLanguage(projekti, projekti.nahtavillaoloVaihe, Kieli.SUOMI, type)
     );
   });
 
@@ -244,8 +239,7 @@ describe("asiakirjaService", async () => {
       ];
       await runTestWithTypes(
         hyvaksymisPaatosTypes,
-        async (type) =>
-          await testHyvaksymisPaatosKuulutusWithLanguage(projekti, projekti.hyvaksymisPaatosVaihe, kieli, type)
+        async (type) => await testHyvaksymisPaatosKuulutusWithLanguage(projekti, projekti.hyvaksymisPaatosVaihe, kieli, type)
       );
 
       // ----------
@@ -253,8 +247,7 @@ describe("asiakirjaService", async () => {
       projekti.velho.vaylamuoto = ["rata"];
       await runTestWithTypes(
         hyvaksymisPaatosTypes,
-        async (type) =>
-          await testHyvaksymisPaatosKuulutusWithLanguage(projekti, projekti.hyvaksymisPaatosVaihe, kieli, type)
+        async (type) => await testHyvaksymisPaatosKuulutusWithLanguage(projekti, projekti.hyvaksymisPaatosVaihe, kieli, type)
       );
 
       // ----------
@@ -262,8 +255,7 @@ describe("asiakirjaService", async () => {
       projekti.velho.vaylamuoto = ["rata"];
       await runTestWithTypes(
         hyvaksymisPaatosTypes,
-        async (type) =>
-          await testHyvaksymisPaatosKuulutusWithLanguage(projekti, projekti.hyvaksymisPaatosVaihe, kieli, type)
+        async (type) => await testHyvaksymisPaatosKuulutusWithLanguage(projekti, projekti.hyvaksymisPaatosVaihe, kieli, type)
       );
     }
   });

--- a/backend/test/database/projektiDatabase.test.ts
+++ b/backend/test/database/projektiDatabase.test.ts
@@ -51,6 +51,7 @@ describe("apiHandler", () => {
           },
         });
 
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const projekti: DBProjekti = {
           oid: fixture.PROJEKTI1_OID,
           muistiinpano: "foo",

--- a/backend/test/fixture/projektiFixture.ts
+++ b/backend/test/fixture/projektiFixture.ts
@@ -339,29 +339,24 @@ export class ProjektiFixture {
           SAAME: null,
         },
         ilmoituksenVastaanottajat: {
-          __typename: "IlmoituksenVastaanottajat",
           kunnat: [
             {
               nimi: "Mikkeli",
               sahkoposti: "mikkeli@mikke.li",
-              __typename: "KuntaVastaanottaja",
             },
             {
               nimi: " Juva",
               sahkoposti: "juva@ju.va",
-              __typename: "KuntaVastaanottaja",
             },
             {
               nimi: " Savonlinna",
               sahkoposti: "savonlinna@savonlin.na",
-              __typename: "KuntaVastaanottaja",
             },
           ],
           viranomaiset: [
             {
               nimi: IlmoitettavaViranomainen.ETELA_SAVO_ELY,
               sahkoposti: "kirjaamo.etela-savo@ely-keskus.fi",
-              __typename: "ViranomaisVastaanottaja",
             },
           ],
         },
@@ -502,29 +497,24 @@ export class ProjektiFixture {
         SAAME: null,
       },
       ilmoituksenVastaanottajat: {
-        __typename: "IlmoituksenVastaanottajat",
         kunnat: [
           {
             nimi: "Mikkeli",
             sahkoposti: "mikkeli@mikke.li",
-            __typename: "KuntaVastaanottaja",
           },
           {
             nimi: " Juva",
             sahkoposti: "juva@ju.va",
-            __typename: "KuntaVastaanottaja",
           },
           {
             nimi: " Savonlinna",
             sahkoposti: "savonlinna@savonlin.na",
-            __typename: "KuntaVastaanottaja",
           },
         ],
         viranomaiset: [
           {
             nimi: IlmoitettavaViranomainen.ETELA_SAVO_ELY,
             sahkoposti: "kirjaamo.etela-savo@ely-keskus.fi",
-            __typename: "ViranomaisVastaanottaja",
           },
         ],
       },
@@ -575,17 +565,14 @@ export class ProjektiFixture {
             {
               nimi: "Kerava",
               sahkoposti: "email@email.email",
-              __typename: "KuntaVastaanottaja",
             },
           ],
           viranomaiset: [
             {
               nimi: IlmoitettavaViranomainen.VAYLAVIRASTO,
               sahkoposti: "kirjaamo@vayla.fi",
-              __typename: "ViranomaisVastaanottaja",
             },
           ],
-          __typename: "IlmoituksenVastaanottajat",
         },
         kielitiedot: {
           ensisijainenKieli: Kieli.RUOTSI,
@@ -672,22 +659,18 @@ export class ProjektiFixture {
           hyvaksymisPaatosVaihePDFt: undefined,
           id: 1,
           ilmoituksenVastaanottajat: {
-            __typename: "IlmoituksenVastaanottajat",
             kunnat: [
               {
-                __typename: "KuntaVastaanottaja",
                 lahetetty: "2022-03-11T14:54",
                 nimi: "Mikkeli",
                 sahkoposti: "mikkeli@mikke.li",
               },
               {
-                __typename: "KuntaVastaanottaja",
                 lahetetty: "2022-03-11T14:54",
                 nimi: " Juva",
                 sahkoposti: "juva@ju.va",
               },
               {
-                __typename: "KuntaVastaanottaja",
                 lahetetty: "2022-03-11T14:54",
                 nimi: " Savonlinna",
                 sahkoposti: "savonlinna@savonlin.na",
@@ -695,7 +678,6 @@ export class ProjektiFixture {
             ],
             viranomaiset: [
               {
-                __typename: "ViranomaisVastaanottaja",
                 lahetetty: "2022-03-11T14:54",
                 nimi: IlmoitettavaViranomainen.ETELA_SAVO_ELY,
                 sahkoposti: "kirjaamo.etela-savo@ely-keskus.fi",

--- a/backend/test/personSearch/kayttajas.test.ts
+++ b/backend/test/personSearch/kayttajas.test.ts
@@ -15,20 +15,20 @@ describe("kayttajas", () => {
     };
     const kayttajas = new Kayttajas(kayttajaMap);
     expect(kayttajas.getKayttajaByUid(undefined)).to.eql(undefined);
-    const a1Kayttaja = {
+    const a1Kayttaja: Kayttaja = {
       __typename: "Kayttaja",
       uid: "A1",
       etuNimi: "Matti",
       sukuNimi: "Meikäläinen",
       email: "e1",
-    } as Kayttaja;
-    const a2Kayttaja = {
+    };
+    const a2Kayttaja: Kayttaja = {
       __typename: "Kayttaja",
       uid: "A2",
       etuNimi: "Minna",
       sukuNimi: "Esimerkkinen",
       email: "e2",
-    } as Kayttaja;
+    };
     expect(kayttajas.getKayttajaByUid("A1")).to.eql(a1Kayttaja);
     expect(kayttajas.findByText("nen").sort(sortByUidFn)).to.eql([a1Kayttaja, a2Kayttaja]);
     expect(kayttajas.findByText("")).to.eql([]);

--- a/backend/test/personSearch/lambda/personAdapter.test.ts
+++ b/backend/test/personSearch/lambda/personAdapter.test.ts
@@ -17,30 +17,32 @@ describe("personAdapter", () => {
   it("should adapt person search result succesfully", () => {
     const kayttajas = {};
     adaptPersonSearchResult(searchResultFixture.pekkaProjariSearchResult, kayttajas);
+    const person: Person = {
+      email: ["pekka.projari@vayla.fi"],
+      etuNimi: "Pekka",
+      organisaatio: "Väylävirasto",
+      puhelinnumero: "123456789",
+      sukuNimi: "Projari",
+      vaylaKayttajaTyyppi: VaylaKayttajaTyyppi.A_TUNNUS,
+    };
     expect(kayttajas).to.eql({
-      A123: {
-        email: ["pekka.projari@vayla.fi"],
-        etuNimi: "Pekka",
-        organisaatio: "Väylävirasto",
-        puhelinnumero: "123456789",
-        sukuNimi: "Projari",
-        vaylaKayttajaTyyppi: VaylaKayttajaTyyppi.A_TUNNUS,
-      } as Person,
+      A123: person,
     });
   });
 
   it("should adapt person search result succesfully", () => {
     const kayttajas = {};
     adaptPersonSearchResult(searchResultFixture.mattiMeikalainenSearchResult, kayttajas);
+    const person: Person = {
+      email: ["matti.meikalainen@vayla.fi"],
+      etuNimi: "Matti",
+      organisaatio: "ELY",
+      puhelinnumero: "123456789",
+      sukuNimi: "Meikäläinen",
+      vaylaKayttajaTyyppi: VaylaKayttajaTyyppi.A_TUNNUS,
+    };
     expect(kayttajas).to.eql({
-      A000111: {
-        email: ["matti.meikalainen@vayla.fi"],
-        etuNimi: "Matti",
-        organisaatio: "ELY",
-        puhelinnumero: "123456789",
-        sukuNimi: "Meikäläinen",
-        vaylaKayttajaTyyppi: VaylaKayttajaTyyppi.A_TUNNUS,
-      } as Person,
+      A000111: person,
     });
   });
 });

--- a/backend/test/projektiSearch/dynamoDBStreamHandler.test.ts
+++ b/backend/test/projektiSearch/dynamoDBStreamHandler.test.ts
@@ -52,6 +52,7 @@ describe("dynamoDBStreamHandler", () => {
     sandbox.restore();
   });
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const context = { functionName: "myFunction" } as Context;
   it("should index new projektis successfully", async () => {
     await handleDynamoDBEvents(fixture.createNewProjektiEvent(projekti), context);


### PR DESCRIPTION
Ennen tässä PR:ssä olevia korjauksia tietokantaan meni __typename-kenttiä, vaikka ei pitäisi mennä YHTÄÄN.
Lisäksi oli jäänyt jotain vanhoja kenttiä, esim. "esitetaanYhteystiedoissa" oli jäänyt henkilotietojen yhteyteen.
Sitten kun taas tarjoillaan API:lle kamaa, niissä kaikissa PITÄÄ olla __typename.
Nämä muutokset vaativat mm. sen, että tietyt tietotyypit luotiin erikseen tietokantaan ja graphql:lle. Ainoastaan enum-tietotyypit voi importoida tietokantaa graphql-puolelta, koska niissä ei ole __typename-kenttää.
Korjasin samassa PR:ssä muita tyypitysjuttuja, esim. jatkossa ei hyväksytä "as JokinTyyppi" -tyylistä type castingiä.
Lisäsin myös funktioille return typeja.