### PR TITLE
fix: hassu 1103 korjaa indeksoinnin logiikka ja poista estoja BE:stä indeksoinnin toimimiseksi

### DIFF
--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -76,7 +76,8 @@ function adaptJulkaisuPDFPaths(oid: string, aloitusKuulutusPDFS: LocalizedMap<Al
   for (const kieli in aloitusKuulutusPDFS) {
     const pdfs = aloitusKuulutusPDFS[kieli as API.Kieli];
     if (!pdfs) {
-      throw new Error(`adaptJulkaisuPDFPaths: aloitusKuulutusPDFS[${kieli}] määrittelemättä`);
+      result[kieli as API.Kieli] = undefined;
+      continue;
     }
     const aloitusKuulutusPdf: API.AloitusKuulutusPDF = {
       __typename: "AloitusKuulutusPDF",

--- a/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
@@ -18,6 +18,7 @@ import {
   adaptStandardiYhteystiedotByAddingTypename,
 } from "../common";
 import { fileService } from "../../../files/fileService";
+import { cloneDeep } from "lodash";
 
 export function adaptSuunnitteluVaihe(
   oid: string,
@@ -50,7 +51,8 @@ function adaptVuorovaikutukset(
   vuorovaikutukset: Array<Vuorovaikutus> | undefined | null
 ): API.Vuorovaikutus[] | undefined {
   if (vuorovaikutukset && vuorovaikutukset.length > 0) {
-    return vuorovaikutukset.map((vuorovaikutus) => {
+    const vuorovaikutuksetCopy = cloneDeep(vuorovaikutukset);
+    return vuorovaikutuksetCopy.map((vuorovaikutus) => {
       if (!vuorovaikutus.ilmoituksenVastaanottajat) {
         throw new Error("adaptVuorovaikutukset: vuorovaikutus.ilmoituksenVastaanottajat määrittelemättä");
       }
@@ -84,7 +86,8 @@ function adaptVuorovaikutusTilaisuudet(
   vuorovaikutusTilaisuudet: Array<VuorovaikutusTilaisuus> | null | undefined
 ): API.VuorovaikutusTilaisuus[] | undefined {
   if (vuorovaikutusTilaisuudet) {
-    return vuorovaikutusTilaisuudet.map((vuorovaikutusTilaisuus) => {
+    const vuorovaikutusTilaisuudetCopy = cloneDeep(vuorovaikutusTilaisuudet);
+    return vuorovaikutusTilaisuudetCopy.map((vuorovaikutusTilaisuus) => {
       const esitettavatYhteystiedot: StandardiYhteystiedot | undefined = vuorovaikutusTilaisuus.esitettavatYhteystiedot;
       delete vuorovaikutusTilaisuus.esitettavatYhteystiedot;
       const tilaisuus: API.VuorovaikutusTilaisuus = {

--- a/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptSuunnitteluVaihe.ts
@@ -108,16 +108,15 @@ function adaptVuorovaikutusPDFPaths(oid: string, vuorovaikutusPdfs: LocalizedMap
   const result: { [Kieli: string]: API.VuorovaikutusPDF } = {};
   for (const kieli in vuorovaikutusPdfs) {
     const pdfs = vuorovaikutusPdfs[kieli as API.Kieli];
-    if (!pdfs) {
-      throw new Error(`adaptVuorovaikutusPDFPaths: vuorovaikutusPdfs[${kieli}] määrittelemättä`);
+    if (pdfs) {
+      result[kieli] = {
+        __typename: "VuorovaikutusPDF",
+        // getYllapitoPathForProjektiFile molemmat argumentit on määritelty, joten funktio palauttaa ei-undefined arvon
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        kutsuPDFPath: fileService.getYllapitoPathForProjektiFile(oid, pdfs.kutsuPDFPath),
+      };
     }
-    result[kieli] = {
-      __typename: "VuorovaikutusPDF",
-      // getYllapitoPathForProjektiFile molemmat argumentit on määritelty, joten funktio palauttaa ei-undefined arvon
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      kutsuPDFPath: fileService.getYllapitoPathForProjektiFile(oid, pdfs.kutsuPDFPath),
-    };
   }
   return { __typename: "VuorovaikutusPDFt", SUOMI: result[API.Kieli.SUOMI], ...result };
 }

--- a/backend/src/projekti/adapter/adaptToDB/adaptVuorovaikutusToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptVuorovaikutusToSave.ts
@@ -47,7 +47,7 @@ export function adaptVuorovaikutusToSave(
 
     const vuorovaikutusToSave: Vuorovaikutus = {
       vuorovaikutusNumero: vuorovaikutusInput.vuorovaikutusNumero,
-      esitettavatYhteystiedot: adaptStandardiYhteystiedotToSave(vuorovaikutusInput.esitettavatYhteystiedot, true),
+      esitettavatYhteystiedot: adaptStandardiYhteystiedotToSave(vuorovaikutusInput.esitettavatYhteystiedot),
       vuorovaikutusTilaisuudet,
       // Jos vuorovaikutuksen ilmoituksella ei tarvitse olla viranomaisvastaanottajia, muokkaa adaptIlmoituksenVastaanottajatToSavea
       ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajatToSave(vuorovaikutusInput.ilmoituksenVastaanottajat),

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -97,6 +97,13 @@ export class ProjektiAdapter {
       ...fieldsToCopyAsIs
     } = dbProjekti;
 
+    console.log();
+    console.log("adaptProjekti normaali");
+    dbProjekti.vuorovaikutukset?.map((vv) => {
+      console.log(vv.vuorovaikutusTilaisuudet);
+    });
+    console.log();
+
     const apiProjekti: API.Projekti = removeUndefinedFields({
       __typename: "Projekti",
       tallennettu: !!dbProjekti.tallennettu,
@@ -136,6 +143,12 @@ export class ProjektiAdapter {
       kasittelynTila: adaptKasittelynTila(kasittelynTila),
       ...fieldsToCopyAsIs,
     });
+    console.log();
+    console.log("adaptProjekti normaali, after removeUndefinedFields");
+    dbProjekti.vuorovaikutukset?.map((vv) => {
+      console.log(vv.vuorovaikutusTilaisuudet);
+    });
+    console.log();
     if (apiProjekti.tallennettu) {
       applyProjektiStatus(apiProjekti);
     }

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -97,13 +97,6 @@ export class ProjektiAdapter {
       ...fieldsToCopyAsIs
     } = dbProjekti;
 
-    console.log();
-    console.log("adaptProjekti normaali");
-    dbProjekti.vuorovaikutukset?.map((vv) => {
-      console.log(vv.vuorovaikutusTilaisuudet);
-    });
-    console.log();
-
     const apiProjekti: API.Projekti = removeUndefinedFields({
       __typename: "Projekti",
       tallennettu: !!dbProjekti.tallennettu,
@@ -143,12 +136,7 @@ export class ProjektiAdapter {
       kasittelynTila: adaptKasittelynTila(kasittelynTila),
       ...fieldsToCopyAsIs,
     });
-    console.log();
-    console.log("adaptProjekti normaali, after removeUndefinedFields");
-    dbProjekti.vuorovaikutukset?.map((vv) => {
-      console.log(vv.vuorovaikutusTilaisuudet);
-    });
-    console.log();
+
     if (apiProjekti.tallennettu) {
       applyProjektiStatus(apiProjekti);
     }

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -40,6 +40,12 @@ import { adaptSuunnitteluSopimusJulkaisuJulkinen } from "./adaptToAPI";
 
 class ProjektiAdapterJulkinen {
   public adaptProjekti(dbProjekti: DBProjekti): API.ProjektiJulkinen | undefined {
+    console.log();
+    console.log("adaptProjekti (julkinen)");
+    dbProjekti.vuorovaikutukset?.map((vv) => {
+      console.log(vv.vuorovaikutusTilaisuudet);
+    });
+    console.log();
     if (!dbProjekti.velho) {
       throw new Error("adaptProjekti: dbProjekti.velho määrittelemättä");
     }

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -41,12 +41,6 @@ import { cloneDeep } from "lodash";
 
 class ProjektiAdapterJulkinen {
   public adaptProjekti(dbProjekti: DBProjekti): API.ProjektiJulkinen | undefined {
-    console.log();
-    console.log("adaptProjekti (julkinen)");
-    dbProjekti.vuorovaikutukset?.map((vv) => {
-      console.log(vv.vuorovaikutusTilaisuudet);
-    });
-    console.log();
     if (!dbProjekti.velho) {
       throw new Error("adaptProjekti: dbProjekti.velho määrittelemättä");
     }

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -37,6 +37,7 @@ import {
   adaptStandardiYhteystiedotLisaamattaProjaria,
 } from "../../util/adaptStandardiYhteystiedot";
 import { adaptSuunnitteluSopimusJulkaisuJulkinen } from "./adaptToAPI";
+import { cloneDeep } from "lodash";
 
 class ProjektiAdapterJulkinen {
   public adaptProjekti(dbProjekti: DBProjekti): API.ProjektiJulkinen | undefined {
@@ -403,7 +404,8 @@ function adaptVuorovaikutusTilaisuudet(
   vuorovaikutusTilaisuudet: Array<VuorovaikutusTilaisuus>,
   dbProjekti: DBProjekti
 ): API.VuorovaikutusTilaisuusJulkinen[] {
-  return vuorovaikutusTilaisuudet.map((vuorovaikutusTilaisuus) => {
+  const vuorovaikutusTilaisuudetCopy = cloneDeep(vuorovaikutusTilaisuudet);
+  return vuorovaikutusTilaisuudetCopy.map((vuorovaikutusTilaisuus) => {
     const esitettavatYhteystiedot: StandardiYhteystiedot | undefined = vuorovaikutusTilaisuus.esitettavatYhteystiedot;
     delete vuorovaikutusTilaisuus.esitettavatYhteystiedot;
     const tilaisuus: API.VuorovaikutusTilaisuusJulkinen = {

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -370,9 +370,6 @@ function adaptVuorovaikutukset(dbProjekti: DBProjekti): API.VuorovaikutusJulkine
       if (!vuorovaikutus.vuorovaikutusTilaisuudet) {
         throw new Error("adaptVuorovaikutukset: vuorovaikutus.vuorovaikutusTilaisuudet määrittelmättä");
       }
-      if (!vuorovaikutus.vuorovaikutusPDFt) {
-        throw new Error("adaptVuorovaikutukset: vuorovaikutus.vuorovaikutusPDFt määrittelmättä");
-      }
       // tarkistettu jo, että vuorovaikutusJulkaisuPaiva määritelty
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -462,9 +459,15 @@ function isKuulutusNahtavillaVaiheOver(
   return !nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva || parseDate(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva).isBefore(dayjs());
 }
 
-function adaptVuorovaikutusPDFPaths(oid: string, vuorovaikutuspdfs: LocalizedMap<VuorovaikutusPDF>): API.VuorovaikutusPDFt {
+function adaptVuorovaikutusPDFPaths(
+  oid: string,
+  vuorovaikutuspdfs: LocalizedMap<VuorovaikutusPDF> | undefined
+): API.VuorovaikutusPDFt | undefined {
+  if (!vuorovaikutuspdfs) {
+    return undefined;
+  }
   const result: Partial<API.VuorovaikutusPDFt> = {};
-  if (!vuorovaikutuspdfs || !vuorovaikutuspdfs[API.Kieli.SUOMI]) {
+  if (vuorovaikutuspdfs && !vuorovaikutuspdfs[API.Kieli.SUOMI]) {
     throw new Error(`adaptVuorovaikutusPDFPaths: vuorovaikutuspdfs.${API.Kieli.SUOMI} määrittelemättä`);
   }
   for (const kieli in vuorovaikutuspdfs) {

--- a/backend/src/projektiSearch/projektiSearchService.ts
+++ b/backend/src/projektiSearch/projektiSearchService.ts
@@ -32,32 +32,14 @@ const projektiSarakeToField: Record<ProjektiSarake, string> = {
 
 class ProjektiSearchService {
   async indexProjekti(projekti: DBProjekti) {
-    console.log();
-    console.log("indexProjektiALKU");
-    projekti.vuorovaikutukset?.map((vv) => {
-      console.log(vv.vuorovaikutusTilaisuudet);
-    });
-    console.log();
     const projektiToIndex = adaptProjektiToIndex(projekti);
     log.info("Index projekti", { oid: projekti.oid });
     await openSearchClientYllapito.putDocument(projekti.oid, projektiToIndex);
 
     projekti.tallennettu = true;
-    console.log();
-    console.log("indexProjekti");
-    projekti.vuorovaikutukset?.map((vv) => {
-      console.log(vv.vuorovaikutusTilaisuudet);
-    });
-    console.log();
+
     const apiProjekti = projektiAdapterJulkinen.adaptProjekti(projekti);
-    console.log();
-    console.log("afterAdapting Projekti (julkinen)");
-    console.log(
-      apiProjekti?.suunnitteluVaihe?.vuorovaikutukset?.map((vv) => {
-        console.log(vv.vuorovaikutusTilaisuudet);
-      })
-    );
-    console.log();
+
     if (apiProjekti) {
       for (const kieli of Object.values(Kieli)) {
         const projektiJulkinenToIndex = adaptProjektiToJulkinenIndex(apiProjekti, kieli);

--- a/backend/src/projektiSearch/projektiSearchService.ts
+++ b/backend/src/projektiSearch/projektiSearchService.ts
@@ -32,12 +32,32 @@ const projektiSarakeToField: Record<ProjektiSarake, string> = {
 
 class ProjektiSearchService {
   async indexProjekti(projekti: DBProjekti) {
+    console.log();
+    console.log("indexProjektiALKU");
+    projekti.vuorovaikutukset?.map((vv) => {
+      console.log(vv.vuorovaikutusTilaisuudet);
+    });
+    console.log();
     const projektiToIndex = adaptProjektiToIndex(projekti);
     log.info("Index projekti", { oid: projekti.oid });
     await openSearchClientYllapito.putDocument(projekti.oid, projektiToIndex);
 
     projekti.tallennettu = true;
+    console.log();
+    console.log("indexProjekti");
+    projekti.vuorovaikutukset?.map((vv) => {
+      console.log(vv.vuorovaikutusTilaisuudet);
+    });
+    console.log();
     const apiProjekti = projektiAdapterJulkinen.adaptProjekti(projekti);
+    console.log();
+    console.log("afterAdapting Projekti (julkinen)");
+    console.log(
+      apiProjekti?.suunnitteluVaihe?.vuorovaikutukset?.map((vv) => {
+        console.log(vv.vuorovaikutusTilaisuudet);
+      })
+    );
+    console.log();
     if (apiProjekti) {
       for (const kieli of Object.values(Kieli)) {
         const projektiJulkinenToIndex = adaptProjektiToJulkinenIndex(apiProjekti, kieli);

--- a/backend/test/projektiSearch/projektiSearchService2.test.ts
+++ b/backend/test/projektiSearch/projektiSearchService2.test.ts
@@ -33,7 +33,7 @@ describe("ProjektiSearchService", () => {
     sandbox.restore();
   });
 
-  it.only("should index projekti correctly", async () => {
+  it("should index projekti correctly", async () => {
     await projektiSearchService.indexProjekti(projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi);
     expect(openSearchClientJulkinenSuomiStub.calledWith("1.2.246.578.5.1.2724991921.3534113206", julkinenIndeksi));
     expect(openSearchClientYllapitoStub.called);
@@ -41,7 +41,7 @@ describe("ProjektiSearchService", () => {
 });
 
 const julkinenIndeksi: Omit<ProjektiDocument, "oid"> = {
-  nimi: "Elinan testiprojekti 0709",
+  nimi: "Vastuun testiprojekti 0709",
   hankkeenKuvaus: "asdgdrgh",
   projektiTyyppi: ProjektiTyyppi.TIE,
   kunnat: ["Ilmajoki", " Seinäjoki"],
@@ -75,7 +75,7 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
       viranomaiset: [
         {
           nimi: IlmoitettavaViranomainen.VAYLAVIRASTO,
-          sahkoposti: "kirjaamo@vayla.fi",
+          sahkoposti: "email@vayla.fi",
           lahetetty: undefined,
         },
       ],
@@ -93,16 +93,16 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
       },
       yhteystiedot: [
         {
-          etunimi: "Elina",
-          sukunimi: "Manninen",
+          etunimi: "Vastuu",
+          sukunimi: "Henkilo",
           organisaatio: "Väylävirasto",
           puhelinnumero: "0291234567",
-          sahkoposti: "elina.manninen@vayla.fi",
+          sahkoposti: "vastuu.henkilo@vayla.fi",
           titteli: undefined,
         },
       ],
       velho: {
-        nimi: "Elinan testiprojekti 0709",
+        nimi: "Vastuun testiprojekti 0709",
         tyyppi: ProjektiTyyppi.TIE,
         kuvaus: undefined,
         vaylamuoto: ["tie"],
@@ -111,9 +111,9 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
         suunnittelustaVastaavaViranomainen: Viranomainen.VAYLAVIRASTO,
         toteuttavaOrganisaatio: undefined,
         vastuuhenkilonNimi: undefined,
-        vastuuhenkilonEmail: "elina.manninen@vayla.fi",
+        vastuuhenkilonEmail: "vastuu.henkilo@vayla.fi",
         varahenkilonNimi: undefined,
-        varahenkilonEmail: "marika.ojanen@vayla.fi",
+        varahenkilonEmail: "vara.tyyppi@vayla.fi",
         kunnat: ["Ilmajoki", " Seinäjoki"],
         maakunnat: ["Uusimaa"],
         linkki: undefined,
@@ -142,7 +142,7 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
         viranomaiset: [
           {
             nimi: IlmoitettavaViranomainen.VAYLAVIRASTO,
-            sahkoposti: "kirjaamo@vayla.fi",
+            sahkoposti: "email@vayla.fi",
             lahetetty: "2022-10-11T16:17",
           },
         ],
@@ -205,7 +205,7 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
         viranomaiset: [
           {
             nimi: IlmoitettavaViranomainen.VAYLAVIRASTO,
-            sahkoposti: "kirjaamo@vayla.fi",
+            sahkoposti: "email@vayla.fi",
             lahetetty: undefined,
           },
         ],
@@ -242,7 +242,7 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
   jatkoPaatos2Vaihe: undefined,
   jatkoPaatos2VaiheJulkaisut: undefined,
   velho: {
-    nimi: "Elinan testiprojekti 0709",
+    nimi: "Vastuun testiprojekti 0709",
     tyyppi: ProjektiTyyppi.TIE,
     kuvaus: undefined,
     vaylamuoto: ["tie"],
@@ -251,9 +251,9 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
     suunnittelustaVastaavaViranomainen: Viranomainen.VAYLAVIRASTO,
     toteuttavaOrganisaatio: undefined,
     vastuuhenkilonNimi: undefined,
-    vastuuhenkilonEmail: "elina.manninen@vayla.fi",
+    vastuuhenkilonEmail: "vastuu.henkilo@vayla.fi",
     varahenkilonNimi: undefined,
-    varahenkilonEmail: "marika.ojanen@vayla.fi",
+    varahenkilonEmail: "vara.tyyppi@vayla.fi",
     kunnat: ["Ilmajoki", " Seinäjoki"],
     maakunnat: ["Uusimaa"],
     linkki: undefined,
@@ -263,9 +263,9 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
       tyyppi: KayttajaTyyppi.PROJEKTIPAALLIKKO,
       kayttajatunnus: "L036511",
       puhelinnumero: "0291234567",
-      email: "elina.manninen@vayla.fi",
+      email: "vastuu.henkilo@vayla.fi",
       organisaatio: "Väylävirasto",
-      nimi: "Manninen, Elina",
+      nimi: "Henkilo, Vastuu",
       muokattavissa: false,
       yleinenYhteystieto: undefined,
     },
@@ -273,9 +273,9 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
       tyyppi: KayttajaTyyppi.VARAHENKILO,
       kayttajatunnus: "L658321",
       puhelinnumero: "0291234567",
-      email: "marika.ojanen@vayla.fi",
+      email: "vara.tyyppi@vayla.fi",
       organisaatio: "Väylävirasto",
-      nimi: "Ojanen, Marika",
+      nimi: "Tyyppi, Vara",
       muokattavissa: false,
       yleinenYhteystieto: undefined,
     },
@@ -283,7 +283,7 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
       tyyppi: KayttajaTyyppi.VARAHENKILO,
       kayttajatunnus: "A000112",
       puhelinnumero: "0299879867876",
-      email: "mikko.haapamki@cgi.com",
+      email: "joku.hlo@cgi.com",
       organisaatio: "CGI Suomi Oy",
       nimi: "Hassu, A-tunnus1",
       muokattavissa: true,

--- a/backend/test/projektiSearch/projektiSearchService2.test.ts
+++ b/backend/test/projektiSearch/projektiSearchService2.test.ts
@@ -1,0 +1,297 @@
+import { describe, it } from "mocha";
+import { openSearchClientJulkinen, openSearchClientYllapito } from "../../src/projektiSearch/openSearchClient";
+import { projektiSearchService } from "../../src/projektiSearch/projektiSearchService";
+import * as sinon from "sinon";
+import {
+  AloitusKuulutusTila,
+  IlmoitettavaViranomainen,
+  KaytettavaPalvelu,
+  KayttajaTyyppi,
+  Kieli,
+  ProjektiTyyppi,
+  Status,
+  Viranomainen,
+  VuorovaikutusTilaisuusTyyppi,
+} from "../../../common/graphql/apiModel";
+import { DBProjekti } from "../../src/database/model";
+import { ProjektiDocument } from "../../src/projektiSearch/projektiSearchAdapter";
+import { parseDate } from "../../src/util/dateUtil";
+
+const sandbox = require("sinon").createSandbox();
+
+const { expect } = require("chai");
+
+describe("ProjektiSearchService", () => {
+  let openSearchClientYllapitoStub: sinon.SinonStub;
+  let openSearchClientJulkinenSuomiStub: sinon.SinonStub;
+  beforeEach(() => {
+    openSearchClientYllapitoStub = sandbox.stub(openSearchClientYllapito, "putDocument");
+    openSearchClientJulkinenSuomiStub = sandbox.stub(openSearchClientJulkinen["SUOMI"], "putDocument");
+  });
+  afterEach(() => {
+    sandbox.reset();
+    sandbox.restore();
+  });
+
+  it("should index projekti correctly", async () => {
+    await projektiSearchService.indexProjekti(projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi);
+    expect(openSearchClientJulkinenSuomiStub.calledWith("1.2.246.578.5.1.2724991921.3534113206", julkinenIndeksi));
+    expect(openSearchClientYllapitoStub.called);
+  });
+});
+
+const julkinenIndeksi: Omit<ProjektiDocument, "oid"> = {
+  nimi: "Elinan testiprojekti 0709",
+  hankkeenKuvaus: "asdgdrgh",
+  projektiTyyppi: ProjektiTyyppi.TIE,
+  kunnat: ["Ilmajoki", " Seinäjoki"],
+  maakunnat: ["Uusimaa"],
+  vaihe: Status.SUUNNITTELU,
+  viimeinenTilaisuusPaattyy: "2022-10-28 17:18",
+  vaylamuoto: ["tie"],
+  paivitetty: "2022-10-12T14:48:10+03:00",
+  publishTimestamp: parseDate("2022-10-10").format(),
+};
+
+const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
+  oid: "1.2.246.578.5.1.2724991921.3534113206",
+  paivitetty: "2022-10-12T14:48:10+03:00",
+  muistiinpano: "",
+  vaihe: undefined,
+  tyyppi: ProjektiTyyppi.TIE,
+  suunnittelustaVastaavaViranomainen: undefined,
+  aloitusKuulutus: {
+    kuulutusPaiva: "2022-10-10",
+    siirtyySuunnitteluVaiheeseen: "2022-11-09",
+    hankkeenKuvaus: {
+      SUOMI: "asdgdrgh",
+      RUOTSI: undefined,
+      SAAME: undefined,
+    },
+    kuulutusYhteystiedot: undefined,
+    palautusSyy: undefined,
+    ilmoituksenVastaanottajat: {
+      kunnat: [],
+      viranomaiset: [
+        {
+          nimi: IlmoitettavaViranomainen.VAYLAVIRASTO,
+          sahkoposti: "kirjaamo@vayla.fi",
+          lahetetty: undefined,
+        },
+      ],
+    },
+  },
+  aloitusKuulutusJulkaisut: [
+    {
+      id: 1,
+      kuulutusPaiva: "2022-10-10",
+      siirtyySuunnitteluVaiheeseen: "2022-11-09",
+      hankkeenKuvaus: {
+        SUOMI: "asdgdrgh",
+        RUOTSI: undefined,
+        SAAME: undefined,
+      },
+      yhteystiedot: [
+        {
+          etunimi: "Elina",
+          sukunimi: "Manninen",
+          organisaatio: "Väylävirasto",
+          puhelinnumero: "0291234567",
+          sahkoposti: "elina.manninen@vayla.fi",
+          titteli: undefined,
+        },
+      ],
+      velho: {
+        nimi: "Elinan testiprojekti 0709",
+        tyyppi: ProjektiTyyppi.TIE,
+        kuvaus: undefined,
+        vaylamuoto: ["tie"],
+        asiatunnusVayla: undefined,
+        asiatunnusELY: undefined,
+        suunnittelustaVastaavaViranomainen: Viranomainen.VAYLAVIRASTO,
+        toteuttavaOrganisaatio: undefined,
+        vastuuhenkilonNimi: undefined,
+        vastuuhenkilonEmail: "elina.manninen@vayla.fi",
+        varahenkilonNimi: undefined,
+        varahenkilonEmail: "marika.ojanen@vayla.fi",
+        kunnat: ["Ilmajoki", " Seinäjoki"],
+        maakunnat: ["Uusimaa"],
+        linkki: undefined,
+      },
+      suunnitteluSopimus: undefined,
+      kielitiedot: {
+        ensisijainenKieli: Kieli.SUOMI,
+        toissijainenKieli: undefined,
+        projektinNimiVieraskielella: undefined,
+      },
+      aloituskuulutusPDFt: {
+        SUOMI: {
+          aloituskuulutusPDFPath:
+            "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2724991921.3534113206/aloituskuulutus/T412 Aloituskuulutus.pdf",
+          aloituskuulutusIlmoitusPDFPath:
+            "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2724991921.3534113206/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+        },
+        RUOTSI: undefined,
+        SAAME: undefined,
+      },
+      tila: AloitusKuulutusTila.HYVAKSYTTY,
+      muokkaaja: "A000112",
+      hyvaksyja: "A000112",
+      ilmoituksenVastaanottajat: {
+        kunnat: [],
+        viranomaiset: [
+          {
+            nimi: IlmoitettavaViranomainen.VAYLAVIRASTO,
+            sahkoposti: "kirjaamo@vayla.fi",
+            lahetetty: "2022-10-11T16:17",
+          },
+        ],
+      },
+    },
+  ],
+  suunnitteluSopimus: undefined,
+  vuorovaikutukset: [
+    {
+      vuorovaikutusNumero: 1,
+      julkinen: true,
+      vuorovaikutusTilaisuudet: [
+        {
+          tyyppi: VuorovaikutusTilaisuusTyyppi.VERKOSSA,
+          nimi: undefined,
+          paivamaara: "2022-10-28",
+          alkamisAika: "16:18",
+          paattymisAika: "17:18",
+          kaytettavaPalvelu: KaytettavaPalvelu.TEAMS,
+          linkki: "http://www.fi",
+          paikka: undefined,
+          osoite: undefined,
+          postinumero: undefined,
+          postitoimipaikka: undefined,
+          Saapumisohjeet: undefined,
+          esitettavatYhteystiedot: undefined,
+        },
+      ],
+      vuorovaikutusJulkaisuPaiva: "2022-10-12",
+      kysymyksetJaPalautteetViimeistaan: "2022-10-12",
+      videot: [],
+      suunnittelumateriaali: {
+        nimi: "",
+        url: "",
+      },
+      esitettavatYhteystiedot: {
+        yhteysTiedot: undefined,
+        yhteysHenkilot: ["L036511"],
+      },
+      ilmoituksenVastaanottajat: {
+        kunnat: [],
+        viranomaiset: [
+          {
+            nimi: IlmoitettavaViranomainen.VAYLAVIRASTO,
+            sahkoposti: "kirjaamo@vayla.fi",
+            lahetetty: undefined,
+          },
+        ],
+      },
+      esittelyaineistot: undefined,
+      suunnitelmaluonnokset: undefined,
+      vuorovaikutusPDFt: {
+        SUOMI: {
+          kutsuPDFPath:
+            "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2724991921.3534113206/suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf",
+        },
+        RUOTSI: undefined,
+        SAAME: undefined,
+      },
+    },
+  ],
+  suunnitteluVaihe: {
+    hankkeenKuvaus: {
+      SUOMI: "asdgdrgh",
+      RUOTSI: undefined,
+      SAAME: undefined,
+    },
+    arvioSeuraavanVaiheenAlkamisesta: "Pian",
+    suunnittelunEteneminenJaKesto: "",
+    julkinen: true,
+    palautteidenVastaanottajat: undefined,
+  },
+  nahtavillaoloVaihe: undefined,
+  nahtavillaoloVaiheJulkaisut: undefined,
+  hyvaksymisPaatosVaihe: undefined,
+  hyvaksymisPaatosVaiheJulkaisut: undefined,
+  jatkoPaatos1Vaihe: undefined,
+  jatkoPaatos1VaiheJulkaisut: undefined,
+  jatkoPaatos2Vaihe: undefined,
+  jatkoPaatos2VaiheJulkaisut: undefined,
+  velho: {
+    nimi: "Elinan testiprojekti 0709",
+    tyyppi: ProjektiTyyppi.TIE,
+    kuvaus: undefined,
+    vaylamuoto: ["tie"],
+    asiatunnusVayla: undefined,
+    asiatunnusELY: undefined,
+    suunnittelustaVastaavaViranomainen: Viranomainen.VAYLAVIRASTO,
+    toteuttavaOrganisaatio: undefined,
+    vastuuhenkilonNimi: undefined,
+    vastuuhenkilonEmail: "elina.manninen@vayla.fi",
+    varahenkilonNimi: undefined,
+    varahenkilonEmail: "marika.ojanen@vayla.fi",
+    kunnat: ["Ilmajoki", " Seinäjoki"],
+    maakunnat: ["Uusimaa"],
+    linkki: undefined,
+  },
+  kayttoOikeudet: [
+    {
+      tyyppi: KayttajaTyyppi.PROJEKTIPAALLIKKO,
+      kayttajatunnus: "L036511",
+      puhelinnumero: "0291234567",
+      email: "elina.manninen@vayla.fi",
+      organisaatio: "Väylävirasto",
+      nimi: "Manninen, Elina",
+      muokattavissa: false,
+      yleinenYhteystieto: undefined,
+    },
+    {
+      tyyppi: KayttajaTyyppi.VARAHENKILO,
+      kayttajatunnus: "L658321",
+      puhelinnumero: "0291234567",
+      email: "marika.ojanen@vayla.fi",
+      organisaatio: "Väylävirasto",
+      nimi: "Ojanen, Marika",
+      muokattavissa: false,
+      yleinenYhteystieto: undefined,
+    },
+    {
+      tyyppi: KayttajaTyyppi.VARAHENKILO,
+      kayttajatunnus: "A000112",
+      puhelinnumero: "0299879867876",
+      email: "mikko.haapamki@cgi.com",
+      organisaatio: "CGI Suomi Oy",
+      nimi: "Hassu, A-tunnus1",
+      muokattavissa: true,
+      yleinenYhteystieto: undefined,
+    },
+  ],
+  tallennettu: true,
+  euRahoitus: false,
+  liittyvatSuunnitelmat: [],
+  kielitiedot: {
+    ensisijainenKieli: Kieli.SUOMI,
+    toissijainenKieli: undefined,
+    projektinNimiVieraskielella: undefined,
+  },
+  kasittelynTila: {
+    hyvaksymispaatos: {
+      paatoksenPvm: "2022-10-08",
+      asianumero: "1232354sdsdtf",
+    },
+    ensimmainenJatkopaatos: {
+      paatoksenPvm: undefined,
+      asianumero: undefined,
+    },
+    toinenJatkopaatos: {
+      paatoksenPvm: undefined,
+      asianumero: undefined,
+    },
+  },
+};

--- a/backend/test/projektiSearch/projektiSearchService2.test.ts
+++ b/backend/test/projektiSearch/projektiSearchService2.test.ts
@@ -33,7 +33,7 @@ describe("ProjektiSearchService", () => {
     sandbox.restore();
   });
 
-  it("should index projekti correctly", async () => {
+  it.only("should index projekti correctly", async () => {
     await projektiSearchService.indexProjekti(projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi);
     expect(openSearchClientJulkinenSuomiStub.calledWith("1.2.246.578.5.1.2724991921.3534113206", julkinenIndeksi));
     expect(openSearchClientYllapitoStub.called);
@@ -169,6 +169,24 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
           postitoimipaikka: undefined,
           Saapumisohjeet: undefined,
           esitettavatYhteystiedot: undefined,
+        },
+        {
+          tyyppi: VuorovaikutusTilaisuusTyyppi.SOITTOAIKA,
+          nimi: undefined,
+          paivamaara: "2022-10-27",
+          alkamisAika: "16:18",
+          paattymisAika: "17:18",
+          kaytettavaPalvelu: undefined,
+          linkki: undefined,
+          paikka: undefined,
+          osoite: undefined,
+          postinumero: undefined,
+          postitoimipaikka: undefined,
+          Saapumisohjeet: undefined,
+          esitettavatYhteystiedot: {
+            yhteysHenkilot: ["L036511"],
+            yhteysTiedot: [],
+          },
         },
       ],
       vuorovaikutusJulkaisuPaiva: "2022-10-12",


### PR DESCRIPTION
Raportoitu bugi oli, että Vuorovaikutus-tagia ei näy kansalaispuolella silloin, kun pitäisi.
No, se johtui siitä, että indeksiin ei koskaan tullut sitä viimeinenTilaisuusPaattyy-arvoa.
Mikä johtui siitä, että indeksöiminen kaatui kesken Erroriin, koska oli jotain puuttuvia tietoja.
Joten nyt poistin sieltä niitä pakotuksia tietyille tiedoille, joita ei voi olla vielä siinä kohtaa kun indeksöinti tehdään.

MUTTA, edelleen indeksöinti kaatuu, jos projektilla ei ole velho-tiedoissa SEKÄ kuntaa ETTÄ maakuntaa. Eli testatessa sitten nämä hommat kuntoon hox pox.

Lisäksi korjasin bugin, joka vaati, että vuorovaikutuksella olisi muitakin yhteistietoja kuin se yksi pakollinen eli projari. Ts. Vuorovaikutuksen yhteystiedot (ne standardiyhteystiedot) voi olla undefined. (Sen sijaan VuorovaikutusTilaisuuden ei voi.)

Tein uuden BE-testin, joka sai/saa kiinni tuon em. bugin. Mutta siinä olevassa projektidatassa on siis sekä kunta että maakunta.