### PR TITLE
fix: Korjaa logiikkaa milloin julkaisut tulevat näkyviin kansalaispuolelle

### DIFF
--- a/backend/integrationtest/api/hyvaksymisPaatosHyvaksytty.test.ts
+++ b/backend/integrationtest/api/hyvaksymisPaatosHyvaksytty.test.ts
@@ -110,7 +110,7 @@ describe("Hyväksytyn hyväksymispäätöskuulutuksen jälkeen", () => {
 
     const epaAktiivinenProjekti1 = await projektiDatabase.loadProjektiByOid(oid);
     assertIsDefined(epaAktiivinenProjekti1);
-    expect(epaAktiivinenProjekti1!.ajastettuTarkistus).to.eql("2101-01-01T23:59:00+02:00"); // MOCKED_TIMESTAMP + 1 year
+    expect(epaAktiivinenProjekti1!.ajastettuTarkistus).to.eql("2101-01-01T23:59:59+02:00"); // MOCKED_TIMESTAMP + 1 year
     // TODO Aineistot poistetaan vuosi epäaktiivisen olon jälkeen
 
     await lisaaKasittelynTilaJatkopaatos1({

--- a/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
+++ b/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
@@ -268,7 +268,7 @@
       "muistutusoikeusPaattyyPaiva": "2042-06-08"
     }
   ],
-  "ajastettuTarkistus": "2101-01-01T23:59:00+02:00",
+  "ajastettuTarkistus": "2101-01-01T23:59:59+02:00",
   "euRahoitus": false,
   "suunnitteluVaihe": {
     "hankkeenKuvaus": {

--- a/backend/integrationtest/api/records/JATKOPAATOS_1_ALKU.json
+++ b/backend/integrationtest/api/records/JATKOPAATOS_1_ALKU.json
@@ -268,7 +268,7 @@
       "muistutusoikeusPaattyyPaiva": "2042-06-08"
     }
   ],
-  "ajastettuTarkistus": "2101-01-01T23:59:00+02:00",
+  "ajastettuTarkistus": "2101-01-01T23:59:59+02:00",
   "euRahoitus": false,
   "suunnitteluVaihe": {
     "hankkeenKuvaus": {

--- a/backend/src/handler/tila/abstractHyvaksymisPaatosVaiheTilaManager.ts
+++ b/backend/src/handler/tila/abstractHyvaksymisPaatosVaiheTilaManager.ts
@@ -6,13 +6,8 @@ import {
   HyvaksymisPaatosVaihePDF,
   LocalizedMap,
 } from "../../database/model";
-import { parseAndAddDate, parseDate } from "../../util/dateUtil";
-import {
-  HYVAKSYMISPAATOS_DURATION_UNIT,
-  HYVAKSYMISPAATOS_DURATION_VALUE,
-  JATKOPAATOS_DURATION_UNIT,
-  JATKOPAATOS_DURATION_VALUE,
-} from "../../projekti/status/statusHandler";
+import { parseAndAddDateTime, parseDate } from "../../util/dateUtil";
+import { HYVAKSYMISPAATOS_DURATION, JATKOPAATOS_DURATION } from "../../projekti/status/statusHandler";
 import { AsiakirjaTyyppi, Kieli } from "../../../../common/graphql/apiModel";
 import { fileService } from "../../files/fileService";
 import { ProjektiPaths } from "../../files/ProjektiPath";
@@ -37,10 +32,9 @@ export abstract class AbstractHyvaksymisPaatosVaiheTilaManager extends TilaManag
     if (!julkaisu.kuulutusVaihePaattyyPaiva) {
       throw new Error("julkaisulta.kuulutusVaihePaattyyPaiva puuttuu");
     }
-    if (isHyvaksymisPaatos) {
-      return parseAndAddDate(julkaisu.kuulutusVaihePaattyyPaiva, HYVAKSYMISPAATOS_DURATION_VALUE, HYVAKSYMISPAATOS_DURATION_UNIT)?.format();
-    }
-    return parseAndAddDate(julkaisu.kuulutusVaihePaattyyPaiva, JATKOPAATOS_DURATION_VALUE, JATKOPAATOS_DURATION_UNIT)?.format();
+    const paatosDuration = isHyvaksymisPaatos ? HYVAKSYMISPAATOS_DURATION : JATKOPAATOS_DURATION;
+
+    return parseAndAddDateTime(julkaisu.kuulutusVaihePaattyyPaiva, "end-of-day", paatosDuration)?.format();
   }
 
   protected async generatePDFs(

--- a/backend/src/projekti/status/projektiJulkinenStatusHandler.ts
+++ b/backend/src/projekti/status/projektiJulkinenStatusHandler.ts
@@ -32,7 +32,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const nahtavillaOlo = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const kuulutusPaiva = projekti.nahtavillaoloVaihe?.kuulutusPaiva;
-      if (kuulutusPaiva && isDateTimeInThePast(kuulutusPaiva)) {
+      if (kuulutusPaiva && isDateTimeInThePast(kuulutusPaiva, "start-of-day")) {
         projekti.status = API.Status.NAHTAVILLAOLO;
         super.handle(p); // Continue evaluating next rules
       }
@@ -42,7 +42,10 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const hyvaksymisMenettelyssa = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const nahtavillaoloVaihe = projekti.nahtavillaoloVaihe;
-      if (nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva)) {
+      if (
+        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva &&
+        isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "start-of-day")
+      ) {
         projekti.status = API.Status.HYVAKSYMISMENETTELYSSA;
         super.handle(p); // Continue evaluating next rules
       }
@@ -52,7 +55,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const hyvaksytty = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const hyvaksymisPaatosVaihe = projekti.hyvaksymisPaatosVaihe;
-      if (hyvaksymisPaatosVaihe?.kuulutusPaiva && isDateTimeInThePast(hyvaksymisPaatosVaihe.kuulutusPaiva)) {
+      if (hyvaksymisPaatosVaihe?.kuulutusPaiva && isDateTimeInThePast(hyvaksymisPaatosVaihe.kuulutusPaiva, "start-of-day")) {
         projekti.status = API.Status.HYVAKSYTTY;
         super.handle(p); // Continue evaluating next rules
       }
@@ -68,7 +71,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const jatkoPaatos1 = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const jatkoPaatos1Vaihe = projekti.jatkoPaatos1Vaihe;
-      if (jatkoPaatos1Vaihe?.kuulutusPaiva && isDateTimeInThePast(jatkoPaatos1Vaihe.kuulutusPaiva)) {
+      if (jatkoPaatos1Vaihe?.kuulutusPaiva && isDateTimeInThePast(jatkoPaatos1Vaihe.kuulutusPaiva, "start-of-day")) {
         projekti.status = API.Status.JATKOPAATOS_1;
         super.handle(p); // Continue evaluating next rules
       }
@@ -84,7 +87,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const jatkoPaatos2 = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const jatkoPaatos2Vaihe = projekti.jatkoPaatos2Vaihe;
-      if (jatkoPaatos2Vaihe?.kuulutusPaiva && isDateTimeInThePast(jatkoPaatos2Vaihe.kuulutusPaiva)) {
+      if (jatkoPaatos2Vaihe?.kuulutusPaiva && isDateTimeInThePast(jatkoPaatos2Vaihe.kuulutusPaiva, "start-of-day")) {
         projekti.status = API.Status.JATKOPAATOS_2;
         super.handle(p); // Continue evaluating next rules
       }

--- a/backend/src/projekti/status/projektiJulkinenStatusHandler.ts
+++ b/backend/src/projekti/status/projektiJulkinenStatusHandler.ts
@@ -1,6 +1,6 @@
 import * as API from "../../../../common/graphql/apiModel";
 import { Status } from "../../../../common/graphql/apiModel";
-import { isDateInThePast, parseDate } from "../../util/dateUtil";
+import { isDateTimeInThePast, parseDate } from "../../util/dateUtil";
 import dayjs from "dayjs";
 import { AbstractHyvaksymisPaatosEpaAktiivinenStatusHandler, StatusHandler } from "./statusHandler";
 
@@ -32,7 +32,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const nahtavillaOlo = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const kuulutusPaiva = projekti.nahtavillaoloVaihe?.kuulutusPaiva;
-      if (kuulutusPaiva && parseDate(kuulutusPaiva).isBefore(dayjs())) {
+      if (kuulutusPaiva && isDateTimeInThePast(kuulutusPaiva)) {
         projekti.status = API.Status.NAHTAVILLAOLO;
         super.handle(p); // Continue evaluating next rules
       }
@@ -42,7 +42,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const hyvaksymisMenettelyssa = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const nahtavillaoloVaihe = projekti.nahtavillaoloVaihe;
-      if (nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva)) {
+      if (nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva)) {
         projekti.status = API.Status.HYVAKSYMISMENETTELYSSA;
         super.handle(p); // Continue evaluating next rules
       }
@@ -52,7 +52,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const hyvaksytty = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const hyvaksymisPaatosVaihe = projekti.hyvaksymisPaatosVaihe;
-      if (hyvaksymisPaatosVaihe?.kuulutusPaiva && isDateInThePast(hyvaksymisPaatosVaihe.kuulutusPaiva)) {
+      if (hyvaksymisPaatosVaihe?.kuulutusPaiva && isDateTimeInThePast(hyvaksymisPaatosVaihe.kuulutusPaiva)) {
         projekti.status = API.Status.HYVAKSYTTY;
         super.handle(p); // Continue evaluating next rules
       }
@@ -68,7 +68,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const jatkoPaatos1 = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const jatkoPaatos1Vaihe = projekti.jatkoPaatos1Vaihe;
-      if (jatkoPaatos1Vaihe?.kuulutusPaiva && isDateInThePast(jatkoPaatos1Vaihe.kuulutusPaiva)) {
+      if (jatkoPaatos1Vaihe?.kuulutusPaiva && isDateTimeInThePast(jatkoPaatos1Vaihe.kuulutusPaiva)) {
         projekti.status = API.Status.JATKOPAATOS_1;
         super.handle(p); // Continue evaluating next rules
       }
@@ -84,7 +84,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
   const jatkoPaatos2 = new (class extends StatusHandler<API.ProjektiJulkinen> {
     handle(p: API.ProjektiJulkinen) {
       const jatkoPaatos2Vaihe = projekti.jatkoPaatos2Vaihe;
-      if (jatkoPaatos2Vaihe?.kuulutusPaiva && isDateInThePast(jatkoPaatos2Vaihe.kuulutusPaiva)) {
+      if (jatkoPaatos2Vaihe?.kuulutusPaiva && isDateTimeInThePast(jatkoPaatos2Vaihe.kuulutusPaiva)) {
         projekti.status = API.Status.JATKOPAATOS_2;
         super.handle(p); // Continue evaluating next rules
       }

--- a/backend/src/projekti/status/projektiJulkinenStatusHandler.ts
+++ b/backend/src/projekti/status/projektiJulkinenStatusHandler.ts
@@ -44,7 +44,7 @@ export function applyProjektiJulkinenStatus(projekti: API.ProjektiJulkinen): voi
       const nahtavillaoloVaihe = projekti.nahtavillaoloVaihe;
       if (
         nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva &&
-        isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "start-of-day")
+        isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "end-of-day")
       ) {
         projekti.status = API.Status.HYVAKSYMISMENETTELYSSA;
         super.handle(p); // Continue evaluating next rules

--- a/backend/src/projekti/status/projektiStatusHandler.ts
+++ b/backend/src/projekti/status/projektiStatusHandler.ts
@@ -67,7 +67,7 @@ export function applyProjektiStatus(projekti: API.Projekti): void {
     handle(p: API.Projekti) {
       const nahtavillaoloVaihe = findJulkaisuWithTila(p.nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
       const nahtavillaoloKuulutusPaattyyInThePast =
-        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva);
+        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "start-of-day");
 
       if (nahtavillaoloKuulutusPaattyyInThePast) {
         p.status = API.Status.HYVAKSYMISMENETTELYSSA;
@@ -83,7 +83,7 @@ export function applyProjektiStatus(projekti: API.Projekti): void {
 
       const nahtavillaoloVaihe = findJulkaisuWithTila(p.nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
       const nahtavillaoloKuulutusPaattyyInThePast =
-        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva);
+        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "start-of-day");
 
       if (hasHyvaksymisPaatos && nahtavillaoloKuulutusPaattyyInThePast) {
         p.status = API.Status.HYVAKSYTTY;

--- a/backend/src/projekti/status/projektiStatusHandler.ts
+++ b/backend/src/projekti/status/projektiStatusHandler.ts
@@ -6,7 +6,7 @@ import { log } from "../../logger";
 import { perustiedotValidationSchema } from "../../../../src/schemas/perustiedot";
 import { findJulkaisutWithTila, findJulkaisuWithTila } from "../projektiUtil";
 import { AbstractHyvaksymisPaatosEpaAktiivinenStatusHandler, StatusHandler } from "./statusHandler";
-import { isDateInThePast } from "../../util/dateUtil";
+import { isDateTimeInThePast } from "../../util/dateUtil";
 
 export function applyProjektiStatus(projekti: API.Projekti): void {
   const perustiedot = new (class extends StatusHandler<API.Projekti> {
@@ -67,7 +67,7 @@ export function applyProjektiStatus(projekti: API.Projekti): void {
     handle(p: API.Projekti) {
       const nahtavillaoloVaihe = findJulkaisuWithTila(p.nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
       const nahtavillaoloKuulutusPaattyyInThePast =
-        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva);
+        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva);
 
       if (nahtavillaoloKuulutusPaattyyInThePast) {
         p.status = API.Status.HYVAKSYMISMENETTELYSSA;
@@ -83,7 +83,7 @@ export function applyProjektiStatus(projekti: API.Projekti): void {
 
       const nahtavillaoloVaihe = findJulkaisuWithTila(p.nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
       const nahtavillaoloKuulutusPaattyyInThePast =
-        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva);
+        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva);
 
       if (hasHyvaksymisPaatos && nahtavillaoloKuulutusPaattyyInThePast) {
         p.status = API.Status.HYVAKSYTTY;

--- a/backend/src/projekti/status/projektiStatusHandler.ts
+++ b/backend/src/projekti/status/projektiStatusHandler.ts
@@ -67,7 +67,7 @@ export function applyProjektiStatus(projekti: API.Projekti): void {
     handle(p: API.Projekti) {
       const nahtavillaoloVaihe = findJulkaisuWithTila(p.nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
       const nahtavillaoloKuulutusPaattyyInThePast =
-        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "start-of-day");
+        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "end-of-day");
 
       if (nahtavillaoloKuulutusPaattyyInThePast) {
         p.status = API.Status.HYVAKSYMISMENETTELYSSA;
@@ -83,7 +83,7 @@ export function applyProjektiStatus(projekti: API.Projekti): void {
 
       const nahtavillaoloVaihe = findJulkaisuWithTila(p.nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
       const nahtavillaoloKuulutusPaattyyInThePast =
-        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "start-of-day");
+        nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva && isDateTimeInThePast(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva, "end-of-day");
 
       if (hasHyvaksymisPaatos && nahtavillaoloKuulutusPaattyyInThePast) {
         p.status = API.Status.HYVAKSYTTY;

--- a/backend/src/projekti/status/statusHandler.ts
+++ b/backend/src/projekti/status/statusHandler.ts
@@ -1,10 +1,8 @@
 import * as API from "../../../../common/graphql/apiModel";
-import { isDateInThePast } from "../../util/dateUtil";
+import { DateAddTuple, isDateTimeInThePast } from "../../util/dateUtil";
 
-export const HYVAKSYMISPAATOS_DURATION_VALUE = 1;
-export const HYVAKSYMISPAATOS_DURATION_UNIT = "year";
-export const JATKOPAATOS_DURATION_VALUE = 6;
-export const JATKOPAATOS_DURATION_UNIT = "months";
+export const HYVAKSYMISPAATOS_DURATION: DateAddTuple = [1, "year"];
+export const JATKOPAATOS_DURATION: DateAddTuple = [6, "months"];
 
 // Chain of responsibilites pattern to determine projekti status
 export abstract class StatusHandler<T> {
@@ -48,20 +46,8 @@ export abstract class AbstractHyvaksymisPaatosEpaAktiivinenStatusHandler<
     // Kuulutusvaiheen päättymisestä pitää olla vuosi
     const kuulutusVaihePaattyyPaiva = hyvaksymisPaatosVaihe?.kuulutusVaihePaattyyPaiva;
     if (kuulutusVaihePaattyyPaiva) {
-      let hyvaksymisPaatosKuulutusPaattyyInThePast: boolean;
-      if (this.isHyvaksymisPaatos) {
-        hyvaksymisPaatosKuulutusPaattyyInThePast = isDateInThePast(
-          kuulutusVaihePaattyyPaiva,
-          HYVAKSYMISPAATOS_DURATION_VALUE,
-          HYVAKSYMISPAATOS_DURATION_UNIT
-        );
-      } else {
-        hyvaksymisPaatosKuulutusPaattyyInThePast = isDateInThePast(
-          kuulutusVaihePaattyyPaiva,
-          JATKOPAATOS_DURATION_VALUE,
-          JATKOPAATOS_DURATION_UNIT
-        );
-      }
+      const paatosDuration = this.isHyvaksymisPaatos ? HYVAKSYMISPAATOS_DURATION : JATKOPAATOS_DURATION;
+      const hyvaksymisPaatosKuulutusPaattyyInThePast = isDateTimeInThePast(kuulutusVaihePaattyyPaiva, "end-of-day", paatosDuration);
 
       if (hyvaksymisPaatosKuulutusPaattyyInThePast) {
         p.status = this.epaAktiivisuusStatus;

--- a/backend/src/util/dateUtil.ts
+++ b/backend/src/util/dateUtil.ts
@@ -50,10 +50,10 @@ export function localDateTimeString(): string {
 
 export function isDateTimeInThePast(
   dateString: string | undefined,
-  defaultTimeToEndOfDay?: DefaultTimeTo | undefined,
+  defaultTimeTo: DefaultTimeTo,
   ...dateAddTuples: DateAddTuple[]
 ): boolean {
-  const date = parseAndAddDateTime(dateString, defaultTimeToEndOfDay, ...dateAddTuples);
+  const date = parseAndAddDateTime(dateString, defaultTimeTo, ...dateAddTuples);
   if (date) {
     return date.isBefore(dayjs());
   }
@@ -62,7 +62,7 @@ export function isDateTimeInThePast(
 
 export function parseAndAddDateTime(
   dateString: string | undefined,
-  defaultTimeToEndOfDay?: DefaultTimeTo | undefined,
+  defaultTimeTo: DefaultTimeTo,
   ...dateAddTuples: DateAddTuple[]
 ): Dayjs | undefined {
   if (dateString) {
@@ -70,7 +70,7 @@ export function parseAndAddDateTime(
     dateAddTuples.forEach(([value, unit]) => {
       date = date.add(value, unit);
     });
-    if (defaultTimeToEndOfDay === "end-of-day" && isDateStringLackingTimeElement(dateString)) {
+    if (defaultTimeTo === "end-of-day" && isDateStringLackingTimeElement(dateString)) {
       date = date.endOf("day");
     }
     return date;


### PR DESCRIPTION
Tässä PR:ssä korjasin HASSU-1155 tiketissä havaitun hyväksymispäätösjulkaisun logiikkavirheen.

Osa julkaisuista tuli julkaisupäivän lopussa näkyville kansalais puolelle. Tämä johtui siitä, että backend/src/util/dateUtil.ts-tiedoston isDateTimeInThePast ja parseAndAddDateTime oli laitettu oletus kellon ajaksi 23.59. Muokkasin nyt sen parametrilla muokattavaksi. 

Muokkasin funktioiden käyttäytymistä niin, että parseAndAddDateTime ei aseta kellon aikaa erikseen mihinkään, joten se jää 00.00, mikäli sille annetaan YYYY-MM-DD -muodossa ISO-päivämäärä. Mikäli funktiolle annetaan "end-of-day" string-parametri, siirretään kellonaika päivän loppuun.