### PR TITLE
feat: optimoi AWS SDK-kutsut käyttämään kevyempää muotoa

### DIFF
--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -1642,16 +1642,19 @@ Object {
 
 exports[`Api should search, load and save a project 14`] = `
 Object {
-  "DistributionId": "unit-test-distribution-id",
-  "InvalidationBatch": Object {
-    "CallerReference": "***unittest***",
-    "Paths": Object {
-      "Items": Array [
-        "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/*",
-      ],
-      "Quantity": 1,
+  "args": Object {
+    "DistributionId": "unit-test-distribution-id",
+    "InvalidationBatch": Object {
+      "CallerReference": "***unittest***",
+      "Paths": Object {
+        "Items": Array [
+          "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/*",
+        ],
+        "Quantity": 1,
+      },
     },
   },
+  "stub": "createInvalidation",
 }
 `;
 
@@ -1698,16 +1701,19 @@ Object {
 
 exports[`Api should search, load and save a project 17`] = `
 Object {
-  "DistributionId": "unit-test-distribution-id",
-  "InvalidationBatch": Object {
-    "CallerReference": "***unittest***",
-    "Paths": Object {
-      "Items": Array [
-        "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/*",
-      ],
-      "Quantity": 1,
+  "args": Object {
+    "DistributionId": "unit-test-distribution-id",
+    "InvalidationBatch": Object {
+      "CallerReference": "***unittest***",
+      "Paths": Object {
+        "Items": Array [
+          "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/*",
+        ],
+        "Quantity": 1,
+      },
     },
   },
+  "stub": "createInvalidation",
 }
 `;
 

--- a/backend/integrationtest/api/testUtil/tests.ts
+++ b/backend/integrationtest/api/testUtil/tests.ts
@@ -31,18 +31,14 @@ import { expectApiError, expectToMatchSnapshot } from "./util";
 import { handleEvent } from "../../../src/aineisto/aineistoImporterLambda";
 import { SQSEvent } from "aws-lambda/trigger/sqs";
 import cloneDeep from "lodash/cloneDeep";
-import { projektiDatabase } from "../../../src/database/projektiDatabase";
 import { fileService } from "../../../src/files/fileService";
 import { testProjektiDatabase } from "../../../src/database/testProjektiDatabase";
+import { expectAwsCalls } from "../../../test/aws/awsMock";
 
 const { expect } = require("chai");
 
 export function verifyCloudfrontWasInvalidated(awsCloudfrontInvalidationStub: Sinon.SinonStub): void {
-  expect(awsCloudfrontInvalidationStub.getCalls()).to.have.length(1, "verifyCloudfrontWasInvalidated");
-  expect(awsCloudfrontInvalidationStub.getCalls()[0].args).to.have.length(2, "verifyCloudfrontWasInvalidated");
-  const invalidationParams = awsCloudfrontInvalidationStub.getCalls()[0].args[0];
-  invalidationParams.InvalidationBatch.CallerReference = "***unittest***";
-  expect(invalidationParams).toMatchSnapshot();
+  expectAwsCalls(awsCloudfrontInvalidationStub, "CallerReference");
   awsCloudfrontInvalidationStub.resetHistory();
 }
 

--- a/backend/src/aineisto/aineistoImporterClient.ts
+++ b/backend/src/aineisto/aineistoImporterClient.ts
@@ -2,7 +2,7 @@ import { ImportAineistoEvent } from "./importAineistoEvent";
 import { getSQS } from "../aws/client";
 import { config } from "../config";
 import { log } from "../logger";
-import { SQS } from "aws-sdk";
+import SQS from "aws-sdk/clients/sqs";
 
 class AineistoImporterClient {
   async importAineisto(params: ImportAineistoEvent) {

--- a/backend/src/aws/awsRequest.ts
+++ b/backend/src/aws/awsRequest.ts
@@ -1,14 +1,11 @@
 import { HttpRequest } from "@aws-sdk/protocol-http";
 import { SignatureV4 } from "@aws-sdk/signature-v4";
-import AWS from "aws-sdk";
+import AWS from "aws-sdk/global";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { HttpRequest as IHttpRequest } from "@aws-sdk/types/dist-types/http";
 import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 
-export async function sendSignedRequest(
-  request: HttpRequest,
-  service: string
-): Promise<{ body: unknown; statusCode: number }> {
+export async function sendSignedRequest(request: HttpRequest, service: string): Promise<{ body: unknown; statusCode: number }> {
   // Sign the request
   if (!AWS.config.credentials) {
     throw new Error("No AWS credentials available");

--- a/backend/src/aws/client.ts
+++ b/backend/src/aws/client.ts
@@ -1,9 +1,12 @@
-import AWS from "aws-sdk";
+import SSM from "aws-sdk/clients/ssm";
+import SQS from "aws-sdk/clients/sqs";
+import S3 from "aws-sdk/clients/s3";
+import Cloudfront from "aws-sdk/clients/cloudfront";
 import * as AWSXRay from "aws-xray-sdk-core";
 
-export function produce<T>(name: string, p: () => T, override = false): T {
+function produce<T>(name: string, p: () => T, override = false): T {
   const key = "produce_" + name;
-  if (!(globalThis as any)[key] || override || process.env.MOCHA_WORKER_ID) {
+  if (!(globalThis as any)[key] || override) {
     const client = p();
     try {
       (globalThis as any)[key] = AWSXRay.captureAWSClient(client);
@@ -14,19 +17,17 @@ export function produce<T>(name: string, p: () => T, override = false): T {
   return (globalThis as any)[key];
 }
 
-export const getUSEast1ssm = (): AWS.SSM =>
-  produce<AWS.SSM>("ssm_us_east_1", () => new AWS.SSM({ region: "us-east-1" }));
-export const getSSM = (): AWS.SSM => produce<AWS.SSM>("ssm", () => new AWS.SSM({ region: "eu-west-1" }));
-export const getS3 = (): AWS.S3 => {
+export const getUSEast1ssm = (): SSM => produce<SSM>("ssm_us_east_1", () => new SSM({ region: "us-east-1" }));
+export const getSSM = (): SSM => produce<SSM>("ssm", () => new SSM({ region: "eu-west-1" }));
+export const getS3 = (): S3 => {
   if (process.env.S3_ENDPOINT) {
-    return new AWS.S3({ endpoint: process.env.S3_ENDPOINT, s3ForcePathStyle: true });
+    return produce<S3>("s3", () => new S3({ endpoint: process.env.S3_ENDPOINT, s3ForcePathStyle: true }));
   } else {
-    return produce<AWS.S3>("s3", () => new AWS.S3({ region: "eu-west-1" }));
+    return produce<S3>("s3", () => new S3({ region: "eu-west-1" }));
   }
 };
-export const getSQS = (): AWS.SQS => {
-  return produce<AWS.SQS>("sqs", () => new AWS.SQS({ region: "eu-west-1" }));
+export const getSQS = (): SQS => {
+  return produce<SQS>("sqs", () => new SQS({ region: "eu-west-1" }));
 };
 
-export const getCloudFront = (): AWS.CloudFront =>
-  produce<AWS.CloudFront>("cloudfront", () => new AWS.CloudFront({ region: "us-east-1" }));
+export const getCloudFront = (): Cloudfront => produce<Cloudfront>("cloudfront", () => new Cloudfront({ region: "us-east-1" }));

--- a/backend/src/aws/lambda.ts
+++ b/backend/src/aws/lambda.ts
@@ -1,13 +1,9 @@
-import AWS from "aws-sdk";
+import Lambda from "aws-sdk/clients/lambda";
 import { log } from "../logger";
 
-const lambda = new AWS.Lambda();
+const lambda = new Lambda();
 
-export async function invokeLambda(
-  functionName: string,
-  synchronousCall: boolean,
-  payload?: string
-): Promise<string | undefined> {
+export async function invokeLambda(functionName: string, synchronousCall: boolean, payload?: string): Promise<string | undefined> {
   try {
     if (synchronousCall) {
       const output = await lambda
@@ -16,7 +12,11 @@ export async function invokeLambda(
           Payload: payload || "{}",
         })
         .promise();
-      return new TextDecoder().decode(output.Payload as Buffer);
+      const outputPayload = output.Payload;
+      if (typeof outputPayload === "string") {
+        return outputPayload;
+      }
+      return new TextDecoder().decode(outputPayload as Buffer);
     } else {
       await lambda
         .invokeAsync({

--- a/backend/src/database/projektiDatabase.ts
+++ b/backend/src/database/projektiDatabase.ts
@@ -3,7 +3,7 @@ import { AloitusKuulutusJulkaisu, DBProjekti, HyvaksymisPaatosVaiheJulkaisu, Nah
 import { config } from "../config";
 import { getDynamoDBDocumentClient } from "./dynamoDB";
 import { DocumentClient } from "aws-sdk/lib/dynamodb/document_client";
-import { AWSError } from "aws-sdk";
+import { AWSError } from "aws-sdk/lib/error";
 import { Response } from "aws-sdk/lib/response";
 import dayjs from "dayjs";
 

--- a/backend/src/files/fileService.ts
+++ b/backend/src/files/fileService.ts
@@ -11,7 +11,7 @@ import S3, { ListObjectsV2Output } from "aws-sdk/clients/s3";
 import { getS3 } from "../aws/client";
 import { parseDate } from "../util/dateUtil";
 import { ProjektiPaths } from "./ProjektiPath";
-import { AWSError } from "aws-sdk";
+import { AWSError } from "aws-sdk/lib/error";
 
 export type UploadFileProperties = {
   fileNameWithPath: string;

--- a/backend/src/handler/asiakirjaAdapter.ts
+++ b/backend/src/handler/asiakirjaAdapter.ts
@@ -1,10 +1,10 @@
 import { AloitusKuulutusJulkaisu, DBProjekti, HyvaksymisPaatosVaiheJulkaisu, NahtavillaoloVaiheJulkaisu, Velho } from "../database/model";
 import cloneDeep from "lodash/cloneDeep";
 import { AloitusKuulutusTila, HyvaksymisPaatosVaiheTila, NahtavillaoloVaiheTila } from "../../../common/graphql/apiModel";
-import { deepClone } from "aws-cdk/lib/util";
 import adaptStandardiYhteystiedot from "../util/adaptStandardiYhteystiedot";
 import { findJulkaisuWithTila, findUserByKayttajatunnus } from "../projekti/projektiUtil";
 import { adaptSuunnitteluSopimusToSuunnitteluSopimusJulkaisu } from "../projekti/adapter/adaptToAPI";
+import assert from "assert";
 
 function createNextAloitusKuulutusJulkaisuID(dbProjekti: DBProjekti) {
   if (!dbProjekti.aloitusKuulutusJulkaisut) {
@@ -110,7 +110,8 @@ export class AsiakirjaAdapter {
 }
 
 function adaptVelho(dbProjekti: DBProjekti): Velho {
-  return deepClone(dbProjekti.velho);
+  assert(dbProjekti.velho);
+  return cloneDeep(dbProjekti.velho);
 }
 
 export const asiakirjaAdapter = new AsiakirjaAdapter();

--- a/backend/src/user/signedCookie.ts
+++ b/backend/src/user/signedCookie.ts
@@ -1,5 +1,5 @@
 import { config } from "../config";
-import AWS from "aws-sdk";
+import Cloudfront from "aws-sdk/clients/cloudfront";
 import { getUSEast1ssm } from "../aws/client";
 
 export async function createSignedCookies(): Promise<string[]> {
@@ -39,12 +39,12 @@ async function getCloudFrontSigner() {
       if (!publicKeyId.Parameter?.Value) {
         throw new Error("Configuration error: SSM parameter " + parameterKey + " not found");
       }
-      (globalThis as any).cloudFrontSigner = new AWS.CloudFront.Signer(
+      (globalThis as any).cloudFrontSigner = new Cloudfront.Signer(
         publicKeyId.Parameter.Value,
         config.frontendPrivateKey || ""
       );
     } else {
-      (globalThis as any).cloudFrontSigner = new AWS.CloudFront.Signer(
+      (globalThis as any).cloudFrontSigner = new Cloudfront.Signer(
         config.frontendPublicKeyId,
         config.frontendPrivateKey || ""
       );

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -521,8 +521,8 @@ Array [
 `;
 
 exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 10`] = `
-Array [
-  Object {
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -531,7 +531,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 11`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -540,7 +546,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 12`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -549,7 +561,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 13`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -558,7 +576,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 14`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -567,7 +591,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 15`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -576,7 +606,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 16`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -585,7 +621,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 17`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -594,7 +636,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 18`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -603,7 +651,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 19`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -612,7 +666,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 20`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -621,7 +681,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 21`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -630,7 +696,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 22`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -639,7 +711,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 23`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
     "ContentType": "application/pdf",
@@ -648,7 +726,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 24`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -657,7 +741,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 25`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
     "ContentType": "application/pdf",
@@ -666,7 +756,13 @@ Array [
       "publication-timestamp": "2022-01-02T00:00:00+02:00",
     },
   },
-  Object {
+  "stub": "putObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 26`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-public",
     "CopySource": "hassu-localstack-yllapito/yllapito/tiedostot/projekti/1/suunnittelusopimus/logo.gif",
     "Key": "tiedostot/suunnitelma/1/suunnittelusopimus/logo.gif",
@@ -675,10 +771,81 @@ Array [
     },
     "MetadataDirective": "REPLACE",
   },
-]
+  "stub": "copyObject",
+}
 `;
 
-exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 11`] = `
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 27`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+  },
+  "stub": "getObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 28`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+  },
+  "stub": "getObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 29`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "Key": "yllapito/tiedostot/projekti/1/suunnittelusopimus/logo.gif",
+  },
+  "stub": "headObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 30`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+  },
+  "stub": "deleteObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 31`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+  },
+  "stub": "deleteObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 32`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+  },
+  "stub": "deleteObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 33`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+  },
+  "stub": "deleteObject",
+}
+`;
+
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 34`] = `
 Object {
   "__typename": "Projekti",
   "aloitusKuulutus": Object {
@@ -894,7 +1061,7 @@ Object {
 }
 `;
 
-exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 12`] = `
+exports[`apiHandler handleEvent tallennaProjekti should modify permissions from a project successfully 35`] = `
 Object {
   "description": "Public version of the projekti",
   "projekti": Object {

--- a/backend/test/aws/awsMock.ts
+++ b/backend/test/aws/awsMock.ts
@@ -1,0 +1,23 @@
+import * as sinon from "sinon";
+import { replaceFieldsByName } from "../../integrationtest/api/testFixtureRecorder";
+
+const { expect } = require("chai");
+
+export function awsMockResolves<T>(stub: sinon.SinonStub, returnValue?: T): void {
+  stub.returns({
+    promise() {
+      return returnValue;
+    },
+  });
+}
+
+export function expectAwsCalls(stub: sinon.SinonStub, ...cleanupFieldNames: string[]): void {
+  const calls = stub.getCalls();
+  calls.map((call) => {
+    const { Body: _Body, ...rest } = call.args[0];
+    if (cleanupFieldNames) {
+      replaceFieldsByName(rest, "***unittest***", ...cleanupFieldNames);
+    }
+    expect({ stub: stub.toString(), args: { ...rest } }).toMatchSnapshot();
+  });
+}

--- a/backend/test/email/__snapshots__/emailHandler.test.ts.snap
+++ b/backend/test/email/__snapshots__/emailHandler.test.ts.snap
@@ -1,14 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`emailHandler sendEmailsByToiminto sendApprovalMailsAndAttachments should send emails and attachments succesfully 1`] = `
-Array [
-  Object {
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "Key": "yllapito/tiedostot/projekti/2/aloituskuulutus/KUULUTUS SUUNNITTELUN ALOITTAMISESTA Marikan testiprojekti.pdf",
   },
-  Object {
+  "stub": "getObject",
+}
+`;
+
+exports[`emailHandler sendEmailsByToiminto sendApprovalMailsAndAttachments should send emails and attachments succesfully 2`] = `
+Object {
+  "args": Object {
     "Bucket": "hassu-localstack-yllapito",
     "Key": "yllapito/tiedostot/projekti/2/aloituskuulutus/ILMOITUS TOIMIVALTAISEN VIRANOMAISEN KUULUTUKSESTA Marikan testiprojekti.pdf",
   },
-]
+  "stub": "getObject",
+}
 `;

--- a/backend/test/files/__snapshots__/fileService.test.ts.snap
+++ b/backend/test/files/__snapshots__/fileService.test.ts.snap
@@ -1,7 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UploadService should create file to projekti successfully 1`] = `undefined`;
+exports[`UploadService should create file to projekti successfully 1`] = `
+Object {
+  "args": Object {
+    "Bucket": "hassu-localstack-yllapito",
+    "ContentDisposition": "inline; filename*=UTF-8''test%20%C3%A4%C3%A4kk%C3%B6sill%C3%A4.pdf",
+    "ContentType": "application/pdf",
+    "Key": "yllapito/tiedostot/projekti/1/testfilepath/test ääkkösillä.pdf",
+    "Metadata": Object {
+      "publication-timestamp": "2000-01-01T12:34:00+02:00",
+    },
+  },
+  "stub": "putObject",
+}
+`;
 
-exports[`UploadService should upload file successfully 1`] = `undefined`;
+exports[`UploadService should upload file successfully 1`] = `
+Object {
+  "Bucket": "hassu-localstack-upload",
+  "Key": "1-2-3-4/logo ääkkösillä.png",
+}
+`;
 
-exports[`UploadService should upload file successfully 2`] = `undefined`;
+exports[`UploadService should upload file successfully 2`] = `
+Object {
+  "Bucket": "hassu-localstack-yllapito",
+  "ContentType": "image/png",
+  "CopySource": "hassu-localstack-upload/1-2-3-4/logo%20%C3%A4%C3%A4kk%C3%B6sill%C3%A4.png",
+  "Key": "yllapito/tiedostot/projekti/1/suunnittelusopimus/logo ääkkösillä.png",
+  "MetadataDirective": "REPLACE",
+}
+`;

--- a/backend/test/projekti/projektiAdapter.test.ts
+++ b/backend/test/projekti/projektiAdapter.test.ts
@@ -5,14 +5,40 @@ import { projektiAdapter } from "../../src/projekti/adapter/projektiAdapter";
 import { findPublishedAloitusKuulutusJulkaisu } from "../../src/projekti/adapter/common";
 
 import { IllegalArgumentError } from "../../src/error/IllegalArgumentError";
+import * as sinon from "sinon";
+import { personSearch } from "../../src/personSearch/personSearchClient";
+import { PersonSearchFixture } from "../personSearch/lambda/personSearchFixture";
+import { Kayttajas } from "../../src/personSearch/kayttajas";
 
 const { expect } = require("chai");
 
 describe("projektiAdapter", () => {
   let fixture: ProjektiFixture;
 
+  let getKayttajasStub: sinon.SinonStub;
+
+  before(() => {
+    getKayttajasStub = sinon.stub(personSearch, "getKayttajas");
+  });
+
   beforeEach(() => {
     fixture = new ProjektiFixture();
+    const personSearchFixture = new PersonSearchFixture();
+    getKayttajasStub.resolves(
+      Kayttajas.fromKayttajaList([
+        personSearchFixture.pekkaProjari,
+        personSearchFixture.mattiMeikalainen,
+        personSearchFixture.manuMuokkaaja,
+      ])
+    );
+  });
+
+  afterEach(() => {
+    sinon.reset();
+  });
+
+  after(() => {
+    sinon.restore();
   });
 
   it("should prevent suunnitteluvaihe publishing without valid aloituskuulutusjulkaisu", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "esbuild": "0.12.19",
         "graphql": "14.7.0",
         "graphql-tag": "2.12.5",
-        "jsonschema": "^1.4.1",
+        "jsonschema": "1.4.1",
         "jsonwebtoken": "8.5.1",
         "jwk-to-pem": "2.0.5",
         "lodash": "4.17.21",
@@ -114,7 +114,6 @@
         "aws-amplify": "4.3.6",
         "aws-cdk": "1.132.0",
         "aws-cdk-local": "1.65.8",
-        "aws-sdk-mock": "5.7.0",
         "axios-logger": "2.5.0",
         "babel-jest": "27.2.4",
         "babel-loader": "8.2.3",
@@ -25399,65 +25398,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/aws-sdk-mock": {
-      "version": "5.7.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sdk": "^2.1122.0",
-        "sinon": "^13.0.2",
-        "traverse": "^0.6.6"
-      }
-    },
-    "node_modules/aws-sdk-mock/node_modules/@sinonjs/fake-timers": {
-      "version": "9.1.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/aws-sdk-mock/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-sdk-mock/node_modules/sinon": {
-      "version": "13.0.2",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^9.1.2",
-        "@sinonjs/samsam": "^6.1.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.1",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/aws-sdk-mock/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-sdk-mock/node_modules/traverse": {
-      "version": "0.6.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/aws-sdk/node_modules/buffer": {
       "version": "4.9.2",
@@ -71331,51 +71271,6 @@
         },
         "xmlbuilder": {
           "version": "9.0.7"
-        }
-      }
-    },
-    "aws-sdk-mock": {
-      "version": "5.7.0",
-      "dev": true,
-      "requires": {
-        "aws-sdk": "^2.1122.0",
-        "sinon": "^13.0.2",
-        "traverse": "^0.6.6"
-      },
-      "dependencies": {
-        "@sinonjs/fake-timers": {
-          "version": "9.1.2",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.7.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "dev": true
-        },
-        "sinon": {
-          "version": "13.0.2",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^1.8.3",
-            "@sinonjs/fake-timers": "^9.1.2",
-            "@sinonjs/samsam": "^6.1.1",
-            "diff": "^5.0.0",
-            "nise": "^5.1.1",
-            "supports-color": "^7.2.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "traverse": {
-          "version": "0.6.6",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -109,7 +109,6 @@
     "aws-amplify": "4.3.6",
     "aws-cdk": "1.132.0",
     "aws-cdk-local": "1.65.8",
-    "aws-sdk-mock": "5.7.0",
     "axios-logger": "2.5.0",
     "babel-jest": "27.2.4",
     "babel-loader": "8.2.3",


### PR DESCRIPTION
* poistettu kaikki suorat "aws-sdk"-importit backend-koodista
* vaihdettu aws-sdk:n mockaaminen erilaiseksi, koska vanha tyyli ei toiminut
* poistettu virheellinen importti aws-cdk:hon
* korjattu stubaus yksikkötesteissä; nyt ne eivät oikeasti koske localstackiin enää. Nyt myös stubausta käytetään "oikein" before/beforeEach/afterEach/after-funktioissa
