### PR TITLE
fix: Korjaa tekstien overflowaaminen flexboxeissa

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,7 +5,7 @@
 @layer base {
   body {
     @apply vayla-body-text;
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
     /* For legacy support */
     word-wrap: break-word;
     -ms-word-break: break-all;


### PR DESCRIPTION
Nykyisellään bodyyn on lisätty _overflow-wrap: break-word_. Tämä toimii 99% tapauksista oikein. Jostain syystä flexboxeissa overflow käyttäytyy eritavoin joten tarvitsemme _overflow-wrap: anywhere_. Testailin ja koitin katsoa monessa paikassa toimiiko oikein. Mielestäni toimii.

Esimerkkiä -> https://dev.to/somshekhar/overflow-wrap-in-a-flex-container-35