### PR TITLE
feat: virkamiehen projektihaussa haetaan erikseen epäaktiiviset projektit (BE+FE)

### DIFF
--- a/backend/src/projektiSearch/projektiSearchAdapter.ts
+++ b/backend/src/projektiSearch/projektiSearchAdapter.ts
@@ -17,6 +17,7 @@ export type ProjektiDocument = {
   suunnittelustaVastaavaViranomainen?: API.Viranomainen;
   vaihe?: API.Status;
   viimeinenTilaisuusPaattyy?: string;
+  aktiivinen?: boolean;
   projektiTyyppi?: API.ProjektiTyyppi;
   paivitetty?: string;
   projektipaallikko?: string;
@@ -42,6 +43,9 @@ export function adaptProjektiToIndex(projekti: DBProjekti): Partial<ProjektiDocu
       .filter((value) => value.tyyppi == API.KayttajaTyyppi.PROJEKTIPAALLIKKO)
       .map((value) => safeTrim(value.nimi))
       .pop(),
+    aktiivinen: ![API.Status.EPAAKTIIVINEN_1, API.Status.EPAAKTIIVINEN_2, API.Status.EPAAKTIIVINEN_3].includes(
+      apiProjekti.status as API.Status
+    ),
     paivitetty: projekti.paivitetty || dayjs().format(),
     muokkaajat: projekti.kayttoOikeudet.map((value) => value.kayttajatunnus),
   };

--- a/backend/src/projektiSearch/projektiSearchService.ts
+++ b/backend/src/projektiSearch/projektiSearchService.ts
@@ -179,7 +179,7 @@ class ProjektiSearchService {
     let maara = 0;
     log.info("epäaktiiviset " + epaaktiiviset);
     epaaktiiviset.aggregations.statukset.buckets.forEach((bucket: any) => {
-      if (bucket.key == Status.EPAAKTIIVINEN) {
+      if ([Status.EPAAKTIIVINEN_1, Status.EPAAKTIIVINEN_2, Status.EPAAKTIIVINEN_3].includes(bucket.key)) {
         maara = maara + bucket.doc_count;
       }
     });
@@ -293,7 +293,9 @@ class ProjektiSearchService {
       if (vaiheParam.indexOf(Status.EI_JULKAISTU) >= 0) {
         vaiheParam.push(Status.EI_JULKAISTU_PROJEKTIN_HENKILOT);
       }
-      const eiEpaaktiivisiaTiloja = vaiheParam.filter((tila) => tila === Status.EPAAKTIIVINEN);
+      const eiEpaaktiivisiaTiloja = vaiheParam.filter(
+        (tila) => ![Status.EPAAKTIIVINEN_1, Status.EPAAKTIIVINEN_2, Status.EPAAKTIIVINEN_3].includes(tila)
+      );
       if (eiEpaaktiivisiaTiloja.length > 0) {
         queries.push({ terms: { "vaihe.keyword": vaiheParam } });
       }
@@ -305,7 +307,7 @@ class ProjektiSearchService {
     if (epaaktiiviset) {
       allQueries.push({
         terms: {
-          "vaihe.keyword": [Status.EPAAKTIIVINEN],
+          "vaihe.keyword": [Status.EPAAKTIIVINEN_1, Status.EPAAKTIIVINEN_2, Status.EPAAKTIIVINEN_3],
         },
       });
     }
@@ -318,7 +320,7 @@ class ProjektiSearchService {
       obj.bool.must_not = [
         {
           terms: {
-            "vaihe.keyword": [Status.EPAAKTIIVINEN],
+            "vaihe.keyword": [Status.EPAAKTIIVINEN_1, Status.EPAAKTIIVINEN_2, Status.EPAAKTIIVINEN_3],
           },
         },
       ];

--- a/backend/test/projektiSearch/__snapshots__/dynamoDBStreamHandler.test.ts.snap
+++ b/backend/test/projektiSearch/__snapshots__/dynamoDBStreamHandler.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`dynamoDBStreamHandler should index new projektis successfully 1`] = `
 Object {
+  "aktiivinen": true,
   "asiatunnus": "ELY/2/2022",
   "maakunnat": Array [
     1,
@@ -73,6 +74,7 @@ Object {
 
 exports[`dynamoDBStreamHandler should index projekti updates successfully 1`] = `
 Object {
+  "aktiivinen": true,
   "asiatunnus": "ELY/2/2022",
   "maakunnat": Array [
     1,

--- a/backend/test/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
+++ b/backend/test/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
@@ -43,6 +43,15 @@ Object {
         },
         Object {
           "terms": Object {
+            "vaihe.keyword": Array [
+              "EI_JULKAISTU",
+              "SUUNNITTELU",
+              "EI_JULKAISTU_PROJEKTIN_HENKILOT",
+            ],
+          },
+        },
+        Object {
+          "terms": Object {
             "suunnittelustaVastaavaViranomainen.keyword": Array [
               "VAYLAVIRASTO",
               "UUDENMAAN_ELY",
@@ -59,7 +68,9 @@ Object {
         Object {
           "terms": Object {
             "vaihe.keyword": Array [
-              "EPAAKTIIVINEN",
+              "EPAAKTIIVINEN_1",
+              "EPAAKTIIVINEN_2",
+              "EPAAKTIIVINEN_3",
             ],
           },
         },
@@ -132,6 +143,15 @@ Object {
         },
         Object {
           "terms": Object {
+            "vaihe.keyword": Array [
+              "EI_JULKAISTU",
+              "SUUNNITTELU",
+              "EI_JULKAISTU_PROJEKTIN_HENKILOT",
+            ],
+          },
+        },
+        Object {
+          "terms": Object {
             "suunnittelustaVastaavaViranomainen.keyword": Array [
               "VAYLAVIRASTO",
               "UUDENMAAN_ELY",
@@ -141,7 +161,9 @@ Object {
         Object {
           "terms": Object {
             "vaihe.keyword": Array [
-              "EPAAKTIIVINEN",
+              "EPAAKTIIVINEN_1",
+              "EPAAKTIIVINEN_2",
+              "EPAAKTIIVINEN_3",
             ],
           },
         },
@@ -150,7 +172,9 @@ Object {
         Object {
           "terms": Object {
             "vaihe.keyword": Array [
-              "EPAAKTIIVINEN",
+              "EPAAKTIIVINEN_1",
+              "EPAAKTIIVINEN_2",
+              "EPAAKTIIVINEN_3",
             ],
           },
         },
@@ -179,7 +203,9 @@ Object {
         Object {
           "terms": Object {
             "vaihe.keyword": Array [
-              "EPAAKTIIVINEN",
+              "EPAAKTIIVINEN_1",
+              "EPAAKTIIVINEN_2",
+              "EPAAKTIIVINEN_3",
             ],
           },
         },

--- a/backend/test/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
+++ b/backend/test/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
@@ -43,15 +43,6 @@ Object {
         },
         Object {
           "terms": Object {
-            "vaihe.keyword": Array [
-              "EI_JULKAISTU",
-              "SUUNNITTELU",
-              "EI_JULKAISTU_PROJEKTIN_HENKILOT",
-            ],
-          },
-        },
-        Object {
-          "terms": Object {
             "suunnittelustaVastaavaViranomainen.keyword": Array [
               "VAYLAVIRASTO",
               "UUDENMAAN_ELY",
@@ -61,6 +52,15 @@ Object {
         Object {
           "term": Object {
             "projektiTyyppi.keyword": "TIE",
+          },
+        },
+      ],
+      "must_not": Array [
+        Object {
+          "terms": Object {
+            "vaihe.keyword": Array [
+              "EPAAKTIIVINEN",
+            ],
           },
         },
       ],
@@ -132,18 +132,25 @@ Object {
         },
         Object {
           "terms": Object {
-            "vaihe.keyword": Array [
-              "EI_JULKAISTU",
-              "SUUNNITTELU",
-              "EI_JULKAISTU_PROJEKTIN_HENKILOT",
+            "suunnittelustaVastaavaViranomainen.keyword": Array [
+              "VAYLAVIRASTO",
+              "UUDENMAAN_ELY",
             ],
           },
         },
         Object {
           "terms": Object {
-            "suunnittelustaVastaavaViranomainen.keyword": Array [
-              "VAYLAVIRASTO",
-              "UUDENMAAN_ELY",
+            "vaihe.keyword": Array [
+              "EPAAKTIIVINEN",
+            ],
+          },
+        },
+      ],
+      "must_not": Array [
+        Object {
+          "terms": Object {
+            "vaihe.keyword": Array [
+              "EPAAKTIIVINEN",
             ],
           },
         },
@@ -165,6 +172,15 @@ Object {
             "publishTimestamp": Object {
               "lte": "now",
             },
+          },
+        },
+      ],
+      "must_not": Array [
+        Object {
+          "terms": Object {
+            "vaihe.keyword": Array [
+              "EPAAKTIIVINEN",
+            ],
           },
         },
       ],

--- a/backend/test/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
+++ b/backend/test/projektiSearch/__snapshots__/projektiSearchService.test.ts.snap
@@ -63,15 +63,9 @@ Object {
             "projektiTyyppi.keyword": "TIE",
           },
         },
-      ],
-      "must_not": Array [
         Object {
-          "terms": Object {
-            "vaihe.keyword": Array [
-              "EPAAKTIIVINEN_1",
-              "EPAAKTIIVINEN_2",
-              "EPAAKTIIVINEN_3",
-            ],
+          "term": Object {
+            "aktiivinen": true,
           },
         },
       ],
@@ -96,9 +90,17 @@ Object {
 exports[`ProjektiSearchService should handle query parameters successfully 2`] = `
 Object {
   "aggs": Object {
-    "projektiTyypit": Object {
+    "aktiivinen": Object {
+      "aggs": Object {
+        "projektiTyyppi": Object {
+          "terms": Object {
+            "field": "projektiTyyppi.keyword",
+            "size": 10,
+          },
+        },
+      },
       "terms": Object {
-        "field": "projektiTyyppi.keyword",
+        "field": "aktiivinen",
         "size": 10,
       },
     },
@@ -158,30 +160,9 @@ Object {
             ],
           },
         },
-        Object {
-          "terms": Object {
-            "vaihe.keyword": Array [
-              "EPAAKTIIVINEN_1",
-              "EPAAKTIIVINEN_2",
-              "EPAAKTIIVINEN_3",
-            ],
-          },
-        },
-      ],
-      "must_not": Array [
-        Object {
-          "terms": Object {
-            "vaihe.keyword": Array [
-              "EPAAKTIIVINEN_1",
-              "EPAAKTIIVINEN_2",
-              "EPAAKTIIVINEN_3",
-            ],
-          },
-        },
       ],
     },
   },
-  "size": 0,
 }
 `;
 
@@ -196,17 +177,6 @@ Object {
             "publishTimestamp": Object {
               "lte": "now",
             },
-          },
-        },
-      ],
-      "must_not": Array [
-        Object {
-          "terms": Object {
-            "vaihe.keyword": Array [
-              "EPAAKTIIVINEN_1",
-              "EPAAKTIIVINEN_2",
-              "EPAAKTIIVINEN_3",
-            ],
           },
         },
       ],

--- a/backend/test/projektiSearch/projektiSearchService.test.ts
+++ b/backend/test/projektiSearch/projektiSearchService.test.ts
@@ -139,10 +139,31 @@ describe("ProjektiSearchService", () => {
   it("should handle query parameters successfully", async () => {
     openSearchQueryStub.onFirstCall().returns(fakeSearchResponse);
     openSearchQueryStub.onSecondCall().returns({
-      aggregations: { projektiTyypit: { buckets: [{ key: ProjektiTyyppi.TIE, doc_count: 2 }] } },
-    });
-    openSearchQueryStub.onThirdCall().returns({
-      aggregations: { statukset: { buckets: [{ key: "EI_JULKAISTU", doc_count: 2 }] } },
+      aggregations: {
+        aktiivinen: {
+          buckets: [
+            {
+              key: 0,
+              doc_count: 0,
+              projektiTyyppi: {
+                buckets: [],
+              },
+            },
+            {
+              key: 1,
+              doc_count: 1,
+              projektiTyyppi: {
+                buckets: [
+                  {
+                    key: ProjektiTyyppi.TIE,
+                    doc_count: 1,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
     });
 
     await projektiSearchService.searchYllapito({

--- a/backend/test/projektiSearch/projektiSearchService.test.ts
+++ b/backend/test/projektiSearch/projektiSearchService.test.ts
@@ -141,6 +141,9 @@ describe("ProjektiSearchService", () => {
     openSearchQueryStub.onSecondCall().returns({
       aggregations: { projektiTyypit: { buckets: [{ key: ProjektiTyyppi.TIE, doc_count: 2 }] } },
     });
+    openSearchQueryStub.onThirdCall().returns({
+      aggregations: { statukset: { buckets: [{ key: "EI_JULKAISTU", doc_count: 2 }] } },
+    });
 
     await projektiSearchService.searchYllapito({
       projektiTyyppi: ProjektiTyyppi.TIE,

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -213,6 +213,7 @@ input ListaaProjektitInput {
   suunnittelustaVastaavaViranomainen: [Viranomainen!]
   vaihe: [Status!]
   vainProjektitMuokkausOikeuksin: Boolean
+  epaaktiivinen: Boolean
   projektiTyyppi: ProjektiTyyppi
   sivunumero: Int
   sivunKoko: Int

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -736,6 +736,7 @@ type ProjektiHakutulos implements IProjektiHakutulos {
   tiesuunnitelmatMaara: Int
   ratasuunnitelmatMaara: Int
   yleissuunnitelmatMaara: Int
+  epaaktiivisetMaara: Int
   hakutulosProjektiTyyppi: ProjektiTyyppi
   tulokset: [ProjektiHakutulosDokumentti!]
 }

--- a/src/locales/fi/projekti.json
+++ b/src/locales/fi/projekti.json
@@ -76,9 +76,11 @@
     "HYVAKSYMISMENETTELYSSA": "Hyväksynnässä",
     "LAINVOIMA": "Lainvoima",
     "ARKISTOITU": "Arkistoitu",
-    "EPAAKTIIVINEN": "Epäaktiivinen",
+    "EPAAKTIIVINEN_1": "Epäaktiivinen",
     "JATKOPAATOS_1": "1. jatkopäätös",
-    "JATKOPAATOS_2": "2. jatkopäätös"
+    "EPAAKTIIVINEN_2": "Epäaktiivinen",
+    "JATKOPAATOS_2": "2. jatkopäätös",
+    "EPAAKTIIVINEN_3": "Epäaktiivinen"
   },
   "projekti-status-kansalaiselle": {
     "ALOITUSKUULUTUS": "Aloituskuulutus",

--- a/src/locales/sv/projekti.json
+++ b/src/locales/sv/projekti.json
@@ -76,9 +76,11 @@
     "HYVAKSYMISMENETTELYSSA": "RUOTSIKSI Hyväksynnässä",
     "LAINVOIMA": "RUOTSIKSI Lainvoima",
     "ARKISTOITU": "RUOTSIKSI Arkistoitu",
-    "EPAAKTIIVINEN": "RUOTSIKSI Epäaktiivinen",
+    "EPAAKTIIVINEN_1": "RUOTSIKSI Epäaktiivinen",
     "JATKOPAATOS_1": "RUOTSIKSI 1. jatkopäätös",
-    "JATKOPAATOS_2": "RUOTSIKSI 2. jatkopäätös"
+    "EPAAKTIIVINEN_2": "RUOTSIKSI Epäaktiivinen",
+    "JATKOPAATOS_2": "RUOTSIKSI 2. jatkopäätös",
+    "EPAAKTIIVINEN_3": "RUOTSIKSI Epäaktiivinen"
   },
   "projekti-status-kansalaiselle": {
     "ALOITUSKUULUTUS": "RUOTSIKSI Aloituskuulutus",


### PR DESCRIPTION
Epäaktiivisia projekteja ei oteta mukaan julkisen puolen haussa. Virkamiespuolen haussa erotellaan epäaktiiviset ja epäaktiiviset toisistaan. BE palauttaa virkamiespuolen haun yhteydessä tiedon myös epäaktiivisten projektien määrästä. Haussa on mahdollista antaa boolean-parametri 'epaaktiivinen'. Testejä päivitetty.

UI:ssa epäaktiivisilla on oma täbinsä. Virkamiehen etusivukomponenttia on refaktoroitu toimivammaksi. Tieto siitä, mikä täbi on avattu, on yksinomaan queryparametreissa. 