### PR TITLE
feat: Mahdollista julkisella puolella näytettävien projektin henkilöiden valinta

### DIFF
--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -1262,7 +1262,7 @@ Object {
         "nimi": "Hassu, A-tunnus1",
         "organisaatio": "CGI Suomi Oy",
         "puhelinnumero": "123",
-        "yleinenYhteystieto": undefined,
+        "yleinenYhteystieto": true,
       },
       Object {
         "__typename": "ProjektiKayttajaJulkinen",
@@ -1271,7 +1271,7 @@ Object {
         "nimi": "Hassu, A-tunnus3",
         "organisaatio": "CGI Suomi Oy",
         "puhelinnumero": "123",
-        "yleinenYhteystieto": undefined,
+        "yleinenYhteystieto": false,
       },
       Object {
         "__typename": "ProjektiKayttajaJulkinen",

--- a/backend/integrationtest/api/__snapshots__/hyvaksymisPaatosHyvaksytty.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/hyvaksymisPaatosHyvaksytty.test.ts.snap
@@ -13,6 +13,7 @@ Object {
       "organisaatio": "CGI Suomi Oy",
       "puhelinnumero": "123",
       "tyyppi": "PROJEKTIPAALLIKKO",
+      "yleinenYhteystieto": true,
     },
     Object {
       "__typename": "ProjektiKayttaja",
@@ -23,6 +24,7 @@ Object {
       "organisaatio": "CGI Suomi Oy",
       "puhelinnumero": "123",
       "tyyppi": "VARAHENKILO",
+      "yleinenYhteystieto": false,
     },
   ],
 }

--- a/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
+++ b/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
@@ -477,6 +477,7 @@
   "kayttoOikeudet": [
     {
       "kayttajatunnus": "A000112",
+      "yleinenYhteystieto": true,
       "nimi": "Hassu, A-tunnus1",
       "organisaatio": "CGI Suomi Oy",
       "tyyppi": "PROJEKTIPAALLIKKO",
@@ -486,6 +487,7 @@
     },
     {
       "kayttajatunnus": "A000114",
+      "yleinenYhteystieto": false,
       "nimi": "Hassu, A-tunnus3",
       "organisaatio": "CGI Suomi Oy",
       "tyyppi": "VARAHENKILO",

--- a/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
+++ b/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
@@ -476,8 +476,8 @@
   "paivitetty": "2020-01-01T00:00:00+02:00",
   "kayttoOikeudet": [
     {
-      "kayttajatunnus": "A000112",
       "yleinenYhteystieto": true,
+      "kayttajatunnus": "A000112",
       "nimi": "Hassu, A-tunnus1",
       "organisaatio": "CGI Suomi Oy",
       "tyyppi": "PROJEKTIPAALLIKKO",

--- a/backend/integrationtest/api/records/JATKOPAATOS_1_ALKU.json
+++ b/backend/integrationtest/api/records/JATKOPAATOS_1_ALKU.json
@@ -476,6 +476,7 @@
   "paivitetty": "2020-01-01T00:00:00+02:00",
   "kayttoOikeudet": [
     {
+      "yleinenYhteystieto": true,
       "kayttajatunnus": "A000112",
       "nimi": "Hassu, A-tunnus1",
       "organisaatio": "CGI Suomi Oy",
@@ -486,6 +487,7 @@
     },
     {
       "kayttajatunnus": "A000114",
+      "yleinenYhteystieto": false,
       "nimi": "Hassu, A-tunnus3",
       "organisaatio": "CGI Suomi Oy",
       "tyyppi": "VARAHENKILO",

--- a/backend/integrationtest/api/records/NAHTAVILLAOLO.json
+++ b/backend/integrationtest/api/records/NAHTAVILLAOLO.json
@@ -138,8 +138,8 @@
   "paivitetty": "2020-01-01T00:00:00+02:00",
   "kayttoOikeudet": [
     {
-      "kayttajatunnus": "A000112",
       "yleinenYhteystieto": true,
+      "kayttajatunnus": "A000112",
       "nimi": "Hassu, A-tunnus1",
       "organisaatio": "CGI Suomi Oy",
       "tyyppi": "PROJEKTIPAALLIKKO",

--- a/backend/integrationtest/api/records/NAHTAVILLAOLO.json
+++ b/backend/integrationtest/api/records/NAHTAVILLAOLO.json
@@ -139,6 +139,7 @@
   "kayttoOikeudet": [
     {
       "kayttajatunnus": "A000112",
+      "yleinenYhteystieto": true,
       "nimi": "Hassu, A-tunnus1",
       "organisaatio": "CGI Suomi Oy",
       "tyyppi": "PROJEKTIPAALLIKKO",
@@ -148,6 +149,7 @@
     },
     {
       "kayttajatunnus": "A000114",
+      "yleinenYhteystieto": false,
       "nimi": "Hassu, A-tunnus3",
       "organisaatio": "CGI Suomi Oy",
       "tyyppi": "VARAHENKILO",

--- a/backend/src/projekti/kayttoOikeudetManager.ts
+++ b/backend/src/projekti/kayttoOikeudetManager.ts
@@ -112,6 +112,7 @@ export class KayttoOikeudetManager {
         user: {
           tyyppi: KayttajaTyyppi.PROJEKTIPAALLIKKO,
           email: email.toLowerCase(),
+          yleinenYhteystieto: true,
           muokattavissa: false,
         },
         searchMode: SearchMode.EMAIL,

--- a/backend/src/projekti/kayttoOikeudetManager.ts
+++ b/backend/src/projekti/kayttoOikeudetManager.ts
@@ -36,10 +36,18 @@ export class KayttoOikeudetManager {
     return this.users.reduce((resultingUsers: DBVaylaUser[], currentUser) => {
       const inputUser = changes.find((user) => user.kayttajatunnus === currentUser.kayttajatunnus);
       if (inputUser) {
-        if (currentUser.tyyppi === KayttajaTyyppi.PROJEKTIPAALLIKKO || currentUser.muokattavissa === false) {
-          // Update only puhelinnumero if projektipaallikko or varahenkilö
+        if (currentUser.tyyppi === KayttajaTyyppi.PROJEKTIPAALLIKKO) {
+          // Update only puhelinnumero if projektipaallikko
           resultingUsers.push({
             ...currentUser,
+            yleinenYhteystieto: true,
+            puhelinnumero: inputUser.puhelinnumero,
+          });
+        } else if (currentUser.muokattavissa === false) {
+          // Update only puhelinnumero and yleinenYhteystieto if varahenkilö from Projektivelho
+          resultingUsers.push({
+            ...currentUser,
+            yleinenYhteystieto: !!inputUser.yleinenYhteystieto,
             puhelinnumero: inputUser.puhelinnumero,
           });
         } else {

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -12,6 +12,7 @@ Object {
       "nimi": "Projari, Pekka",
       "organisaatio": "Väylävirasto",
       "tyyppi": "PROJEKTIPAALLIKKO",
+      "yleinenYhteystieto": true,
     },
     Object {
       "__typename": "ProjektiKayttaja",
@@ -48,6 +49,7 @@ Array [
       "nimi": "Projari, Pekka",
       "organisaatio": "Väylävirasto",
       "tyyppi": "PROJEKTIPAALLIKKO",
+      "yleinenYhteystieto": true,
     },
     Object {
       "__typename": "ProjektiKayttaja",

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -75,6 +75,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
       Object {
         "email": "matti.meikalainen@vayla.fi",
@@ -114,6 +115,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
       Object {
         "__typename": "ProjektiKayttaja",
@@ -161,6 +163,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
     ],
     "kielitiedot": undefined,
@@ -191,6 +194,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
     ],
     "muistiinpano": "Testiprojekti 1:n muistiinpano",
@@ -227,6 +231,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
       Object {
         "email": "matti.meikalainen@vayla.fi",
@@ -267,6 +272,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
       Object {
         "__typename": "ProjektiKayttaja",
@@ -360,6 +366,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
       Object {
         "email": "matti.meikalainen@vayla.fi",
@@ -475,6 +482,7 @@ Array [
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
         "tyyppi": "PROJEKTIPAALLIKKO",
+        "yleinenYhteystieto": true,
       },
       Object {
         "__typename": "ProjektiKayttaja",
@@ -1017,6 +1025,7 @@ Object {
       "organisaatio": "Väylävirasto",
       "puhelinnumero": "11",
       "tyyppi": "PROJEKTIPAALLIKKO",
+      "yleinenYhteystieto": true,
     },
     Object {
       "__typename": "ProjektiKayttaja",
@@ -1156,7 +1165,7 @@ Object {
         "nimi": "Projari, Pekka",
         "organisaatio": "Väylävirasto",
         "puhelinnumero": "11",
-        "yleinenYhteystieto": undefined,
+        "yleinenYhteystieto": true,
       },
       Object {
         "__typename": "ProjektiKayttajaJulkinen",

--- a/backend/test/projekti/__snapshots__/kayttoOikeudetManager.test.ts.snap
+++ b/backend/test/projekti/__snapshots__/kayttoOikeudetManager.test.ts.snap
@@ -9,6 +9,7 @@ Array [
     "nimi": "SukunimiA1, EtunimiA1",
     "organisaatio": "Väylävirasto",
     "tyyppi": "PROJEKTIPAALLIKKO",
+    "yleinenYhteystieto": true,
   },
   Object {
     "email": "a2@vayla.fi",

--- a/backend/test/projekti/__snapshots__/kayttoOikeudetManager.test.ts.snap
+++ b/backend/test/projekti/__snapshots__/kayttoOikeudetManager.test.ts.snap
@@ -39,6 +39,7 @@ Array [
     "organisaatio": "Väylävirasto",
     "puhelinnumero": "123456789",
     "tyyppi": "PROJEKTIPAALLIKKO",
+    "yleinenYhteystieto": true,
   },
   Object {
     "email": "a2@vayla.fi",
@@ -48,6 +49,7 @@ Array [
     "organisaatio": "Väylävirasto",
     "puhelinnumero": "123456789",
     "tyyppi": "VARAHENKILO",
+    "yleinenYhteystieto": false,
   },
   Object {
     "email": "a3@vayla.fi",

--- a/backend/test/projekti/__snapshots__/projektiHandler.test.ts.snap
+++ b/backend/test/projekti/__snapshots__/projektiHandler.test.ts.snap
@@ -36,6 +36,7 @@ Object {
       "nimi": "SukunimiA1, EtunimiA1",
       "organisaatio": "Väylävirasto",
       "tyyppi": "PROJEKTIPAALLIKKO",
+      "yleinenYhteystieto": true,
     },
     Object {
       "email": "a2@vayla.fi",

--- a/src/components/layout/ContentSpacer.tsx
+++ b/src/components/layout/ContentSpacer.tsx
@@ -1,0 +1,19 @@
+import { styled, experimental_sx as sx } from "@mui/material";
+import isPropValid from "@emotion/is-prop-valid";
+
+export type HassuGaps = 2 | 4 | 7 | 8 | 12 | 27.5;
+
+export type ContentSpacerProps = {
+  gap?: HassuGaps;
+};
+
+const ContentSpacer = styled("div", { shouldForwardProp: isPropValid })<ContentSpacerProps>(({ gap = 4 }: ContentSpacerProps) =>
+  sx({
+    "& > *": { margin: 0 },
+    "& > * + *": {
+      marginTop: gap,
+    },
+  })
+);
+
+export default ContentSpacer;

--- a/src/components/layout/HassuMuiThemeProvider.tsx
+++ b/src/components/layout/HassuMuiThemeProvider.tsx
@@ -105,6 +105,7 @@ export const createLocalizedTheme = (locale: Localization) =>
                 borderRadius: "4px",
                 position: "relative",
                 zIndex: 2,
+                margin: "2px",
               },
               "& .hassu-checkbox-icon-unchecked": {
                 background: "#FFFFFF",
@@ -359,6 +360,9 @@ export const createLocalizedTheme = (locale: Localization) =>
         MuiFormHelperText: {
           styleOverrides: {
             root: {
+              whiteSpace: "normal",
+              overflowWrap: "anywhere",
+              maxWidth: "fit-content",
               lineHeight: "0.75rem",
               fontSize: "0.75rem",
               marginTop: "8px",

--- a/src/components/layout/HassuMuiThemeProvider.tsx
+++ b/src/components/layout/HassuMuiThemeProvider.tsx
@@ -1,3 +1,5 @@
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { BreakpointsOptions, createTheme, ThemeProvider } from "@mui/material";
 import { fiFI, Localization, svSE } from "@mui/material/locale";
 import { ThemeProviderProps } from "@mui/material/styles/ThemeProvider";
@@ -59,6 +61,85 @@ export const createLocalizedTheme = (locale: Localization) =>
           defaultProps: {
             rowGap: 4,
             columnGap: 7,
+          },
+        },
+        MuiTouchRipple: {
+          styleOverrides: {
+            root: {},
+            child: {
+              color: "rgba(0, 100, 175, 0.2)",
+            },
+            ripple: {
+              color: "rgba(0, 100, 175, 0.2)",
+            },
+          },
+        },
+        MuiCheckbox: {
+          defaultProps: {
+            checkedIcon: (
+              <span className="hassu-checkbox-icon hassu-checkbox-icon-checked">
+                <FontAwesomeIcon
+                  icon={faCheck}
+                  color="#FFFFFF"
+                  style={{
+                    position: "absolute",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%)",
+                    fontSize: "12px",
+                  }}
+                />
+              </span>
+            ),
+            icon: <span className="hassu-checkbox-icon hassu-checkbox-icon-unchecked" />,
+          },
+          styleOverrides: {
+            root: {
+              "&:hover": {
+                backgroundColor: "rgba(0, 153, 255, 0.08)",
+              },
+              color: "rgba(0, 153, 255, 0.6)",
+              "& .hassu-checkbox-icon": {
+                width: "20px",
+                height: "20px",
+                borderRadius: "4px",
+                position: "relative",
+                zIndex: 2,
+              },
+              "& .hassu-checkbox-icon-unchecked": {
+                background: "#FFFFFF",
+                borderColor: "#333333",
+                border: "1px solid",
+                boxShadow: "inset 0 2px 6px rgb(153, 153, 153, 0.4)",
+                color: "#333333",
+              },
+              "& .hassu-checkbox-icon-checked": {
+                background: "#0064AF",
+              },
+              "&.Mui-focusVisible .hassu-checkbox-icon-unchecked": {
+                border: "2px solid transparent",
+                backgroundClip: "padding-box",
+                transformStyle: "preserve-3d",
+              },
+              "&.Mui-focusVisible .hassu-checkbox-icon-unchecked::after": {
+                position: "absolute",
+                top: "-2px",
+                bottom: "-2px",
+                left: "-2px",
+                right: "-2px",
+                background: "linear-gradient(117deg, #0064AF, #49c2f1)",
+                content: '""',
+                transform: "translateZ(-1px)",
+                borderRadius: "4px",
+              },
+              "&.Mui-disabled .hassu-checkbox-icon": {
+                background: "#C7C7C7",
+                boxShadow: "none",
+              },
+              "&.Mui-focusVisible .hassu-checkbox-icon-checked": {
+                background: "linear-gradient(117deg, #0064AF, #49c2f1)",
+              },
+            },
           },
         },
         MuiDialogTitle: {
@@ -150,6 +231,18 @@ export const createLocalizedTheme = (locale: Localization) =>
                 },
                 "&.Mui-focusVisible": {
                   backgroundColor: "rgba(60,210,255,0.20)",
+                },
+              },
+            },
+          },
+        },
+        MuiFormControlLabel: {
+          styleOverrides: {
+            root: {
+              ".MuiFormControlLabel-label": {
+                padding: "2px",
+                "&.Mui-disabled": {
+                  color: "#999999",
                 },
               },
             },

--- a/src/components/layout/HassuMuiThemeProvider.tsx
+++ b/src/components/layout/HassuMuiThemeProvider.tsx
@@ -63,17 +63,6 @@ export const createLocalizedTheme = (locale: Localization) =>
             columnGap: 7,
           },
         },
-        MuiTouchRipple: {
-          styleOverrides: {
-            root: {},
-            child: {
-              color: "rgba(0, 100, 175, 0.2)",
-            },
-            ripple: {
-              color: "rgba(0, 100, 175, 0.2)",
-            },
-          },
-        },
         MuiCheckbox: {
           defaultProps: {
             checkedIcon: (
@@ -245,6 +234,28 @@ export const createLocalizedTheme = (locale: Localization) =>
                 "&.Mui-disabled": {
                   color: "#999999",
                 },
+              },
+            },
+          },
+        },
+        MuiIconButton: {
+          styleOverrides: {
+            root: {
+              color: "#0064AF",
+              "&:hover": {
+                backgroundColor: "rgba(0, 153, 255, 0.08)",
+              },
+              "& .MuiTouchRipple-child": {
+                color: "rgba(0, 153, 255, 1)",
+              },
+            },
+            colorPrimary: {
+              color: "#0064AF",
+              "&:hover": {
+                backgroundColor: "rgba(0, 153, 255, 0.08)",
+              },
+              "& .MuiTouchRipple-child": {
+                color: "rgba(0, 153, 255, 1)",
               },
             },
           },

--- a/src/components/layout/HassuMuiThemeProvider.tsx
+++ b/src/components/layout/HassuMuiThemeProvider.tsx
@@ -229,8 +229,10 @@ export const createLocalizedTheme = (locale: Localization) =>
         MuiFormControlLabel: {
           styleOverrides: {
             root: {
+              alignItems: "start",
               ".MuiFormControlLabel-label": {
                 padding: "2px",
+                paddingTop: "9px",
                 "&.Mui-disabled": {
                   color: "#999999",
                 },

--- a/src/components/layout/Section2.tsx
+++ b/src/components/layout/Section2.tsx
@@ -1,0 +1,27 @@
+import React, { ComponentProps } from "react";
+import { styled, experimental_sx as sx } from "@mui/material";
+import ContentSpacer, { HassuGaps } from "./ContentSpacer";
+
+type Props = {
+  noDivider?: boolean;
+  marginBottom?: HassuGaps;
+  marginTop?: HassuGaps;
+} & ComponentProps<typeof ContentSpacer>;
+
+const Section = styled(
+  ({ children, noDivider, gap = 7, as = "section", marginBottom: _marginBottom, marginTop: _marginTop, ...contentSpacerProps }: Props) => (
+    <>
+      <ContentSpacer gap={gap} as={as} {...contentSpacerProps}>
+        {children}
+      </ContentSpacer>
+      {!noDivider && <hr />}
+    </>
+  )
+)(({ marginTop = 7, marginBottom = 12 }: Props) =>
+  sx({
+    marginTop,
+    marginBottom,
+  })
+);
+
+export default Section;

--- a/src/components/projekti/KayttoOikeusHallinta.tsx
+++ b/src/components/projekti/KayttoOikeusHallinta.tsx
@@ -22,6 +22,7 @@ interface Props {
   disableFields?: boolean;
   onKayttajatUpdate: (kayttajat: ProjektiKayttajaInput[]) => void;
   projektiKayttajat: ProjektiKayttaja[];
+  suunnitteluSopimusYhteysHenkilo?: string | undefined;
 }
 
 const getKayttajaNimi = (k: Kayttaja | null | undefined) => {
@@ -62,6 +63,7 @@ function KayttoOikeusHallintaFormElements({
   onKayttajatUpdate,
   projektiKayttajat: projektiKayttajatFromApi,
   initialKayttajat,
+  suunnitteluSopimusYhteysHenkilo,
 }: Props & { initialKayttajat: Kayttaja[] }) {
   const {
     control,
@@ -133,6 +135,8 @@ function KayttoOikeusHallintaFormElements({
           const initialKayttaja = initialKayttajat?.find(({ uid }) => uid === user.kayttajatunnus) || null;
           const kayttajaFromApi = projektiKayttajatFromApi.find(({ kayttajatunnus }) => kayttajatunnus === user.kayttajatunnus);
           const muokattavissa = kayttajaFromApi?.muokattavissa === false ? false : true;
+          const isSuunnitteluSopimusYhteysHenkilo =
+            !!suunnitteluSopimusYhteysHenkilo && user.kayttajatunnus === suunnitteluSopimusYhteysHenkilo;
           return (
             <UserFields
               disableFields={disableFields}
@@ -141,6 +145,7 @@ function KayttoOikeusHallintaFormElements({
               remove={remove}
               key={user.id}
               muokattavissa={muokattavissa}
+              isSuunnitteluSopimusYhteysHenkilo={isSuunnitteluSopimusYhteysHenkilo}
             />
           );
         })}
@@ -166,9 +171,18 @@ interface UserFieldProps {
   remove: UseFieldArrayRemove;
   muokattavissa: boolean;
   isProjektiPaallikko?: boolean;
+  isSuunnitteluSopimusYhteysHenkilo?: boolean;
 }
 
-const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavissa, isProjektiPaallikko }: UserFieldProps) => {
+const UserFields = ({
+  index,
+  disableFields,
+  remove,
+  initialKayttaja,
+  muokattavissa,
+  isProjektiPaallikko,
+  isSuunnitteluSopimusYhteysHenkilo,
+}: UserFieldProps) => {
   const [kayttaja, setKayttaja] = useState<Kayttaja | null>(initialKayttaja);
 
   useEffect(() => {
@@ -321,11 +335,11 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
         shouldUnregister
         render={({ field: { value, onChange, ...field } }) => (
           <FormControlLabel
-            disabled={isProjektiPaallikko}
+            disabled={isProjektiPaallikko || isSuunnitteluSopimusYhteysHenkilo}
             label="Yhteystiedot näytetään julkisella puolella projektin yleisissä yhteystiedoissa."
             control={
               <Checkbox
-                checked={isProjektiPaallikko ? true : !!value}
+                checked={isProjektiPaallikko || isSuunnitteluSopimusYhteysHenkilo ? true : !!value}
                 onChange={(event) => {
                   const checked = event.target.checked;
                   onChange(!!checked);

--- a/src/components/projekti/KayttoOikeusHallinta.tsx
+++ b/src/components/projekti/KayttoOikeusHallinta.tsx
@@ -5,12 +5,12 @@ import Button from "@components/button/Button";
 import { maxPhoneLength } from "src/schemas/puhelinNumero";
 import Section from "@components/layout/Section";
 import SectionContent from "@components/layout/SectionContent";
-import HassuGrid from "@components/HassuGrid";
 import { isAorL } from "backend/src/util/userUtil";
 import { TextFieldWithController } from "@components/form/TextFieldWithController";
 import { Autocomplete, TextField, Checkbox, FormControlLabel, useTheme, useMediaQuery, IconButton, SvgIcon, Stack } from "@mui/material";
 import useDebounceCallback from "src/hooks/useDebounceCallback";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import HassuGrid from "@components/HassuGrid";
 
 // Extend TallennaProjektiInput by making the field nonnullable and required
 type RequiredFields = Pick<TallennaProjektiInput, "kayttoOikeudet">;
@@ -199,7 +199,11 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
 
   return (
     <SectionContent>
-      <HassuGrid sx={{ width: "100%" }} cols={{ xs: 1, lg: 3 }}>
+      <HassuGrid
+        sx={{
+          gridTemplateColumns: { width: "100%", xs: "1fr", lg: "repeat(3, minmax(max-content, 1fr))" },
+        }}
+      >
         <Controller
           name={`kayttoOikeudet.${index}.kayttajatunnus`}
           render={({ field: { onChange, name, onBlur, ref }, fieldState }) => (
@@ -262,9 +266,8 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
             {muokattavissa && (
               <div>
                 <IconButton
-                  sx={{ color: "#0064AF", marginTop: 5.5 }}
-                  onClick={(event) => {
-                    event.preventDefault();
+                  sx={{ marginTop: 5.5 }}
+                  onClick={() => {
                     if (muokattavissa) {
                       remove(index);
                     }

--- a/src/components/projekti/KayttoOikeusHallinta.tsx
+++ b/src/components/projekti/KayttoOikeusHallinta.tsx
@@ -8,17 +8,7 @@ import SectionContent from "@components/layout/SectionContent";
 import HassuGrid from "@components/HassuGrid";
 import { isAorL } from "backend/src/util/userUtil";
 import { TextFieldWithController } from "@components/form/TextFieldWithController";
-import {
-  Autocomplete,
-  TextField,
-  Checkbox,
-  FormGroup,
-  FormControlLabel,
-  useTheme,
-  useMediaQuery,
-  IconButton,
-  SvgIcon,
-} from "@mui/material";
+import { Autocomplete, TextField, Checkbox, FormControlLabel, useTheme, useMediaQuery, IconButton, SvgIcon, Stack } from "@mui/material";
 import useDebounceCallback from "src/hooks/useDebounceCallback";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
@@ -262,7 +252,7 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
             disabled={disableFields}
           />
         ) : (
-          <div>
+          <Stack direction="row" columnGap={4.5}>
             <TextFieldWithController
               label="Puhelinnumero *"
               controllerProps={{ name: `kayttoOikeudet.${index}.puhelinnumero` }}
@@ -270,23 +260,25 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
               disabled={disableFields}
             />
             {muokattavissa && (
-              <IconButton
-                sx={{ color: "#0064AF", margin: 4.5 }}
-                onClick={(event) => {
-                  event.preventDefault();
-                  if (muokattavissa) {
-                    remove(index);
-                  }
-                }}
-                disabled={disableFields || !muokattavissa}
-                size="large"
-              >
-                <SvgIcon>
-                  <FontAwesomeIcon icon="trash" />
-                </SvgIcon>
-              </IconButton>
+              <div>
+                <IconButton
+                  sx={{ color: "#0064AF", marginTop: 5.5 }}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    if (muokattavissa) {
+                      remove(index);
+                    }
+                  }}
+                  disabled={disableFields || !muokattavissa}
+                  size="large"
+                >
+                  <SvgIcon>
+                    <FontAwesomeIcon icon="trash" />
+                  </SvgIcon>
+                </IconButton>
+              </div>
             )}
-          </div>
+          </Stack>
         )}
         <TextField label="Sähköpostiosoite *" value={kayttaja?.email || ""} disabled />
         {!isProjektiPaallikko && kayttaja?.uid && isAorL(kayttaja?.uid) && (
@@ -294,8 +286,9 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
             name={`kayttoOikeudet.${index}.tyyppi`}
             shouldUnregister
             render={({ field: { value, onChange, ...field } }) => (
-              <FormGroup className="col-span-1 lg:col-span-2">
+              <div className="col-span-1 lg:col-span-2">
                 <FormControlLabel
+                  sx={{ marginTop: { lg: 6.5 } }}
                   disabled={!muokattavissa}
                   label="Projektipäällikön varahenkilö"
                   control={
@@ -310,11 +303,34 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
                     />
                   }
                 />
-              </FormGroup>
+              </div>
             )}
           />
         )}
       </HassuGrid>
+      {!muokattavissa && !isProjektiPaallikko && (
+        <p>Tämän henkilön tiedot on haettu Projektivelhosta. Jos haluat poistaa tämän henkilön, muutos pitää tehdä Projektivelhoon.</p>
+      )}
+      <Controller<RequiredInputValues>
+        name={`kayttoOikeudet.${index}.yleinenYhteystieto`}
+        shouldUnregister
+        render={({ field: { value, onChange, ...field } }) => (
+          <FormControlLabel
+            disabled={isProjektiPaallikko}
+            label="Yhteystiedot näytetään julkisella puolella projektin yleisissä yhteystiedoissa."
+            control={
+              <Checkbox
+                checked={isProjektiPaallikko ? true : !!value}
+                onChange={(event) => {
+                  const checked = event.target.checked;
+                  onChange(!!checked);
+                }}
+                {...field}
+              />
+            }
+          />
+        )}
+      />
       {!!muokattavissa && isMobile && (
         <Button
           onClick={(event) => {
@@ -328,9 +344,6 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
         >
           Poista
         </Button>
-      )}
-      {!muokattavissa && !isProjektiPaallikko && (
-        <p>Tämän henkilön tiedot on haettu Projektivelhosta. Jos haluat poistaa tämän henkilön, muutos pitää tehdä Projektivelhoon.</p>
       )}
     </SectionContent>
   );

--- a/src/components/projekti/KayttoOikeusHallinta.tsx
+++ b/src/components/projekti/KayttoOikeusHallinta.tsx
@@ -213,6 +213,8 @@ const UserFields = ({
 
   const debouncedSearchKayttajat = useDebounceCallback(searchAndUpdateKayttajat, 200);
 
+  const isCurrentKayttajaMissingFromOptions = kayttaja && !options.some((o) => o.uid === kayttaja.uid);
+
   return (
     <ContentSpacer>
       <HassuGrid
@@ -224,7 +226,7 @@ const UserFields = ({
           name={`kayttoOikeudet.${index}.kayttajatunnus`}
           render={({ field: { onChange, name, onBlur, ref }, fieldState }) => (
             <Autocomplete
-              options={options}
+              options={isCurrentKayttajaMissingFromOptions ? [...options, kayttaja] : options}
               renderInput={(params) => (
                 <TextField
                   {...params}

--- a/src/components/projekti/KayttoOikeusHallinta.tsx
+++ b/src/components/projekti/KayttoOikeusHallinta.tsx
@@ -3,14 +3,14 @@ import { Controller, FieldArrayWithId, useFieldArray, UseFieldArrayRemove, useFo
 import { api, Kayttaja, KayttajaTyyppi, ProjektiKayttaja, ProjektiKayttajaInput, TallennaProjektiInput } from "@services/api";
 import Button from "@components/button/Button";
 import { maxPhoneLength } from "src/schemas/puhelinNumero";
-import Section from "@components/layout/Section";
-import SectionContent from "@components/layout/SectionContent";
+import Section from "@components/layout/Section2";
 import { isAorL } from "backend/src/util/userUtil";
 import { TextFieldWithController } from "@components/form/TextFieldWithController";
 import { Autocomplete, TextField, Checkbox, FormControlLabel, useTheme, useMediaQuery, IconButton, SvgIcon, Stack } from "@mui/material";
 import useDebounceCallback from "src/hooks/useDebounceCallback";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import HassuGrid from "@components/HassuGrid";
+import ContentSpacer from "@components/layout/ContentSpacer";
 
 // Extend TallennaProjektiInput by making the field nonnullable and required
 type RequiredFields = Pick<TallennaProjektiInput, "kayttoOikeudet">;
@@ -100,11 +100,13 @@ function KayttoOikeusHallintaFormElements({
   }, [kayttoOikeudet, onKayttajatUpdate]);
 
   return (
-    <Section>
+    <Section gap={8}>
       {projektiPaallikot.length > 0 && (
-        <SectionContent>
-          <h5 className="vayla-paragraph">Projektipäällikkö</h5>
-          <p>Projektipäällikö on haettu Projektivelhosta. Jos haluat vaihtaa projektipäällikön, muutos pitää tehdä Projektivelhoon.</p>
+        <ContentSpacer gap={8}>
+          <ContentSpacer>
+            <h5 className="vayla-subtitle">Projektipäällikkö</h5>
+            <p>Projektipäällikö on haettu Projektivelhosta. Jos haluat vaihtaa projektipäällikön, muutos pitää tehdä Projektivelhoon.</p>
+          </ContentSpacer>
           {projektiPaallikot.map((paallikko, index) => {
             const initialKayttaja = initialKayttajat?.find(({ uid }) => uid === paallikko.kayttajatunnus) || null;
             const kayttajaFromApi = projektiKayttajatFromApi.find(({ kayttajatunnus }) => kayttajatunnus === paallikko.kayttajatunnus);
@@ -121,12 +123,12 @@ function KayttoOikeusHallintaFormElements({
               />
             );
           })}
-        </SectionContent>
+        </ContentSpacer>
       )}
-      <SectionContent largeGaps>
-        <SectionContent>
+      <ContentSpacer gap={8}>
+        <ContentSpacer>
           <h5 className="vayla-subtitle">Muut henkilöt</h5>
-        </SectionContent>
+        </ContentSpacer>
         {muutHenkilot.map((user, index) => {
           const initialKayttaja = initialKayttajat?.find(({ uid }) => uid === user.kayttajatunnus) || null;
           const kayttajaFromApi = projektiKayttajatFromApi.find(({ kayttajatunnus }) => kayttajatunnus === user.kayttajatunnus);
@@ -142,7 +144,7 @@ function KayttoOikeusHallintaFormElements({
             />
           );
         })}
-      </SectionContent>
+      </ContentSpacer>
       <Button
         onClick={(event) => {
           event.preventDefault();
@@ -198,7 +200,7 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
   const debouncedSearchKayttajat = useDebounceCallback(searchAndUpdateKayttajat, 200);
 
   return (
-    <SectionContent>
+    <ContentSpacer>
       <HassuGrid
         sx={{
           gridTemplateColumns: { width: "100%", xs: "1fr", lg: "repeat(3, minmax(max-content, 1fr))" },
@@ -348,7 +350,7 @@ const UserFields = ({ index, disableFields, remove, initialKayttaja, muokattavis
           Poista
         </Button>
       )}
-    </SectionContent>
+    </ContentSpacer>
   );
 };
 

--- a/src/components/projekti/ProjektiPageLayout.tsx
+++ b/src/components/projekti/ProjektiPageLayout.tsx
@@ -40,11 +40,11 @@ export default function ProjektiPageLayout({ children, title, showUpdateButton }
 
   return (
     <section>
-      <div className="grid grid-cols-1 md:grid-cols-12 gap-8 mb-3">
-        <div className="md:col-span-6 lg:col-span-4 xl:col-span-3">
+      <div className="flex flex-col md:flex-row gap-8 mb-3">
+        <div style={{ minWidth: "345px" }}>
           <ProjektiSideNavigation />
         </div>
-        <div className="md:col-span-6 lg:col-span-8 xl:col-span-9">
+        <div className="grow">
           <Stack
             sx={{ marginBottom: { xs: 3, sm: 0 } }}
             alignItems="flex-start"

--- a/src/pages/yllapito/perusta/[oid].tsx
+++ b/src/pages/yllapito/perusta/[oid].tsx
@@ -63,11 +63,12 @@ interface PerustaProjektiFormProps {
 const defaultFormValues: (projekti: ProjektiLisatiedolla) => FormValues = (projekti: ProjektiLisatiedolla) => ({
   oid: projekti.oid,
   kayttoOikeudet:
-    projekti.kayttoOikeudet?.map(({ kayttajatunnus, puhelinnumero, tyyppi }) => {
+    projekti.kayttoOikeudet?.map(({ kayttajatunnus, puhelinnumero, tyyppi, yleinenYhteystieto }) => {
       const formValues: ProjektiKayttajaInput = {
         kayttajatunnus,
         puhelinnumero: puhelinnumero || "",
         tyyppi,
+        yleinenYhteystieto: !!yleinenYhteystieto,
       };
       return formValues;
     }) || [],

--- a/src/pages/yllapito/projekti/[oid]/henkilot.tsx
+++ b/src/pages/yllapito/projekti/[oid]/henkilot.tsx
@@ -78,10 +78,11 @@ function Henkilot({ projekti, projektiLoadError, reloadProjekti }: HenkilotFormP
     () => ({
       oid: projekti.oid,
       kayttoOikeudet:
-        projekti.kayttoOikeudet?.map(({ kayttajatunnus, puhelinnumero, tyyppi }) => ({
+        projekti.kayttoOikeudet?.map(({ kayttajatunnus, puhelinnumero, tyyppi, yleinenYhteystieto }) => ({
           kayttajatunnus,
           puhelinnumero: puhelinnumero || "",
           tyyppi,
+          yleinenYhteystieto: !!yleinenYhteystieto,
         })) || [],
     }),
     [projekti]

--- a/src/pages/yllapito/projekti/[oid]/henkilot.tsx
+++ b/src/pages/yllapito/projekti/[oid]/henkilot.tsx
@@ -146,6 +146,7 @@ function Henkilot({ projekti, projektiLoadError, reloadProjekti }: HenkilotFormP
               disableFields={disableFormEdit}
               projektiKayttajat={projekti.kayttoOikeudet || []}
               onKayttajatUpdate={onKayttajatUpdate}
+              suunnitteluSopimusYhteysHenkilo={projekti.suunnitteluSopimus?.yhteysHenkilo}
             />
             <Section noDivider>
               <HassuStack alignItems="flex-end">


### PR DESCRIPTION
Muokattu backendia niin, että velhosta tulevalle varahenkilölle voidaan asettaa yleinenYhteystieto -tieto. Backendia muokattu myös niin, että projektipäällikkölle asetetaan aina _yleinenYhteystieto: true_.

Olen aiemmin rakentanut Section- ja SectionContent-komponentit vertikaaliseen välien luomiseen. Olen toteuttanut ne niin, että ne määrittelevät lapsikomponenttien välityksen suuruuden. KayttoOikeusHallinta-komponentissa tarvittiin customisoitua välitystä ja rakensin uudet versiot näistä kahdesta komponentista. Nimesin ne ContentSpacer- ja Section2-komponenteiksi. Halusin nimetä SectionContentin uudelleen, sillä tämän kaltaista vertikaalista välien asettamista tarvitaan muuallakin kuin Sectioneiden sisällä. En kuitenkaan halunnut tässä PR:ssä tehdä isoja refaktorointeja aiempiin komponentteihin, joissa muokkaisin kaikki käyttämään näitä uusia komponentteja.

Tyylittelin myös MUI-kirjaston Checkboxia ja FormControlLabelia ja IconButtonia, jotta ne olisivat oletuksena tyylimäärityksiemme mukaisia.

Muokkasin projektipagelayoutista sivuosion käyttämään flexboxia ja jotta sen koko on vähän joustavampi.

Ja tietty tein myös tämän tiketin kannalta olennaisimman eli lisäsin checkboxin, jolla mahdollistin julkisella puolella näytettävien projektin henkilöiden valinnan.