### PR TITLE
feat: Mahdollista aloituskuulutuksen uudelleenkuulutus

### DIFF
--- a/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusUudelleenKuulutus.test.ts.snap
+++ b/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusUudelleenKuulutus.test.ts.snap
@@ -82,7 +82,7 @@ Object {
       "RUOTSI": "På Svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -98,7 +98,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi suunnitteluvaihe",
       "SUOMI": "Lorem Ipsum suunnitteluvaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "palautteidenVastaanottajat": Array [
       "A000111",
@@ -119,7 +119,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi suunnitteluvaihe",
       "SUOMI": "Lorem Ipsum suunnitteluvaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "palautteidenVastaanottajat": Array [
       "A000111",
@@ -1188,7 +1188,7 @@ Object {
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
         "SUOMI": "Lorem Ipsum",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "kielitiedot": Object {
         "__typename": "Kielitiedot",
@@ -1307,7 +1307,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi suunnitteluvaihe",
       "SUOMI": "Lorem Ipsum suunnitteluvaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "suunnittelunEteneminenJaKesto": "suunnitelma etenee aikataulussa ja valmistuu vuoden 2022 aikana",
     "vuorovaikutukset": Array [
@@ -1820,7 +1820,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi nahtavillaoloVaihe",
       "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "id": 1,
     "ilmoituksenVastaanottajat": Object {
@@ -1943,7 +1943,7 @@ Object {
       "hankkeenKuvaus": Object {
         "SAAME": "Saameksi nahtavillaoloVaihe",
         "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "id": 1,
       "ilmoituksenVastaanottajat": Object {
@@ -2139,7 +2139,7 @@ Object {
       "hankkeenKuvaus": Object {
         "SAAME": "Saameksi nahtavillaoloVaihe",
         "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "id": 1,
       "ilmoituksenVastaanottajat": Object {
@@ -2276,7 +2276,7 @@ Object {
         "hankkeenKuvaus": Object {
           "SAAME": "Saameksi nahtavillaoloVaihe",
           "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-          "__typename": "HankkeenKuvaukset",
+          "__typename": "LokalisoituTeksti",
         },
         "hyvaksyja": "A000112",
         "id": 1,
@@ -2446,7 +2446,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi nahtavillaoloVaihe",
       "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",

--- a/backend/integrationtest/api/apiTestFixture.ts
+++ b/backend/integrationtest/api/apiTestFixture.ts
@@ -1,12 +1,13 @@
 import {
-  AloitusKuulutus, AloitusKuulutusInput,
-  HankkeenKuvauksetInput,
+  AloitusKuulutus,
+  AloitusKuulutusInput,
   IlmoitettavaViranomainen,
   IlmoituksenVastaanottajat,
   KaytettavaPalvelu,
   Kieli,
   Kielitiedot,
   KielitiedotInput,
+  LokalisoituTekstiInput,
   MuokkausTila,
   NahtavillaoloVaiheInput,
   SuunnitteluSopimus,
@@ -125,7 +126,7 @@ class ApiTestFixture {
     muokkausTila: MuokkausTila.MUOKKAUS,
     kuulutusPaiva: "2022-01-02",
     hankkeenKuvaus: {
-      __typename: "HankkeenKuvaukset",
+      __typename: "LokalisoituTeksti",
       SUOMI: "Lorem Ipsum",
       RUOTSI: "På Svenska",
       SAAME: "Saameksi",
@@ -165,7 +166,7 @@ class ApiTestFixture {
     ensisijainenKieli: Kieli.SUOMI,
   };
 
-  hankkeenKuvausSuunnittelu: HankkeenKuvauksetInput = {
+  hankkeenKuvausSuunnittelu: LokalisoituTekstiInput = {
     SUOMI: "Lorem Ipsum suunnitteluvaihe",
     SAAME: "Saameksi suunnitteluvaihe",
   };

--- a/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
+++ b/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
@@ -566,7 +566,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi nahtavillaoloVaihe",
       "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "id": 1,
     "ilmoituksenVastaanottajat": Object {
@@ -648,7 +648,7 @@ Object {
       "hankkeenKuvaus": Object {
         "SAAME": "Saameksi nahtavillaoloVaihe",
         "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "id": 1,
       "ilmoituksenVastaanottajat": Object {
@@ -731,7 +731,7 @@ Object {
       "hankkeenKuvaus": Object {
         "SAAME": "Saameksi nahtavillaoloVaihe",
         "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "id": 1,
       "ilmoituksenVastaanottajat": Object {
@@ -807,7 +807,7 @@ Object {
         "hankkeenKuvaus": Object {
           "SAAME": "Saameksi nahtavillaoloVaihe",
           "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-          "__typename": "HankkeenKuvaukset",
+          "__typename": "LokalisoituTeksti",
         },
         "hyvaksyja": "A000112",
         "id": 1,
@@ -920,7 +920,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi nahtavillaoloVaihe",
       "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
@@ -1020,7 +1020,7 @@ Object {
       "hankkeenKuvaus": Object {
         "SAAME": "Saameksi nahtavillaoloVaihe",
         "SUOMI": "Lorem Ipsum nahtavillaoloVaihe",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "kielitiedot": Object {
         "__typename": "Kielitiedot",
@@ -1128,7 +1128,7 @@ Object {
     "hankkeenKuvaus": Object {
       "SAAME": "Saameksi suunnitteluvaihe",
       "SUOMI": "Lorem Ipsum suunnitteluvaihe",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "palautteidenVastaanottajat": Array [
       "A000111",
@@ -1195,7 +1195,7 @@ Object {
       "hankkeenKuvaus": Object {
         "SAAME": "Saameksi suunnitteluvaihe",
         "SUOMI": "Lorem Ipsum suunnitteluvaihe",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "suunnittelunEteneminenJaKesto": "suunnitelma etenee aikataulussa ja valmistuu vuoden 2022 aikana",
       "vuorovaikutukset": Array [],

--- a/backend/src/projekti/adapter/adaptToDB/common.ts
+++ b/backend/src/projekti/adapter/adaptToDB/common.ts
@@ -150,7 +150,7 @@ export function removeTypeName<Type>(o: General<Type> | null | undefined): Type 
 }
 
 export function adaptHankkeenKuvausToSave(
-  hankkeenKuvaus: API.HankkeenKuvauksetInput | undefined | null
+  hankkeenKuvaus: API.LokalisoituTekstiInput | undefined | null
 ): LocalizedMap<string> | undefined | null {
   if (!hankkeenKuvaus) {
     return hankkeenKuvaus;

--- a/backend/src/projekti/adapter/common/adaptHankkeenKuvaus.ts
+++ b/backend/src/projekti/adapter/common/adaptHankkeenKuvaus.ts
@@ -1,10 +1,10 @@
 import { LocalizedMap } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 
-export function adaptHankkeenKuvaus(hankkeenKuvaus: LocalizedMap<string> | undefined): API.HankkeenKuvaukset | undefined {
+export function adaptHankkeenKuvaus(hankkeenKuvaus: LocalizedMap<string> | undefined): API.LokalisoituTeksti | undefined {
   if (hankkeenKuvaus && Object.keys(hankkeenKuvaus).length > 0) {
     return {
-      __typename: "HankkeenKuvaukset",
+      __typename: "LokalisoituTeksti",
       [API.Kieli.SUOMI]: hankkeenKuvaus[API.Kieli.SUOMI] || "",
       ...hankkeenKuvaus,
     };

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -449,7 +449,7 @@ Array [
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
         "SUOMI": "Lorem Ipsum",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "ilmoituksenVastaanottajat": Object {
         "__typename": "IlmoituksenVastaanottajat",
@@ -795,7 +795,7 @@ Object {
       "RUOTSI": "På Svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "ilmoituksenVastaanottajat": Object {
       "__typename": "IlmoituksenVastaanottajat",
@@ -862,7 +862,7 @@ Object {
       "RUOTSI": "På Svenska",
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
-      "__typename": "HankkeenKuvaukset",
+      "__typename": "LokalisoituTeksti",
     },
     "hyvaksyja": "A123",
     "hyvaksymisPaiva": "2022-09-28",
@@ -1031,7 +1031,7 @@ Object {
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
         "SUOMI": "Lorem Ipsum",
-        "__typename": "HankkeenKuvaukset",
+        "__typename": "LokalisoituTeksti",
       },
       "kielitiedot": Object {
         "__typename": "Kielitiedot",

--- a/common/testUtil.dev.js
+++ b/common/testUtil.dev.js
@@ -6,6 +6,7 @@ export const TestAction = {
   NAHTAVILLAOLO_MENNEISYYTEEN: "nahtavillaolomenneisyyteen",
   HYVAKSYMISPAATOS_MENNEISYYTEEN: "hyvaksymispaatosmenneisyyteen",
   HYVAKSYMISPAATOS_VUOSI_MENNEISYYTEEN: "hyvaksymispaatosvuosimenneisyyteen",
+  RESET_ALOITUSKUULUTUS: "reset_aloituskuulutus",
   RESET_SUUNNITTELU: "reset_suunnittelu",
   RESET_VUOROVAIKUTUKSET: "reset_vuorovaikutukset",
   RESET_NAHTAVILLAOLO: "reset_nahtavillaolo",
@@ -42,6 +43,10 @@ export class ProjektiTestCommand {
 
   hyvaksymispaatosVuosiMenneisyyteen() {
     return this.createActionUrl(TestAction.HYVAKSYMISPAATOS_VUOSI_MENNEISYYTEEN);
+  }
+
+  resetAloituskuulutus() {
+    return this.createActionUrl(TestAction.RESET_ALOITUSKUULUTUS);
   }
 
   resetSuunnitteluVaihe() {
@@ -134,6 +139,12 @@ export class ProjektiTestCommandExecutor {
 
   onResetNahtavillaolo(callback) {
     if (this._action === TestAction.RESET_NAHTAVILLAOLO) {
+      return callback(this._oid);
+    }
+  }
+
+  onResetAloituskuulutus(callback) {
+    if (this._action === TestAction.RESET_ALOITUSKUULUTUS) {
       return callback(this._oid);
     }
   }

--- a/cypress/integration/2-perusta-projekti/004-aloituskuulutus.spec.js
+++ b/cypress/integration/2-perusta-projekti/004-aloituskuulutus.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
-import { capturePDFPreview, requestPDFs } from "../../support/util";
-import { formatDate } from "../../../src/util/dateUtils";
+import { taytaJaJulkaiseAloituskuulutus } from "./aloituskuulutus";
+import { ProjektiTestCommand } from "../../../common/testUtil.dev";
 
 const projektiNimi = Cypress.env("projektiNimi");
 const oid = Cypress.env("oid");
@@ -12,69 +12,11 @@ describe("Projektin aloituskuulutus", () => {
   });
 
   it("Projektin aloituskuulutus", { scrollBehavior: "center" }, () => {
-    cy.visit(Cypress.env("host") + "/yllapito/projekti/" + oid + "/aloituskuulutus");
-    cy.contains(projektiNimi);
-
-    // Make re-running the test automatic in the development by cancelling the acceptance request
-    cy.get("main").then((main) => {
-      let rejectButton = main.find("#button_reject");
-      if (rejectButton.length > 0) {
-        cy.wrap(rejectButton).click();
-        cy.get('[name="syy"]').type("Palautussyy");
-        cy.get("#reject_and_edit").click();
-        cy.visit(Cypress.env("host") + "/yllapito/projekti/" + oid + "/aloituskuulutus");
-      }
-    });
-
-    cy.get('[name="aloitusKuulutus.kuulutusPaiva"]').should("be.enabled").type(formatDate(), {
-      waitForAnimations: true,
-    });
-
-    cy.get("main").then((elem) => {
-      let htmlElements = elem.find('[name="contact_info_trash_button"]');
-      for (const htmlElement of htmlElements) {
-        htmlElement.click();
-      }
-    });
-
-    cy.get("#add_new_contact").click();
-
-    cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.etunimi"]').type("Yhteystietoetunimi");
-    cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.sukunimi"]').type("Yhteystietosukunimi");
-    cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.organisaatio"]').type("Minun Organisaationi");
-    cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.puhelinnumero"]').type("0293333333");
-    cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.sahkoposti"]').type("test@vayla.fi");
-
-    cy.get('[name="aloitusKuulutus.hankkeenKuvaus.SUOMI"]').clear({ scrollBehavior: "center" }).type("Hankkeen kuvaus Suomeksi");
-    cy.get('[name="aloitusKuulutus.hankkeenKuvaus.RUOTSI"]').clear({ scrollBehavior: "center" }).type("Hankkeen kuvaus Ruotsiksi");
-
-    cy.get("main").then((elem) => {
-      let htmlElements = elem.find('[name="viranomainen_trash_button"]');
-      for (const htmlElement of htmlElements) {
-        htmlElement.click();
-      }
-    });
-
-    cy.get("#add_new_viranomainen").click();
-    cy.get('[name="aloitusKuulutus.ilmoituksenVastaanottajat.viranomaiset.0.nimi"]').select("PIRKANMAAN_ELY");
-
-    cy.get('[name="aloitusKuulutus.ilmoituksenVastaanottajat.kunnat.0.sahkoposti"]').clear().type("test@vayla.fi");
-    cy.get('[name="aloitusKuulutus.ilmoituksenVastaanottajat.kunnat.1.sahkoposti"]').clear().type("test@vayla.fi");
-
-    const pdfs = capturePDFPreview();
-    cy.get("#preview_kuulutus_pdf_SUOMI").click();
-    cy.get("#preview_kuulutus_pdf_RUOTSI").click();
-    cy.get("#preview_ilmoitus_pdf_SUOMI").click();
-    cy.get("#preview_ilmoitus_pdf_RUOTSI").click();
-    requestPDFs(pdfs);
-    cy.get("#save_and_send_for_acceptance").click({ force: true });
-    cy.contains("Aloituskuulutus on hyväksyttävänä");
-    cy.get("#button_open_acceptance_dialog")
-      .should("be.enabled")
-      .scrollIntoView({ offset: { top: 500, left: 0 } })
-      .should("be.visible")
-      .click({ force: true });
-    cy.get("#accept_kuulutus").click();
-    cy.contains("Aloituskuulutus on julkaistu", { timeout: 15000 });
+    cy.visit(Cypress.env("host") + ProjektiTestCommand.oid(oid).resetAloituskuulutus(), { timeout: 30000 });
+    taytaJaJulkaiseAloituskuulutus(oid, projektiNimi);
+  });
+  it("Uudelleenkuuluta aloituskuulutus", { scrollBehavior: "center" }, () => {
+    const uudelleenkuulutus = true;
+    taytaJaJulkaiseAloituskuulutus(oid, projektiNimi, uudelleenkuulutus);
   });
 });

--- a/cypress/integration/2-perusta-projekti/aloituskuulutus.js
+++ b/cypress/integration/2-perusta-projekti/aloituskuulutus.js
@@ -1,0 +1,70 @@
+import { formatDate } from "../../../src/util/dateUtils";
+import { capturePDFPreview, requestPDFs } from "../../support/util";
+
+export function taytaJaJulkaiseAloituskuulutus(oid, projektiNimi, uudelleenkuulutus) {
+  cy.visit(Cypress.env("host") + "/yllapito/projekti/" + oid + "/aloituskuulutus");
+  cy.contains(projektiNimi);
+
+  if (uudelleenkuulutus) {
+    cy.get("#uudelleenkuuluta_button").click();
+    cy.get("#avaa_uudelleenkuulutettavaksi", { timeout: 15000 }).click();
+
+    cy.get('[name="aloitusKuulutus.uudelleenKuulutus.selosteKuulutukselle.SUOMI"]', { timeout: 15000 }).type(
+      "Selostetta kuulutukselle suomeksi"
+    );
+    cy.get('[name="aloitusKuulutus.uudelleenKuulutus.selosteKuulutukselle.RUOTSI"]').type("Selostetta kuulutukselle ruotsiksi");
+    cy.get('[name="aloitusKuulutus.uudelleenKuulutus.selosteLahetekirjeeseen.SUOMI"]').type("Selostetta lähetekirjeeseen suomeksi");
+    cy.get('[name="aloitusKuulutus.uudelleenKuulutus.selosteLahetekirjeeseen.RUOTSI"]').type("Selostetta lähetekirjeeseen ruotsiksi");
+  }
+
+  cy.get('[name="aloitusKuulutus.kuulutusPaiva"]').should("be.enabled").type(formatDate(), {
+    waitForAnimations: true,
+  });
+
+  cy.get("main").then((elem) => {
+    let htmlElements = elem.find('[name="contact_info_trash_button"]');
+    for (const htmlElement of htmlElements) {
+      htmlElement.click();
+    }
+  });
+
+  cy.get("#add_new_contact").click();
+
+  cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.etunimi"]').type("Yhteystietoetunimi");
+  cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.sukunimi"]').type("Yhteystietosukunimi");
+  cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.organisaatio"]').type("Minun Organisaationi");
+  cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.puhelinnumero"]').type("0293333333");
+  cy.get('[name="aloitusKuulutus.kuulutusYhteystiedot.yhteysTiedot.0.sahkoposti"]').type("test@vayla.fi");
+
+  cy.get('[name="aloitusKuulutus.hankkeenKuvaus.SUOMI"]').clear({ scrollBehavior: "center" }).type("Hankkeen kuvaus Suomeksi");
+  cy.get('[name="aloitusKuulutus.hankkeenKuvaus.RUOTSI"]').clear({ scrollBehavior: "center" }).type("Hankkeen kuvaus Ruotsiksi");
+
+  cy.get("main").then((elem) => {
+    let htmlElements = elem.find('[name="viranomainen_trash_button"]');
+    for (const htmlElement of htmlElements) {
+      htmlElement.click();
+    }
+  });
+
+  cy.get("#add_new_viranomainen").click();
+  cy.get('[name="aloitusKuulutus.ilmoituksenVastaanottajat.viranomaiset.0.nimi"]').select("PIRKANMAAN_ELY");
+
+  cy.get('[name="aloitusKuulutus.ilmoituksenVastaanottajat.kunnat.0.sahkoposti"]').clear().type("test@vayla.fi");
+  cy.get('[name="aloitusKuulutus.ilmoituksenVastaanottajat.kunnat.1.sahkoposti"]').clear().type("test@vayla.fi");
+
+  const pdfs = capturePDFPreview();
+  cy.get("#preview_kuulutus_pdf_SUOMI").click();
+  cy.get("#preview_kuulutus_pdf_RUOTSI").click();
+  cy.get("#preview_ilmoitus_pdf_SUOMI").click();
+  cy.get("#preview_ilmoitus_pdf_RUOTSI").click();
+  requestPDFs(pdfs);
+  cy.get("#save_and_send_for_acceptance").click({ force: true });
+  cy.contains("Aloituskuulutus on hyväksyttävänä");
+  cy.get("#button_open_acceptance_dialog")
+    .should("be.enabled")
+    .scrollIntoView({ offset: { top: 500, left: 0 } })
+    .should("be.visible")
+    .click({ force: true });
+  cy.get("#accept_kuulutus").click();
+  cy.contains("Aloituskuulutus on julkaistu", { timeout: 15000 });
+}

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -35,16 +35,10 @@ input YhteystietoInput {
   titteli: String
 }
 
-input HankkeenKuvauksetInput {
-  SUOMI: String!
-  RUOTSI: String
-  SAAME: String
-}
-
 input AloitusKuulutusInput {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
-  hankkeenKuvaus: HankkeenKuvauksetInput
+  hankkeenKuvaus: LokalisoituTekstiInput
   kuulutusYhteystiedot: StandardiYhteystiedotInput
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajatInput
   uudelleenKuulutus: UudelleenKuulutusInput
@@ -88,7 +82,7 @@ input SuunnitteluSopimusInput {
 }
 
 input SuunnitteluVaiheInput {
-  hankkeenKuvaus: HankkeenKuvauksetInput
+  hankkeenKuvaus: LokalisoituTekstiInput
   arvioSeuraavanVaiheenAlkamisesta: String
   suunnittelunEteneminenJaKesto: String
   tila: SuunnitteluVaiheTila
@@ -157,7 +151,7 @@ input NahtavillaoloVaiheInput {
   kuulutusPaiva: String
   kuulutusVaihePaattyyPaiva: String
   muistutusoikeusPaattyyPaiva: String
-  hankkeenKuvaus: HankkeenKuvauksetInput
+  hankkeenKuvaus: LokalisoituTekstiInput
   kuulutusYhteystiedot: StandardiYhteystiedotInput
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajatInput
 }

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -137,7 +137,7 @@ type Projekti implements IProjekti {
 }
 
 type SuunnitteluVaihe {
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   arvioSeuraavanVaiheenAlkamisesta: String
   suunnittelunEteneminenJaKesto: String
   tila: SuunnitteluVaiheTila
@@ -151,7 +151,7 @@ type SuunnitteluVaihe {
 
 type SuunnitteluVaiheJulkinen {
   tila: SuunnitteluVaiheTila
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   arvioSeuraavanVaiheenAlkamisesta: String
   suunnittelunEteneminenJaKesto: String
   vuorovaikutukset: [VuorovaikutusJulkinen!]
@@ -211,7 +211,7 @@ type NahtavillaoloVaihe {
   kuulutusPaiva: String
   kuulutusVaihePaattyyPaiva: String
   muistutusoikeusPaattyyPaiva: String
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   kuulutusYhteystiedot: StandardiYhteystiedot
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajat
   palautusSyy: String
@@ -237,7 +237,7 @@ type NahtavillaoloVaiheJulkaisu {
   kuulutusPaiva: String
   kuulutusVaihePaattyyPaiva: String
   muistutusoikeusPaattyyPaiva: String
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   velho: Velho!
   kielitiedot: Kielitiedot
   yhteystiedot: [Yhteystieto!]!
@@ -272,7 +272,7 @@ type NahtavillaoloVaiheJulkaisuJulkinen {
   kuulutusPaiva: String
   kuulutusVaihePaattyyPaiva: String
   muistutusoikeusPaattyyPaiva: String
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   velho: VelhoJulkinen!
   kielitiedot: Kielitiedot
   yhteystiedot: [Yhteystieto!]!
@@ -336,7 +336,7 @@ type NahtavillaoloVaiheJulkinen {
   kuulutusPaiva: String
   kuulutusVaihePaattyyPaiva: String
   muistutusoikeusPaattyyPaiva: String
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   kuulutusYhteysHenkilot: [String!]
   kuulutusYhteystiedot: [Yhteystieto!]
 }
@@ -555,12 +555,6 @@ type UudelleenKuulutus {
   alkuperainenHyvaksymisPaiva: String
 }
 
-type HankkeenKuvaukset {
-  SUOMI: String!
-  RUOTSI: String
-  SAAME: String
-}
-
 type LokalisoituTeksti {
   SUOMI: String!
   RUOTSI: String
@@ -581,7 +575,7 @@ type AloitusKuulutusPDFt {
 type AloitusKuulutus {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   kuulutusYhteystiedot: StandardiYhteystiedot
   palautusSyy: String
   ilmoituksenVastaanottajat: IlmoituksenVastaanottajat
@@ -597,7 +591,7 @@ type StandardiYhteystiedot {
 type AloitusKuulutusJulkaisu {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   yhteystiedot: [Yhteystieto!]!
   velho: Velho!
   suunnitteluSopimus: SuunnitteluSopimusJulkaisu
@@ -613,7 +607,7 @@ type AloitusKuulutusJulkaisu {
 type AloitusKuulutusJulkaisuJulkinen {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
-  hankkeenKuvaus: HankkeenKuvaukset
+  hankkeenKuvaus: LokalisoituTeksti
   yhteystiedot: [Yhteystieto!]!
   velho: VelhoJulkinen!
   suunnitteluSopimus: SuunnitteluSopimusJulkaisu

--- a/src/components/HassuDialog.tsx
+++ b/src/components/HassuDialog.tsx
@@ -1,12 +1,13 @@
 import { Dialog, DialogProps, DialogTitle, Stack } from "@mui/material";
 import React, { ReactElement } from "react";
 import WindowCloseButton from "./button/WindowCloseButton";
-interface Props {
+
+export type HassuDialogProps = {
   title?: string;
   hideCloseButton?: boolean;
-}
+} & DialogProps;
 
-const HassuDialog = (props: DialogProps & Props): ReactElement => {
+const HassuDialog = (props: HassuDialogProps): ReactElement => {
   const { children, title, hideCloseButton, PaperProps, ...dialogProps } = props;
 
   const { sx: paperSx, ...paperProps } = PaperProps || {};
@@ -34,9 +35,7 @@ const HassuDialog = (props: DialogProps & Props): ReactElement => {
             <h4 style={{ margin: 0 }} className="vayla-dialog-title">
               {title}
             </h4>
-            {!hideCloseButton && (
-              <WindowCloseButton size="small" onClick={() => dialogProps.onClose?.({}, "escapeKeyDown")} />
-            )}
+            {!hideCloseButton && <WindowCloseButton size="small" onClick={() => dialogProps.onClose?.({}, "escapeKeyDown")} />}
           </Stack>
         </DialogTitle>
       )}

--- a/src/components/TallentamattomiaMuutoksiaDialog.tsx
+++ b/src/components/TallentamattomiaMuutoksiaDialog.tsx
@@ -1,10 +1,10 @@
 import { DialogActions, DialogContent } from "@mui/material";
-import React, { FC } from "react";
+import React, { FunctionComponent } from "react";
 import Button from "./button/Button";
 import HassuDialog from "./HassuDialog";
 import HassuStack from "./layout/HassuStack";
 
-const TallentamattomiaMuutoksiaDialog: FC<{ open: boolean; handleClickClose: () => void; handleClickOk: () => void }> = ({
+const TallentamattomiaMuutoksiaDialog: FunctionComponent<{ open: boolean; handleClickClose: () => void; handleClickOk: () => void }> = ({
   open,
   handleClickClose,
   handleClickOk,

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, FC } from "react";
+import React, { ReactElement, useMemo, FunctionComponent } from "react";
 import { NextRouter, useRouter } from "next/router";
 import Link from "next/link";
 import useTranslation from "next-translate/useTranslation";
@@ -138,7 +138,7 @@ export const generateRoutes = (nextRouter: NextRouter, labels: RouteLabels): Rou
   return routes;
 };
 
-const BreadcrumbComponent: FC<{ routeLabels: RouteLabels; isYllapito?: boolean }> = ({ routeLabels, isYllapito }) => {
+const BreadcrumbComponent: FunctionComponent<{ routeLabels: RouteLabels; isYllapito?: boolean }> = ({ routeLabels, isYllapito }) => {
   const { t } = useTranslation();
   const router = useRouter();
   return (

--- a/src/components/layout/LinkTab.tsx
+++ b/src/components/layout/LinkTab.tsx
@@ -1,10 +1,10 @@
 import { Tab, TabProps } from "@mui/material";
 import Link, { LinkProps } from "next/link";
-import React, { FC } from "react";
+import React, { FunctionComponent } from "react";
 
 export type LinkTabProps = TabProps & { linkProps: LinkProps };
 
-export const LinkTab: FC<LinkTabProps> = ({ linkProps, ...tabProps }) => (
+export const LinkTab: FunctionComponent<LinkTabProps> = ({ linkProps, ...tabProps }) => (
   <Link {...linkProps} passHref>
     <Tab {...tabProps} />
   </Link>

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -1,8 +1,8 @@
 import { throttle } from "lodash";
-import React, { FC, useEffect, useState } from "react";
+import React, { FunctionComponent, useEffect, useState } from "react";
 
 const SCROLL_OFFSET = 200;
-const ScrollToTopButton: FC = ({}) => {
+const ScrollToTopButton: FunctionComponent = ({}) => {
   const [toTopEnabled, setToTopEnabled] = useState(false);
 
   useEffect(() => {

--- a/src/components/layout/header/KansalaisHeaderTopRightContent.tsx
+++ b/src/components/layout/header/KansalaisHeaderTopRightContent.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FunctionComponent } from "react";
 import useTranslation from "next-translate/useTranslation";
 import { useRouter } from "next/router";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
@@ -6,7 +6,7 @@ import { Kieli } from "@services/api";
 import useSnackbars from "src/hooks/useSnackbars";
 import setLanguage from "next-translate/setLanguage";
 
-const KansalaisHeaderTopRightContent: FC = () => {
+const KansalaisHeaderTopRightContent: FunctionComponent = () => {
   const { t } = useTranslation("common");
   const router = useRouter();
   const { data: projekti } = useProjektiJulkinen();

--- a/src/components/layout/header/VirkamiesHeaderTopRightContent.tsx
+++ b/src/components/layout/header/VirkamiesHeaderTopRightContent.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from "react";
+import React, { FunctionComponent } from "react";
 import ButtonLink from "@components/button/ButtonLink";
 import useCurrentUser from "../../../hooks/useCurrentUser";
 import StyledLink from "@components/StyledLink";
 
-const VirkamiesHeaderTopRightContent: FC<{ mobile?: true }> = ({ mobile }) => {
+const VirkamiesHeaderTopRightContent: FunctionComponent<{ mobile?: true }> = ({ mobile }) => {
   const { data: kayttaja } = useCurrentUser();
   const kayttajaNimi = kayttaja && kayttaja.etunimi && kayttaja.sukunimi && `${kayttaja.sukunimi}, ${kayttaja.etunimi}`;
   const logoutHref = process.env.NEXT_PUBLIC_VAYLA_EXTRANET_URL;

--- a/src/components/layout/header/header.tsx
+++ b/src/components/layout/header/header.tsx
@@ -1,4 +1,14 @@
-import React, { ComponentProps, Dispatch, FC, ReactElement, RefObject, SetStateAction, useEffect, useRef, useState } from "react";
+import React, {
+  ComponentProps,
+  Dispatch,
+  FunctionComponent,
+  ReactElement,
+  RefObject,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/router";
 import VirkamiesHeaderTopRightContent from "./VirkamiesHeaderTopRightContent";
 import { Backdrop, Container, styled, useMediaQuery, useTheme } from "@mui/material";
@@ -206,7 +216,7 @@ export default function Header(): ReactElement {
   );
 }
 
-const Navigation: FC<{ navigationRoutes: NavigationRoute[]; mobile?: true }> = ({ navigationRoutes, mobile }) => {
+const Navigation: FunctionComponent<{ navigationRoutes: NavigationRoute[]; mobile?: true }> = ({ navigationRoutes, mobile }) => {
   return (
     <nav className="block md:flex border-t border-gray-light uppercase">
       <ul className="block pb-8 md:pb-0 md:flex md:float-left md:flex-wrap md:space-x-16">
@@ -236,7 +246,10 @@ const SivustoLogo = styled(({ className, href }: { className?: string; href: str
   },
 }));
 
-const HamburgerButton: FC<{ isHamburgerOpen: boolean; onClick: ComponentProps<"button">["onClick"] }> = ({ isHamburgerOpen, onClick }) => {
+const HamburgerButton: FunctionComponent<{ isHamburgerOpen: boolean; onClick: ComponentProps<"button">["onClick"] }> = ({
+  isHamburgerOpen,
+  onClick,
+}) => {
   return (
     <>
       <div>

--- a/src/components/layout/navigation/HeaderNavigationItem.tsx
+++ b/src/components/layout/navigation/HeaderNavigationItem.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FunctionComponent } from "react";
 import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
@@ -12,7 +12,7 @@ export interface NavigationRoute {
   mobile?: true;
 }
 
-const HeaderNavigationItem: FC<NavigationRoute> = ({ href, label, icon, removeLeftPadding, mobile }) => (
+const HeaderNavigationItem: FunctionComponent<NavigationRoute> = ({ href, label, icon, removeLeftPadding, mobile }) => (
   <li>
     <Link href={href}>
       <a

--- a/src/components/projekti/PaivitaVelhoTiedotButton.tsx
+++ b/src/components/projekti/PaivitaVelhoTiedotButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, VFC } from "react";
+import React, { useCallback, useEffect, useRef, useState, VoidFunctionComponent } from "react";
 import Button from "@components/button/Button";
 import { api } from "@services/api";
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
@@ -7,35 +7,49 @@ import useSnackbars from "src/hooks/useSnackbars";
 import log from "loglevel";
 import HassuSpinner from "@components/HassuSpinner";
 
-const PaivitaVelhoTiedotButton: VFC<{ projektiOid: string; reloadProjekti: KeyedMutator<ProjektiLisatiedolla | null> }> = ({
-  projektiOid,
-  reloadProjekti,
-}) => {
-  const [loading, setLoading] = useState(false);
-  const { showSuccessMessage, showErrorMessage } = useSnackbars();
+const PaivitaVelhoTiedotButton: VoidFunctionComponent<{ projektiOid: string; reloadProjekti: KeyedMutator<ProjektiLisatiedolla | null> }> =
+  ({ projektiOid, reloadProjekti }) => {
+    const mountedRef = useRef(false);
 
-  const uudelleenLataaProjekit = useCallback(async () => {
-    if (projektiOid) {
-      try {
-        setLoading(true);
-        await api.synkronoiProjektiMuutoksetVelhosta(projektiOid);
-        await reloadProjekti();
-        setLoading(false);
-        showSuccessMessage("Projekti päivitetty");
-      } catch (e) {
-        setLoading(false);
-        log.log("realoadProjekti Error", e);
-        showErrorMessage("Päivittämisessä tapahtui virhe!");
+    useEffect(() => {
+      mountedRef.current = true;
+      return () => {
+        mountedRef.current = false;
+      };
+    }, []);
+
+    const [loading, setLoading] = useState(false);
+    const { showSuccessMessage, showErrorMessage } = useSnackbars();
+
+    const uudelleenLataaProjekit = useCallback(async () => {
+      const isMounted = mountedRef.current;
+      if (projektiOid) {
+        try {
+          if (isMounted) {
+            setLoading(true);
+          }
+          await api.synkronoiProjektiMuutoksetVelhosta(projektiOid);
+          await reloadProjekti();
+          if (isMounted) {
+            setLoading(false);
+          }
+          showSuccessMessage("Projekti päivitetty");
+        } catch (e) {
+          log.log("realoadProjekti Error", e);
+          if (isMounted) {
+            setLoading(false);
+            showErrorMessage("Päivittämisessä tapahtui virhe!");
+          }
+        }
       }
-    }
-  }, [projektiOid, reloadProjekti, showErrorMessage, showSuccessMessage]);
+    }, [projektiOid, reloadProjekti, showErrorMessage, showSuccessMessage]);
 
-  return (
-    <>
-      <Button onClick={uudelleenLataaProjekit}>Päivitä tiedot</Button>
-      <HassuSpinner open={loading} />
-    </>
-  );
-};
+    return (
+      <>
+        <Button onClick={uudelleenLataaProjekit}>Päivitä tiedot</Button>
+        <HassuSpinner open={loading} />
+      </>
+    );
+  };
 
 export default PaivitaVelhoTiedotButton;

--- a/src/components/projekti/PaivitaVelhoTiedotButton.tsx
+++ b/src/components/projekti/PaivitaVelhoTiedotButton.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useState, VFC } from "react";
+import Button from "@components/button/Button";
+import { api } from "@services/api";
+import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
+import { KeyedMutator } from "swr";
+import useSnackbars from "src/hooks/useSnackbars";
+import log from "loglevel";
+import HassuSpinner from "@components/HassuSpinner";
+
+const PaivitaVelhoTiedotButton: VFC<{ projektiOid: string; reloadProjekti: KeyedMutator<ProjektiLisatiedolla | null> }> = ({
+  projektiOid,
+  reloadProjekti,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const { showSuccessMessage, showErrorMessage } = useSnackbars();
+
+  const uudelleenLataaProjekit = useCallback(async () => {
+    if (projektiOid) {
+      try {
+        setLoading(true);
+        await api.synkronoiProjektiMuutoksetVelhosta(projektiOid);
+        await reloadProjekti();
+        setLoading(false);
+        showSuccessMessage("Projekti päivitetty");
+      } catch (e) {
+        setLoading(false);
+        log.log("realoadProjekti Error", e);
+        showErrorMessage("Päivittämisessä tapahtui virhe!");
+      }
+    }
+  }, [projektiOid, reloadProjekti, showErrorMessage, showSuccessMessage]);
+
+  return (
+    <>
+      <Button onClick={uudelleenLataaProjekit}>Päivitä tiedot</Button>
+      <HassuSpinner open={loading} />
+    </>
+  );
+};
+
+export default PaivitaVelhoTiedotButton;

--- a/src/components/projekti/ProjektiPageLayout.tsx
+++ b/src/components/projekti/ProjektiPageLayout.tsx
@@ -1,42 +1,18 @@
 import Notification, { NotificationType } from "@components/notification/Notification";
-import { api } from "@services/api";
-import Button from "@components/button/Button";
-import React, { ReactElement, ReactNode, useState } from "react";
+import React, { ReactElement, ReactNode } from "react";
 import { useProjekti } from "src/hooks/useProjekti";
 import ProjektiSideNavigation from "./ProjektiSideNavigation";
-import useSnackbars from "src/hooks/useSnackbars";
-import log from "loglevel";
 import { Stack } from "@mui/material";
-import HassuSpinner from "@components/HassuSpinner";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
 
 interface Props {
   children: ReactNode;
   title: string;
-  showUpdateButton?: boolean;
+  contentAsideTitle?: ReactNode;
 }
 
-export default function ProjektiPageLayout({ children, title, showUpdateButton }: Props): ReactElement {
-  const { data: projekti, mutate: reloadProjekti } = useProjekti();
-  const [loading, setLoading] = useState(false);
-
-  const { showSuccessMessage, showErrorMessage } = useSnackbars();
-
-  const uudelleenLataaProjekit = async () => {
-    if (projekti?.oid) {
-      try {
-        setLoading(true);
-        await api.synkronoiProjektiMuutoksetVelhosta(projekti.oid);
-        await reloadProjekti();
-        setLoading(false);
-        showSuccessMessage("Projekti päivitetty");
-      } catch (e) {
-        setLoading(false);
-        log.log("realoadProjekti Error", e);
-        showErrorMessage("Päivittämisessä tapahtui virhe!");
-      }
-    }
-  };
+export default function ProjektiPageLayout({ children, title, contentAsideTitle }: Props): ReactElement {
+  const { data: projekti } = useProjekti();
 
   if (!projekti) {
     return <></>;
@@ -57,7 +33,7 @@ export default function ProjektiPageLayout({ children, title, showUpdateButton }
             rowGap={0}
           >
             <h1>{title}</h1>
-            {showUpdateButton && <Button onClick={uudelleenLataaProjekit}>Päivitä tiedot</Button>}
+            {contentAsideTitle}
           </Stack>
           <h2>{projekti?.velho?.nimi || "-"}</h2>
           {projekti && projektiOnEpaaktiivinen(projekti) ? (
@@ -76,7 +52,6 @@ export default function ProjektiPageLayout({ children, title, showUpdateButton }
           )}
           {children}
         </div>
-        <HassuSpinner open={loading} />
       </div>
     </section>
   );

--- a/src/components/projekti/ProjektiSideNavigation.tsx
+++ b/src/components/projekti/ProjektiSideNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useEffect } from "react";
+import React, { FunctionComponent, ReactElement, useEffect } from "react";
 import HassuLink from "../HassuLink";
 import classNames from "classnames";
 import { useRouter } from "next/router";
@@ -16,7 +16,7 @@ export default function ProjektiSideNavigationWrapper(): ReactElement {
   return <ProjektiSideNavigation projekti={projekti} />;
 }
 
-const ProjektiSideNavigation: FC<{ projekti: ProjektiLisatiedolla }> = ({ projekti }) => {
+const ProjektiSideNavigation: FunctionComponent<{ projekti: ProjektiLisatiedolla }> = ({ projekti }) => {
   const router = useRouter();
   const { pathnameForAllowedRoute } = useIsAllowedOnCurrentProjektiRoute();
 

--- a/src/components/projekti/UudelleenkuulutaButton.tsx
+++ b/src/components/projekti/UudelleenkuulutaButton.tsx
@@ -1,0 +1,97 @@
+import Button from "@components/button/Button";
+import HassuDialog from "@components/HassuDialog";
+import HassuSpinner from "@components/HassuSpinner";
+import { DialogActions, DialogContent, DialogProps } from "@mui/material";
+import { api, TilaSiirtymaInput, TilasiirtymaToiminto } from "@services/api";
+import log from "loglevel";
+import React, { useCallback, useState, VFC } from "react";
+import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
+import useSnackbars from "src/hooks/useSnackbars";
+import { KeyedMutator } from "swr";
+
+export type UudelleenkuulutaButtonProps = { reloadProjekti: KeyedMutator<ProjektiLisatiedolla | null> } & Pick<
+  TilaSiirtymaInput,
+  "oid" | "tyyppi"
+>;
+
+const UudelleenkuulutaButton: VFC<UudelleenkuulutaButtonProps> = (props) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const openDialog = useCallback(() => {
+    setIsDialogOpen(true);
+  }, []);
+
+  const closeDialog = useCallback(() => {
+    setIsDialogOpen(false);
+  }, []);
+
+  return (
+    <>
+      <Button onClick={openDialog} id="uudelleenkuuluta_button">
+        Uudelleenkuuluta
+      </Button>
+      <UudelleenkuulutaModal open={isDialogOpen} onClose={closeDialog} buttonProps={props} />
+    </>
+  );
+};
+
+const UudelleenkuulutaModal: VFC<DialogProps & { buttonProps: UudelleenkuulutaButtonProps }> = ({
+  buttonProps: { oid, reloadProjekti, tyyppi },
+  onClose,
+  ...dialogProps
+}) => {
+  const { showErrorMessage, showSuccessMessage } = useSnackbars();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const closeDialog: React.MouseEventHandler<HTMLButtonElement> = useCallback((e) => onClose?.(e, "escapeKeyDown"), [onClose]);
+
+  const avaaUudelleenkuulutettavaksi: React.MouseEventHandler<HTMLButtonElement> = useCallback(
+    async (event) => {
+      setIsLoading(true);
+      try {
+        await api.siirraTila({
+          oid,
+          toiminto: TilasiirtymaToiminto.UUDELLEENKUULUTA,
+          tyyppi,
+        });
+        await reloadProjekti();
+        showSuccessMessage("Kuulutus on avattu uudelleenkuulutettavaksi");
+      } catch (error) {
+        log.log("Uudelleenkuulutus Error", error);
+        showErrorMessage("Kuulutuksen avaaminen uudelleenkuulutettavaksi epäonnistui");
+      }
+      closeDialog(event);
+      setIsLoading(false);
+    },
+    [closeDialog, oid, reloadProjekti, showErrorMessage, showSuccessMessage, tyyppi]
+  );
+
+  return (
+    <>
+      <HassuDialog title="Uudelleenkuuluta kuulutus" onClose={onClose} {...dialogProps}>
+        <DialogContent>
+          <p>
+            Olet avaamassa kuulutusta uudelleenkuulutettavaksi. Tarkastathan projektipäälliköltä ennen uuden kuulutuksen avaamista, että
+            olemassaolevan kuulutuksen pdf-tiedostot on viety asianhallintaan. Avaa suunnitelma uudelleenkuulutettavaksi vasta, kun olet
+            saanut vahvistuksen tiedostojen viennistä asianhallintaan.
+          </p>
+          <p>
+            Klikkaamalla Kyllä -painiketta vahvistat kuulutuksen avaamisen muokattavaksi. Kuulutus avataan muokkaustilassa automaattisesti
+            painikkeen klikkaamisen jälkeen.
+          </p>
+        </DialogContent>
+        <DialogActions>
+          <Button type="button" id="avaa_uudelleenkuulutettavaksi" primary onClick={avaaUudelleenkuulutettavaksi}>
+            Kyllä
+          </Button>
+          <Button type="button" id="peruuta_avaa_uudelleenkuulutettavaksi" onClick={closeDialog}>
+            Peruuta
+          </Button>
+        </DialogActions>
+      </HassuDialog>
+      <HassuSpinner open={isLoading} />
+    </>
+  );
+};
+
+export default UudelleenkuulutaButton;

--- a/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
+++ b/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
@@ -1,5 +1,5 @@
 import { AloitusKuulutusJulkaisu, AloitusKuulutusTila, Kieli, UudelleenKuulutus } from "@services/api";
-import React, { ReactElement, VFC } from "react";
+import React, { ReactElement, VoidFunctionComponent } from "react";
 import Notification, { NotificationType } from "@components/notification/Notification";
 import capitalize from "lodash/capitalize";
 import replace from "lodash/replace";
@@ -144,7 +144,7 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
   );
 }
 
-const UudelleenKuulutusSisalto: VFC<{
+const UudelleenKuulutusSisalto: VoidFunctionComponent<{
   ensisijainenKieli: Kieli | null | undefined;
   toissijainenKieli: Kieli | null | undefined;
   uudelleenKuulutus: UudelleenKuulutus;

--- a/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
+++ b/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
@@ -1,5 +1,5 @@
-import { AloitusKuulutusJulkaisu, AloitusKuulutusTila, Kieli } from "@services/api";
-import React, { ReactElement } from "react";
+import { AloitusKuulutusJulkaisu, AloitusKuulutusTila, Kieli, UudelleenKuulutus } from "@services/api";
+import React, { ReactElement, VFC } from "react";
 import Notification, { NotificationType } from "@components/notification/Notification";
 import capitalize from "lodash/capitalize";
 import replace from "lodash/replace";
@@ -38,6 +38,8 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
     aloitusKuulutusHref = window.location.protocol + "//" + window.location.host + "/suunnitelma/" + projekti.oid + "/aloituskuulutus";
   }
 
+  const { ensisijainenKieli, toissijainenKieli } = aloituskuulutusjulkaisu.kielitiedot || {};
+
   const epaaktiivinen = projektiOnEpaaktiivinen(projekti);
 
   return (
@@ -69,8 +71,7 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
             <br />
             {capitalize(kuntametadata.nameForKuntaId(aloituskuulutusjulkaisu.suunnitteluSopimus.kunta, lang))}
             <br />
-            {formatNimi(aloituskuulutusjulkaisu.suunnitteluSopimus)}, puh.{" "}
-            {aloituskuulutusjulkaisu.suunnitteluSopimus.puhelinnumero},{" "}
+            {formatNimi(aloituskuulutusjulkaisu.suunnitteluSopimus)}, puh. {aloituskuulutusjulkaisu.suunnitteluSopimus.puhelinnumero},{" "}
             {aloituskuulutusjulkaisu.suunnitteluSopimus.email ? replace(aloituskuulutusjulkaisu.suunnitteluSopimus.email, "@", "[at]") : ""}
           </Notification>
         )}
@@ -82,28 +83,23 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
             <FormatDate date={aloituskuulutusjulkaisu.siirtyySuunnitteluVaiheeseen} />
           </p>
         </div>
-        <div>
-          <p className="vayla-label">
-            Tiivistetty hankkeen sisällönkuvaus ensisijaisella kielellä ({lowerCase(aloituskuulutusjulkaisu.kielitiedot?.ensisijainenKieli)}
-            )
-          </p>
-          <p>
-            {aloituskuulutusjulkaisu.kielitiedot?.ensisijainenKieli === Kieli.SUOMI
-              ? aloituskuulutusjulkaisu.hankkeenKuvaus?.SUOMI
-              : aloituskuulutusjulkaisu.hankkeenKuvaus?.RUOTSI}
-          </p>
-        </div>
-        {aloituskuulutusjulkaisu.kielitiedot?.toissijainenKieli && (
+        {aloituskuulutusjulkaisu.uudelleenKuulutus && (
+          <UudelleenKuulutusSisalto
+            uudelleenKuulutus={aloituskuulutusjulkaisu.uudelleenKuulutus}
+            ensisijainenKieli={ensisijainenKieli}
+            toissijainenKieli={toissijainenKieli}
+          />
+        )}
+        {ensisijainenKieli && (
+          <div>
+            <p className="vayla-label">Tiivistetty hankkeen sisällönkuvaus ensisijaisella kielellä ({lowerCase(ensisijainenKieli)})</p>
+            <p>{aloituskuulutusjulkaisu.hankkeenKuvaus?.[ensisijainenKieli]}</p>
+          </div>
+        )}
+        {toissijainenKieli && (
           <div className="content">
-            <p className="vayla-label">
-              Tiivistetty hankkeen sisällönkuvaus toissijaisella kielellä (
-              {lowerCase(aloituskuulutusjulkaisu.kielitiedot?.toissijainenKieli)})
-            </p>
-            <p>
-              {aloituskuulutusjulkaisu.kielitiedot?.toissijainenKieli === Kieli.SUOMI
-                ? aloituskuulutusjulkaisu.hankkeenKuvaus?.SUOMI
-                : aloituskuulutusjulkaisu.hankkeenKuvaus?.RUOTSI}
-            </p>
+            <p className="vayla-label">Tiivistetty hankkeen sisällönkuvaus toissijaisella kielellä ({lowerCase(toissijainenKieli)})</p>
+            <p>{aloituskuulutusjulkaisu.hankkeenKuvaus?.[toissijainenKieli]}</p>
           </div>
         )}
         <div>
@@ -147,3 +143,45 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
     </>
   );
 }
+
+const UudelleenKuulutusSisalto: VFC<{
+  ensisijainenKieli: Kieli | null | undefined;
+  toissijainenKieli: Kieli | null | undefined;
+  uudelleenKuulutus: UudelleenKuulutus;
+}> = ({ uudelleenKuulutus, ensisijainenKieli, toissijainenKieli }) => (
+  <Section>
+    <p className="vayla-small-title">Uudelleenkuuluttamisen seloste</p>
+    {uudelleenKuulutus.selosteLahetekirjeeseen && (
+      <>
+        {ensisijainenKieli && (
+          <div>
+            <p className="vayla-label">Seloste lähetekirjeeseen ensisijaisella kielellä ({lowerCase(ensisijainenKieli)})</p>
+            <p>{uudelleenKuulutus.selosteLahetekirjeeseen?.[ensisijainenKieli]}</p>
+          </div>
+        )}
+        {toissijainenKieli && (
+          <div>
+            <p className="vayla-label">Seloste lähetekirjeeseen toissijaisella kielellä ({lowerCase(toissijainenKieli)})</p>
+            <p>{uudelleenKuulutus.selosteLahetekirjeeseen?.[toissijainenKieli]}</p>
+          </div>
+        )}
+      </>
+    )}
+    {uudelleenKuulutus.selosteKuulutukselle && (
+      <>
+        {ensisijainenKieli && (
+          <div>
+            <p className="vayla-label">Seloste kuulutukselle ensisijaisella kielellä ({lowerCase(ensisijainenKieli)})</p>
+            <p>{uudelleenKuulutus.selosteKuulutukselle?.[ensisijainenKieli]}</p>
+          </div>
+        )}
+        {toissijainenKieli && (
+          <div>
+            <p className="vayla-label">Seloste kuulutukselle toissijaisella kielellä ({lowerCase(toissijainenKieli)})</p>
+            <p>{uudelleenKuulutus.selosteKuulutukselle?.[toissijainenKieli]}</p>
+          </div>
+        )}
+      </>
+    )}
+  </Section>
+);

--- a/src/components/projekti/kansalaisnakyma/PaatosPageLayout.tsx
+++ b/src/components/projekti/kansalaisnakyma/PaatosPageLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, VFC } from "react";
+import React, { FunctionComponent, useMemo, VoidFunctionComponent } from "react";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
 import ProjektiJulkinenPageLayout from "@components/projekti/kansalaisnakyma/ProjektiJulkinenPageLayout";
 import { Tabs } from "@mui/material";
@@ -8,7 +8,7 @@ import { UrlObject } from "url";
 import { ProjektiJulkinen } from "@services/api";
 import useTranslation from "next-translate/useTranslation";
 
-const PaatosPageLayout: FC<{ pageTitle: string }> = ({ children, pageTitle }) => {
+const PaatosPageLayout: FunctionComponent<{ pageTitle: string }> = ({ children, pageTitle }) => {
   const { data: projekti } = useProjektiJulkinen();
 
   if (!projekti) {
@@ -23,7 +23,7 @@ const PaatosPageLayout: FC<{ pageTitle: string }> = ({ children, pageTitle }) =>
   );
 };
 
-const PaatosPageTabs: VFC<{ projekti: ProjektiJulkinen }> = ({ projekti }) => {
+const PaatosPageTabs: VoidFunctionComponent<{ projekti: ProjektiJulkinen }> = ({ projekti }) => {
   const router = useRouter();
   const { t } = useTranslation("paatos");
 

--- a/src/components/projekti/nahtavillaolo/kuulutuksentiedot/HankkeenSisallonKuvaus.tsx
+++ b/src/components/projekti/nahtavillaolo/kuulutuksentiedot/HankkeenSisallonKuvaus.tsx
@@ -1,7 +1,7 @@
 import Textarea from "@components/form/Textarea";
 import Section from "@components/layout/Section";
 import SectionContent from "@components/layout/SectionContent";
-import { HankkeenKuvauksetInput, Kielitiedot, Kieli } from "@services/api";
+import { Kielitiedot, Kieli, LokalisoituTekstiInput } from "@services/api";
 import React from "react";
 import { useFormContext } from "react-hook-form";
 import lowerCase from "lodash/lowerCase";
@@ -12,7 +12,7 @@ type Props = {
 
 type FormFields = {
   nahtavillaoloVaihe: {
-    hankkeenKuvaus: HankkeenKuvauksetInput;
+    hankkeenKuvaus: LokalisoituTekstiInput;
   };
 };
 
@@ -30,10 +30,9 @@ export default function KuulutusJaJulkaisuPaiva({ kielitiedot }: Props) {
       <SectionContent>
         <h4 className="vayla-small-title">Hankkeen sisällönkuvaus</h4>
         <p>
-          Kirjoita nähtäville asettamisen kuulutusta varten tiivistetty sisällönkuvaus hankkeesta. Kuvauksen on hyvä
-          sisältää esimerkiksi tieto suunnittelukohteen alueellista rajauksesta (maantietoalue ja vaikutusalue),
-          suunnittelun tavoitteet, vaikutukset ja toimenpiteet pääpiirteittäin karkealla tasolla. Älä lisää tekstiin
-          linkkejä.
+          Kirjoita nähtäville asettamisen kuulutusta varten tiivistetty sisällönkuvaus hankkeesta. Kuvauksen on hyvä sisältää esimerkiksi
+          tieto suunnittelukohteen alueellista rajauksesta (maantietoalue ja vaikutusalue), suunnittelun tavoitteet, vaikutukset ja
+          toimenpiteet pääpiirteittäin karkealla tasolla. Älä lisää tekstiin linkkejä.
         </p>
       </SectionContent>
       <SectionContent>

--- a/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
+++ b/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
@@ -6,13 +6,9 @@ import Section from "@components/layout/Section";
 import HassuAineistoNimiExtLink from "@components/projekti/HassuAineistoNimiExtLink";
 import { Stack } from "@mui/material";
 import { NahtavillaoloVaiheJulkaisu } from "@services/api";
-import {
-  AineistoKategoria,
-  aineistoKategoriat,
-  kategorianAllaOlevienAineistojenMaara,
-} from "common/aineistoKategoriat";
+import { AineistoKategoria, aineistoKategoriat, kategorianAllaOlevienAineistojenMaara } from "common/aineistoKategoriat";
 import useTranslation from "next-translate/useTranslation";
-import React, { FC, useMemo } from "react";
+import React, { FunctionComponent, useMemo } from "react";
 import { useProjekti } from "src/hooks/useProjekti";
 import useSnackbars from "src/hooks/useSnackbars";
 import { formatDate, formatDateTime } from "src/util/dateUtils";
@@ -22,9 +18,7 @@ export default function Lukunakyma() {
   const { showErrorMessage, showInfoMessage } = useSnackbars();
 
   const julkaisu = useMemo(
-    () =>
-      projekti?.nahtavillaoloVaihe ||
-      projekti?.nahtavillaoloVaiheJulkaisut?.[projekti.nahtavillaoloVaiheJulkaisut.length - 1],
+    () => projekti?.nahtavillaoloVaihe || projekti?.nahtavillaoloVaiheJulkaisut?.[projekti.nahtavillaoloVaiheJulkaisut.length - 1],
     [projekti]
   );
 
@@ -93,11 +87,7 @@ export default function Lukunakyma() {
                   <Stack direction="column" rowGap={2}>
                     {julkaisu.lisaAineisto?.map((aineisto) => (
                       <span key={aineisto.dokumenttiOid}>
-                        <HassuAineistoNimiExtLink
-                          tiedostoPolku={aineisto.tiedosto}
-                          aineistoNimi={aineisto.nimi}
-                          sx={{ mr: 3 }}
-                        />
+                        <HassuAineistoNimiExtLink tiedostoPolku={aineisto.tiedosto} aineistoNimi={aineisto.nimi} sx={{ mr: 3 }} />
                         {aineisto.tuotu && formatDateTime(aineisto.tuotu)}
                       </span>
                     ))}
@@ -123,15 +113,14 @@ interface AineistoNahtavillaAccordionProps {
   paakategoria?: boolean;
 }
 
-const AineistoNahtavillaAccordion: FC<AineistoNahtavillaAccordionProps> = ({ julkaisu, kategoriat, paakategoria }) => {
+const AineistoNahtavillaAccordion: FunctionComponent<AineistoNahtavillaAccordionProps> = ({ julkaisu, kategoriat, paakategoria }) => {
   const { t } = useTranslation("aineisto");
   const accordionItems: AccordionItem[] = useMemo(
     () =>
       kategoriat
         .filter((kategoria) => {
           return (
-            julkaisu.aineistoNahtavilla &&
-            (paakategoria || kategorianAllaOlevienAineistojenMaara(julkaisu.aineistoNahtavilla, kategoria))
+            julkaisu.aineistoNahtavilla && (paakategoria || kategorianAllaOlevienAineistojenMaara(julkaisu.aineistoNahtavilla, kategoria))
           );
         })
         .map<AccordionItem>((kategoria) => {
@@ -162,9 +151,7 @@ const AineistoNahtavillaAccordion: FC<AineistoNahtavillaAccordionProps> = ({ jul
                       ))}
                   </Stack>
                 )}
-                {kategoria.alaKategoriat && (
-                  <AineistoNahtavillaAccordion julkaisu={julkaisu} kategoriat={kategoria.alaKategoriat} />
-                )}
+                {kategoria.alaKategoriat && <AineistoNahtavillaAccordion julkaisu={julkaisu} kategoriat={kategoria.alaKategoriat} />}
               </>
             ),
           };

--- a/src/components/projekti/paatos/PaatosAineistotPage.tsx
+++ b/src/components/projekti/paatos/PaatosAineistotPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, VFC } from "react";
+import React, { useMemo, VoidFunctionComponent } from "react";
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
 import { getPaatosSpecificData, PaatosTyyppi } from "src/util/getPaatosSpecificData";
@@ -6,7 +6,10 @@ import PaatosAineistotLukutila from "../lukutila/PaatosAineistotLukutila";
 import PaatosAineistot from "@components/projekti/paatos/aineistot/index";
 import PaatosPageLayout from "./PaatosPageLayout";
 
-export const PaatoksenAineistotPage: VFC<{ projekti: ProjektiLisatiedolla; paatosTyyppi: PaatosTyyppi }> = ({ projekti, paatosTyyppi }) => {
+export const PaatoksenAineistotPage: VoidFunctionComponent<{ projekti: ProjektiLisatiedolla; paatosTyyppi: PaatosTyyppi }> = ({
+  projekti,
+  paatosTyyppi,
+}) => {
   const { viimeisinJulkaisu, julkaisematonPaatos, julkaisut } = useMemo(
     () => getPaatosSpecificData(projekti, paatosTyyppi),
     [paatosTyyppi, projekti]

--- a/src/components/projekti/paatos/PaatosKuulutuksenTiedotPage.tsx
+++ b/src/components/projekti/paatos/PaatosKuulutuksenTiedotPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, VFC } from "react";
+import React, { useMemo, VoidFunctionComponent } from "react";
 import KuulutuksenTiedot from "@components/projekti/paatos/kuulutuksenTiedot/index";
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
@@ -6,7 +6,7 @@ import Lukunakyma from "@components/projekti/paatos/kuulutuksenTiedot/Lukunakyma
 import { getPaatosSpecificData, PaatosTyyppi } from "src/util/getPaatosSpecificData";
 import PaatosPageLayout from "./PaatosPageLayout";
 
-export const PaatoksenKuulutuksenTiedotPage: VFC<{ projekti: ProjektiLisatiedolla; paatosTyyppi: PaatosTyyppi }> = ({
+export const PaatoksenKuulutuksenTiedotPage: VoidFunctionComponent<{ projekti: ProjektiLisatiedolla; paatosTyyppi: PaatosTyyppi }> = ({
   projekti,
   paatosTyyppi,
 }) => {

--- a/src/components/projekti/paatos/aineistot/Lukunakyma.tsx
+++ b/src/components/projekti/paatos/aineistot/Lukunakyma.tsx
@@ -5,7 +5,7 @@ import { Stack } from "@mui/material";
 import { HyvaksymisPaatosVaiheJulkaisu, HyvaksymisPaatosVaiheTila } from "@services/api";
 import { AineistoKategoria, aineistoKategoriat, getNestedAineistoMaaraForCategory } from "common/aineistoKategoriat";
 import useTranslation from "next-translate/useTranslation";
-import React, { FC, useMemo } from "react";
+import React, { FunctionComponent, useMemo } from "react";
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
 import { formatDate, formatDateTime } from "src/util/dateUtils";
 import { getPaatosSpecificData, PaatosTyyppi } from "src/util/getPaatosSpecificData";
@@ -65,7 +65,7 @@ interface AineistoNahtavillaAccordionProps {
   kategoriat: AineistoKategoria[];
 }
 
-const AineistoNahtavillaAccordion: FC<AineistoNahtavillaAccordionProps> = ({ julkaisu, kategoriat }) => {
+const AineistoNahtavillaAccordion: FunctionComponent<AineistoNahtavillaAccordionProps> = ({ julkaisu, kategoriat }) => {
   const { t } = useTranslation("aineisto");
   const accordionItems: AccordionItem[] = useMemo(
     () =>

--- a/src/pages/api/test/[oid].dev.ts
+++ b/src/pages/api/test/[oid].dev.ts
@@ -79,6 +79,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     ...vuorovaikutusFields,
   };
 
+  const aloituskuulutusFields: Partial<DBProjekti> = {
+    aloitusKuulutus: null,
+    aloitusKuulutusJulkaisut: null,
+  };
+
+  await executor.onResetAloituskuulutus(async (oid: string) => {
+    requireProjekti();
+    await testProjektiDatabase.saveProjekti({
+      oid,
+      ...aloituskuulutusFields,
+    });
+  });
+
   await executor.onResetSuunnittelu(async (oid: string) => {
     requireProjekti();
     await testProjektiDatabase.saveProjekti({

--- a/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
+++ b/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
@@ -66,6 +66,7 @@ export default function AloituskuulutusJulkinen(): ReactElement {
       <>
         <Section noDivider>
           <KeyValueTable rows={keyValueData}></KeyValueTable>
+          {kuulutus.uudelleenKuulutus?.selosteKuulutukselle?.[kieli] && <p>{kuulutus.uudelleenKuulutus.selosteKuulutukselle[kieli]}</p>}
           {velho.tyyppi !== ProjektiTyyppi.RATA && (
             <SectionContent>
               {suunnittelusopimus && (

--- a/src/pages/suunnitelma/[oid]/lausuntopyyntoaineistot.tsx
+++ b/src/pages/suunnitelma/[oid]/lausuntopyyntoaineistot.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useMemo } from "react";
+import React, { FunctionComponent, ReactElement, useMemo } from "react";
 import Section from "@components/layout/Section";
 import { useLisaAineisto } from "src/hooks/useLisaAineisto";
 import HassuAccordion, { AccordionItem } from "@components/HassuAccordion";
@@ -12,9 +12,7 @@ export default function Lausuntopyyntoaineistot(): ReactElement {
   return (
     <Section>
       <p>Huomioi, että tämä sisältö on tarkasteltavissa DD.MM.YYYY asti, jonka jälkeen sisältö poistuu näkyvistä.</p>
-      <AineistoNahtavillaAccordion
-        kategoriat={[...aineistoKategoriat.listKategoriat(), new AineistoKategoria({ id: "lisaAineisto" })]}
-      />
+      <AineistoNahtavillaAccordion kategoriat={[...aineistoKategoriat.listKategoriat(), new AineistoKategoria({ id: "lisaAineisto" })]} />
     </Section>
   );
 }
@@ -23,7 +21,7 @@ interface AineistoNahtavillaAccordionProps {
   kategoriat: AineistoKategoria[];
 }
 
-const AineistoNahtavillaAccordion: FC<AineistoNahtavillaAccordionProps> = (props) => {
+const AineistoNahtavillaAccordion: FunctionComponent<AineistoNahtavillaAccordionProps> = (props) => {
   const { t } = useTranslation("aineisto");
   const { data } = useLisaAineisto();
 
@@ -55,11 +53,7 @@ const AineistoNahtavillaAccordion: FC<AineistoNahtavillaAccordionProps> = (props
                     .filter((aineisto) => aineisto.kategoriaId === kategoria.id)
                     .map((aineisto, index) => (
                       <span key={index}>
-                        <ExtLink
-                          href={aineisto?.linkki ? aineisto?.linkki : undefined}
-                          disabled={!aineisto?.linkki}
-                          sx={{ mr: 3 }}
-                        >
+                        <ExtLink href={aineisto?.linkki ? aineisto?.linkki : undefined} disabled={!aineisto?.linkki} sx={{ mr: 3 }}>
                           {aineisto.nimi}
                         </ExtLink>
                       </span>

--- a/src/pages/suunnitelma/[oid]/suunnittelu.tsx
+++ b/src/pages/suunnitelma/[oid]/suunnittelu.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useCallback, useState } from "react";
+import React, { FunctionComponent, ReactElement, useCallback, useState } from "react";
 import ProjektiJulkinenPageLayout from "@components/projekti/kansalaisnakyma/ProjektiJulkinenPageLayout";
 import Section from "@components/layout/Section";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
@@ -64,7 +64,7 @@ export default function Suunnittelu(): ReactElement {
   );
 }
 
-const Perustiedot: FC<{ suunnitteluVaihe: SuunnitteluVaiheJulkinen }> = ({ suunnitteluVaihe }) => {
+const Perustiedot: FunctionComponent<{ suunnitteluVaihe: SuunnitteluVaiheJulkinen }> = ({ suunnitteluVaihe }) => {
   const { t } = useTranslation("suunnittelu");
   const kieli = useKansalaiskieli();
   return (
@@ -87,7 +87,7 @@ const Perustiedot: FC<{ suunnitteluVaihe: SuunnitteluVaiheJulkinen }> = ({ suunn
   );
 };
 
-const VuorovaikutusTiedot: FC<{
+const VuorovaikutusTiedot: FunctionComponent<{
   vuorovaikutus: VuorovaikutusJulkinen | undefined;
   projekti: ProjektiJulkinen;
   suunnitteluVaihe: SuunnitteluVaiheJulkinen;
@@ -250,7 +250,7 @@ const VuorovaikutusTiedot: FC<{
   );
 };
 
-const TilaisuusLista: FC<{
+const TilaisuusLista: FunctionComponent<{
   tilaisuudet: VuorovaikutusTilaisuusJulkinen[];
   inaktiivinen?: true;
 }> = ({ tilaisuudet, inaktiivinen }) => {

--- a/src/pages/yllapito/perusta/[oid].tsx
+++ b/src/pages/yllapito/perusta/[oid].tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, FC, useMemo } from "react";
+import React, { ReactElement, useCallback, FunctionComponent, useMemo } from "react";
 import { ProjektiLisatiedolla, useProjekti } from "src/hooks/useProjekti";
 import { useRouter } from "next/router";
 import ProjektiPerustiedot from "@components/projekti/ProjektiPerustiedot";
@@ -70,7 +70,7 @@ const defaultFormValues: (projekti: ProjektiLisatiedolla) => FormValues = (proje
     }) || [],
 });
 
-const PerustaProjektiForm: FC<PerustaProjektiFormProps> = ({ projekti, projektiLoadError, reloadProjekti }) => {
+const PerustaProjektiForm: FunctionComponent<PerustaProjektiFormProps> = ({ projekti, projektiLoadError, reloadProjekti }) => {
   const router = useRouter();
   const [formIsSubmitting, setFormIsSubmitting] = useState(false);
 

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -9,19 +9,22 @@ import Button from "@components/button/Button";
 import Notification, { NotificationType } from "@components/notification/Notification";
 import {
   AloitusKuulutusInput,
-  AloitusKuulutusJulkaisu,
   AloitusKuulutusTila,
   api,
   AsiakirjaTyyppi,
   Kieli,
   Kielitiedot,
   LaskuriTyyppi,
+  LokalisoituTeksti,
   LokalisoituTekstiInput,
   MuokkausTila,
   Status,
   TallennaProjektiInput,
   TilasiirtymaToiminto,
   TilasiirtymaTyyppi,
+  UudelleenKuulutus,
+  UudelleenKuulutusInput,
+  UudelleenkuulutusTila,
   YhteystietoInput,
 } from "@services/api";
 import log from "loglevel";
@@ -50,6 +53,7 @@ import { removeTypeName } from "src/util/removeTypeName";
 import { HassuDatePickerWithController } from "@components/form/HassuDatePicker";
 import { today } from "src/util/dateUtils";
 import { kuntametadata } from "../../../../../common/kuntametadata";
+import UudelleenkuulutaButton from "@components/projekti/UudelleenkuulutaButton";
 
 type ProjektiFields = Pick<TallennaProjektiInput, "oid">;
 type RequiredProjektiFields = Required<{
@@ -59,7 +63,12 @@ type RequiredProjektiFields = Required<{
 type FormValues = RequiredProjektiFields & {
   aloitusKuulutus: Pick<
     AloitusKuulutusInput,
-    "kuulutusYhteystiedot" | "kuulutusPaiva" | "hankkeenKuvaus" | "siirtyySuunnitteluVaiheeseen" | "ilmoituksenVastaanottajat"
+    | "kuulutusYhteystiedot"
+    | "kuulutusPaiva"
+    | "hankkeenKuvaus"
+    | "siirtyySuunnitteluVaiheeseen"
+    | "ilmoituksenVastaanottajat"
+    | "uudelleenKuulutus"
   >;
 };
 
@@ -88,6 +97,38 @@ interface AloituskuulutusFormProps {
   reloadProjekti: KeyedMutator<ProjektiLisatiedolla | null>;
 }
 
+export function getDefaultValuesForUudelleenKuulutus(
+  kielitiedot: ProjektiLisatiedolla["kielitiedot"],
+  uudelleenKuulutus: UudelleenKuulutus | null | undefined
+): UudelleenKuulutusInput {
+  const uudelleenKuulutusInput: UudelleenKuulutusInput = {
+    selosteLahetekirjeeseen: getDefaultValuesForLokalisoituText(kielitiedot, uudelleenKuulutus?.selosteLahetekirjeeseen),
+  };
+  if (uudelleenKuulutus?.tila === UudelleenkuulutusTila.JULKAISTU_PERUUTETTU) {
+    uudelleenKuulutusInput.selosteKuulutukselle = getDefaultValuesForLokalisoituText(kielitiedot, uudelleenKuulutus?.selosteKuulutukselle);
+  }
+  return uudelleenKuulutusInput;
+}
+
+function getDefaultValuesForLokalisoituText(
+  kielitiedot: ProjektiLisatiedolla["kielitiedot"],
+  lokalisoituTeksti: LokalisoituTeksti | null | undefined
+): LokalisoituTekstiInput {
+  const { ensisijainenKieli, toissijainenKieli } = kielitiedot || {};
+  const hasRuotsinKieli = ensisijainenKieli === Kieli.RUOTSI || toissijainenKieli === Kieli.RUOTSI;
+  const hasSaamenKieli = ensisijainenKieli === Kieli.SAAME || toissijainenKieli === Kieli.SAAME;
+  return {
+    SUOMI: lokalisoituTeksti?.SUOMI || "",
+    ...pickBy(
+      {
+        RUOTSI: hasRuotsinKieli ? lokalisoituTeksti?.RUOTSI || "" : undefined,
+        SAAME: hasSaamenKieli ? lokalisoituTeksti?.SAAME || "" : undefined,
+      },
+      (value) => value !== undefined
+    ),
+  };
+}
+
 function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: AloituskuulutusFormProps): ReactElement {
   const [isFormSubmitting, setIsFormSubmitting] = useState(false);
   const router = useRouter();
@@ -107,24 +148,8 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
       projekti?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysTiedot?.map((yt) => removeTypeName(yt)) || [];
 
     const yhteysHenkilot: string[] = projekti?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysHenkilot || [];
-    const { ensisijainenKieli, toissijainenKieli } = projekti.kielitiedot || {};
 
-    const hasRuotsinKieli = ensisijainenKieli === Kieli.RUOTSI || toissijainenKieli === Kieli.RUOTSI;
-    const hasSaamenKieli = ensisijainenKieli === Kieli.SAAME || toissijainenKieli === Kieli.SAAME;
-
-    // SUOMI hankkeen kuvaus on aina lomakkeella, RUOTSI JA SAAME vain jos kyseinen kieli on projektin kielitiedoissa.
-    // Jos kieli ei ole kielitiedoissa kyseisen kielen kenttää ei tule lisätä hankkeenKuvaus olioon
-    // Tästä syystä pickBy:llä poistetaan undefined hankkeenkuvaus tiedot.
-    const hankkeenKuvaus: LokalisoituTekstiInput = {
-      SUOMI: projekti.aloitusKuulutus?.hankkeenKuvaus?.SUOMI || "",
-      ...pickBy(
-        {
-          RUOTSI: hasRuotsinKieli ? projekti.aloitusKuulutus?.hankkeenKuvaus?.RUOTSI || "" : undefined,
-          SAAME: hasSaamenKieli ? projekti.aloitusKuulutus?.hankkeenKuvaus?.SAAME || "" : undefined,
-        },
-        (value) => value !== undefined
-      ),
-    };
+    const hankkeenKuvaus = getDefaultValuesForLokalisoituText(projekti.kielitiedot, projekti.aloitusKuulutus?.hankkeenKuvaus);
 
     const tallentamisTiedot: FormValues = {
       oid: projekti.oid,
@@ -149,6 +174,14 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
         },
       },
     };
+
+    if (projekti.aloitusKuulutus?.uudelleenKuulutus) {
+      tallentamisTiedot.aloitusKuulutus.uudelleenKuulutus = getDefaultValuesForUudelleenKuulutus(
+        projekti.kielitiedot,
+        projekti.aloitusKuulutus.uudelleenKuulutus
+      );
+    }
+
     return tallentamisTiedot;
   }, [projekti]);
 
@@ -188,16 +221,6 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
     handleSubmit: handleSubmit2,
     formState: { errors: errors2 },
   } = useForm<PalautusValues>({ defaultValues: { syy: "" } });
-
-  const getAloituskuulutusjulkaisuByTila = useCallback(
-    (tila: AloitusKuulutusTila): AloitusKuulutusJulkaisu | undefined => {
-      if (projekti?.aloitusKuulutusJulkaisu?.tila !== tila) {
-        return undefined;
-      }
-      return projekti?.aloitusKuulutusJulkaisu;
-    },
-    [projekti]
-  );
 
   const saveAloituskuulutus = useCallback(
     async (formData: FormValues) => {
@@ -325,13 +348,13 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
   );
 
   const kielitiedot: Kielitiedot | null | undefined = projekti?.kielitiedot;
-  const voiMuokata = projekti?.aloitusKuulutus?.muokkausTila == MuokkausTila.MUOKKAUS;
+  const voiMuokata = projekti?.aloitusKuulutus?.muokkausTila === MuokkausTila.MUOKKAUS;
   const voiHyvaksya =
-    getAloituskuulutusjulkaisuByTila(AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA) && projekti?.nykyinenKayttaja.onProjektipaallikko;
+    projekti.aloitusKuulutusJulkaisu?.tila === AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA && projekti?.nykyinenKayttaja.onProjektipaallikko;
 
   const odottaaJulkaisua = useMemo(() => {
-    const julkaisu = getAloituskuulutusjulkaisuByTila(AloitusKuulutusTila.HYVAKSYTTY);
-    if (julkaisu) {
+    const julkaisu = projekti.aloitusKuulutusJulkaisu;
+    if (julkaisu?.tila === AloitusKuulutusTila.HYVAKSYTTY) {
       // Toistaiseksi tarkastellaan julkaisupaivatietoa, koska ei ole olemassa erillista tilaa julkaistulle kuulutukselle
       const julkaisupvm = dayjs(julkaisu.kuulutusPaiva);
       if (dayjs().isBefore(julkaisupvm, "day")) {
@@ -339,10 +362,10 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
       }
     }
     return null;
-  }, [getAloituskuulutusjulkaisuByTila]);
+  }, [projekti.aloitusKuulutusJulkaisu]);
 
   if (!projekti || isLoadingProjekti) {
-    return <div />;
+    return <></>;
   }
   if (!kielitiedot) {
     return <div>Kielitiedot puttuu</div>;
@@ -354,8 +377,20 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
   const toissijainenKieli = kielitiedot?.toissijainenKieli;
   const esikatselePdf = pdfFormRef.current?.esikatselePdf;
 
+  const showUudelleenkuulutaButton =
+    projekti.aloitusKuulutusJulkaisu?.tila === AloitusKuulutusTila.HYVAKSYTTY &&
+    projekti.aloitusKuulutus?.muokkausTila === MuokkausTila.LUKU &&
+    projekti.nykyinenKayttaja.onYllapitaja;
+
   return (
-    <ProjektiPageLayout title="Aloituskuulutus">
+    <ProjektiPageLayout
+      title="Aloituskuulutus"
+      contentAsideTitle={
+        showUudelleenkuulutaButton && (
+          <UudelleenkuulutaButton oid={projekti.oid} tyyppi={TilasiirtymaTyyppi.ALOITUSKUULUTUS} reloadProjekti={reloadProjekti} />
+        )
+      }
+    >
       {voiMuokata && (
         <>
           <FormProvider {...useFormReturn}>
@@ -404,11 +439,60 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
                     />
                     <HassuDatePickerWithController
                       label="Kuulutusvaihe päättyy"
-                      disabled={true}
+                      disabled
                       controllerProps={{ name: "aloitusKuulutus.siirtyySuunnitteluVaiheeseen" }}
                     />
                   </div>
                 </Section>
+                {projekti.aloitusKuulutus?.uudelleenKuulutus && (
+                  <Section>
+                    <h5 className="vayla-small-title">Uudelleenkuuluttamisen seloste</h5>
+                    {projekti.aloitusKuulutus.uudelleenKuulutus.tila === UudelleenkuulutusTila.JULKAISTU_PERUUTETTU && (
+                      <SectionContent>
+                        <h6 className="vayla-smallest-title">Seloste kuulutukselle</h6>
+                        <p>
+                          Kirjoita kuulutusta varten seloste uudelleenkuuluttamisen syistä. Seloste tulee nähtäville palvelun julkiselle
+                          puolelle sekä kuulutuksen pdf-tiedostoon. Älä lisää tekstiin linkkejä.
+                        </p>
+                        <Textarea
+                          label={`Suunnitelman uudelleenkuuluttamisen syy ensisijaisella kielellä (${lowerCase(ensisijainenKieli)}) *`}
+                          {...register(`aloitusKuulutus.uudelleenKuulutus.selosteKuulutukselle.${ensisijainenKieli}`)}
+                          error={(errors.aloitusKuulutus?.uudelleenKuulutus as any)?.selosteKuulutukselle?.[ensisijainenKieli]}
+                          disabled={disableFormEdit}
+                        />
+                        {toissijainenKieli && (
+                          <Textarea
+                            label={`Suunnitelman uudelleenkuuluttamisen syy toissijaisella kielellä (${lowerCase(toissijainenKieli)}) *`}
+                            {...register(`aloitusKuulutus.uudelleenKuulutus.selosteKuulutukselle.${toissijainenKieli}`)}
+                            error={(errors.aloitusKuulutus?.uudelleenKuulutus as any)?.selosteKuulutukselle?.[toissijainenKieli]}
+                            disabled={disableFormEdit}
+                          />
+                        )}
+                      </SectionContent>
+                    )}
+                    <SectionContent>
+                      <h6 className="vayla-smallest-title">Seloste lähetekirjeeseen</h6>
+                      <p>
+                        Kirjoita lähetekirjettä varten seloste uudelleenkuuluttamisen syistä. Seloste tulee nähtäville viranomaiselle ja
+                        kunnille lähetettävän lähetekirjeen alkuun. Älä lisää tekstiin linkkejä.
+                      </p>
+                      <Textarea
+                        label={`Suunnitelman uudelleenkuuluttamisen syy ensisijaisella kielellä (${lowerCase(ensisijainenKieli)}) *`}
+                        {...register(`aloitusKuulutus.uudelleenKuulutus.selosteLahetekirjeeseen.${ensisijainenKieli}`)}
+                        error={(errors.aloitusKuulutus?.uudelleenKuulutus as any)?.selosteLahetekirjeeseen?.[ensisijainenKieli]}
+                        disabled={disableFormEdit}
+                      />
+                      {toissijainenKieli && (
+                        <Textarea
+                          label={`Suunnitelman uudelleenkuuluttamisen syy toissijaisella kielellä (${lowerCase(toissijainenKieli)}) *`}
+                          {...register(`aloitusKuulutus.uudelleenKuulutus.selosteLahetekirjeeseen.${toissijainenKieli}`)}
+                          error={(errors.aloitusKuulutus?.uudelleenKuulutus as any)?.selosteLahetekirjeeseen?.[toissijainenKieli]}
+                          disabled={disableFormEdit}
+                        />
+                      )}
+                    </SectionContent>
+                  </Section>
+                )}
                 <Section noDivider={!!toissijainenKieli}>
                   <SectionContent>
                     <h5 className="vayla-small-title">Hankkeen sisällönkuvaus</h5>
@@ -510,15 +594,11 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
         <FormProvider {...useFormReturn}>
           <AloituskuulutusLukunakyma
             projekti={projekti}
-            aloituskuulutusjulkaisu={
-              getAloituskuulutusjulkaisuByTila(AloitusKuulutusTila.HYVAKSYTTY) ||
-              getAloituskuulutusjulkaisuByTila(AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA)
-            }
+            aloituskuulutusjulkaisu={projekti.aloitusKuulutusJulkaisu}
             isLoadingProjekti={isLoadingProjekti}
           />
         </FormProvider>
       )}
-
       {voiHyvaksya && (
         <>
           <Section noDivider>

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -13,10 +13,10 @@ import {
   AloitusKuulutusTila,
   api,
   AsiakirjaTyyppi,
-  HankkeenKuvauksetInput,
   Kieli,
   Kielitiedot,
   LaskuriTyyppi,
+  LokalisoituTekstiInput,
   MuokkausTila,
   Status,
   TallennaProjektiInput,
@@ -115,7 +115,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
     // SUOMI hankkeen kuvaus on aina lomakkeella, RUOTSI JA SAAME vain jos kyseinen kieli on projektin kielitiedoissa.
     // Jos kieli ei ole kielitiedoissa kyseisen kielen kenttää ei tule lisätä hankkeenKuvaus olioon
     // Tästä syystä pickBy:llä poistetaan undefined hankkeenkuvaus tiedot.
-    const hankkeenKuvaus: HankkeenKuvauksetInput = {
+    const hankkeenKuvaus: LokalisoituTekstiInput = {
       SUOMI: projekti.aloitusKuulutus?.hankkeenKuvaus?.SUOMI || "",
       ...pickBy(
         {

--- a/src/pages/yllapito/projekti/[oid]/henkilot.tsx
+++ b/src/pages/yllapito/projekti/[oid]/henkilot.tsx
@@ -22,6 +22,7 @@ import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import { KeyedMutator } from "swr";
 import HenkilotLukutila from "@components/projekti/lukutila/HenkilotLukutila";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
+import PaivitaVelhoTiedotButton from "@components/projekti/PaivitaVelhoTiedotButton";
 
 // Extend TallennaProjektiInput by making fields other than muistiinpano nonnullable and required
 type RequiredFields = Pick<TallennaProjektiInput, "oid" | "kayttoOikeudet">;
@@ -45,8 +46,15 @@ export default function HenkilotPage(): ReactElement {
 
   const epaaktiivinen = projektiOnEpaaktiivinen(projekti);
 
+  if (!projekti) {
+    return <></>;
+  }
+
   return (
-    <ProjektiPageLayout title="Projektin Henkilöt" showUpdateButton={true}>
+    <ProjektiPageLayout
+      title="Projektin Henkilöt"
+      contentAsideTitle={<PaivitaVelhoTiedotButton projektiOid={projekti.oid} reloadProjekti={reloadProjekti} />}
+    >
       {projekti &&
         (epaaktiivinen && projekti.kayttoOikeudet ? (
           <HenkilotLukutila kayttoOikeudet={projekti.kayttoOikeudet} />

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -30,6 +30,7 @@ import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import { KeyedMutator } from "swr";
 import ProjektinTiedotLukutila from "@components/projekti/lukutila/ProjektinTiedotLukutila";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
+import PaivitaVelhoTiedotButton from "@components/projekti/PaivitaVelhoTiedotButton";
 
 type TransientFormValues = {
   suunnittelusopimusprojekti: "true" | "false" | null;
@@ -50,9 +51,16 @@ const loadedProjektiValidationSchema = getProjektiValidationSchema([
 export default function ProjektiSivu() {
   const { data: projekti, error: projektiLoadError, mutate: reloadProjekti } = useProjekti({ revalidateOnMount: true });
 
+  if (!projekti) {
+    return <></>;
+  }
+
   const epaaktiivinen = projektiOnEpaaktiivinen(projekti);
   return (
-    <ProjektiPageLayout title={"Projektin tiedot"} showUpdateButton={!epaaktiivinen}>
+    <ProjektiPageLayout
+      title={"Projektin tiedot"}
+      contentAsideTitle={!epaaktiivinen && <PaivitaVelhoTiedotButton projektiOid={projekti.oid} reloadProjekti={reloadProjekti} />}
+    >
       {projekti &&
         (epaaktiivinen ? (
           <ProjektinTiedotLukutila projekti={projekti} />

--- a/src/schemas/aloituskuulutus.ts
+++ b/src/schemas/aloituskuulutus.ts
@@ -3,21 +3,26 @@ import * as Yup from "yup";
 import filter from "lodash/filter";
 import { standardiYhteystiedot } from "./common";
 import { paivamaara } from "./paivamaaraSchema";
+import { uudelleenKuulutus } from "./uudelleenKuulutus";
+import { lokalisoituTeksti } from "./lokalisoituTeksti";
 
 const maxAloituskuulutusLength = 2000;
-
-let hankkeenKuvaus = Yup.string()
-  .max(maxAloituskuulutusLength, `Aloituskuulutukseen voidaan kirjoittaa maksimissaan ${maxAloituskuulutusLength} merkkiä`)
-  .required("Hankkeen kuvaus ei voi olla tyhjä")
-  .nullable();
 
 export const aloituskuulutusSchema = Yup.object().shape({
   oid: Yup.string().required(),
   aloitusKuulutus: Yup.object().shape({
     kuulutusYhteystiedot: standardiYhteystiedot(),
-    hankkeenKuvaus: Yup.object().shape({ SUOMI: hankkeenKuvaus }),
+    hankkeenKuvaus: lokalisoituTeksti({
+      requiredText: "Hankkeen kuvaus ei voi olla tyhjä",
+      additionalStringValidations: (schema) =>
+        schema.max(maxAloituskuulutusLength, `Aloituskuulutukseen voidaan kirjoittaa maksimissaan ${maxAloituskuulutusLength} merkkiä`),
+    }),
     kuulutusPaiva: paivamaara({ preventPast: "Kuulutuspäivää ei voida asettaa menneisyyteen" }).required("Kuulutuspäivä ei voi olla tyhjä"),
     siirtyySuunnitteluVaiheeseen: paivamaara(),
+    uudelleenKuulutus: uudelleenKuulutus({
+      uudelleenKuulutusKey: "$aloitusKuulutus.uudelleenKuulutus",
+      requiredText: "Seloste on annettava",
+    }),
     ilmoituksenVastaanottajat: Yup.object()
       .shape({
         kunnat: Yup.array()

--- a/src/schemas/lokalisoituTeksti.ts
+++ b/src/schemas/lokalisoituTeksti.ts
@@ -1,0 +1,30 @@
+import { Kieli, Kielitiedot } from "@services/api";
+import * as Yup from "yup";
+import { ObjectShape } from "yup/lib/object";
+
+interface LokalisoituTekstiSchemaProps {
+  requiredText?: string;
+  additionalStringValidations?: (schema: Yup.StringSchema) => Yup.StringSchema;
+}
+
+type LocalisoituTekstiSchema = (props: LokalisoituTekstiSchemaProps) => Yup.ObjectSchema<ObjectShape>;
+
+export const lokalisoituTeksti: LocalisoituTekstiSchema = ({
+  requiredText = "Tieto on annettava",
+  additionalStringValidations: schemaWithValidations = (schema) => schema,
+}) =>
+  Yup.object().shape({
+    SUOMI: schemaWithValidations(Yup.string().required(requiredText)),
+    RUOTSI: Yup.string().when("$kielitiedot", {
+      is: (kielitiedot: Kielitiedot | null | undefined) =>
+        [kielitiedot?.ensisijainenKieli, kielitiedot?.toissijainenKieli].includes(Kieli.RUOTSI),
+      then: (schema) => schemaWithValidations(schema.required(requiredText)),
+      otherwise: (schema) => schema.optional(),
+    }),
+    SAAME: Yup.string().when("$kielitiedot", {
+      is: (kielitiedot: Kielitiedot | null | undefined) =>
+        [kielitiedot?.ensisijainenKieli, kielitiedot?.toissijainenKieli].includes(Kieli.SAAME),
+      then: (schema) => schemaWithValidations(schema.required(requiredText)),
+      otherwise: (schema) => schema.optional(),
+    }),
+  });

--- a/src/schemas/uudelleenKuulutus.ts
+++ b/src/schemas/uudelleenKuulutus.ts
@@ -7,11 +7,21 @@ interface UudelleenKuulutusSchemaProps {
   uudelleenKuulutusKey: string;
 }
 
+export const maxSelosteLength = 2000;
+
 export const uudelleenKuulutus = ({ requiredText, uudelleenKuulutusKey }: UudelleenKuulutusSchemaProps) =>
   Yup.object()
     .shape({
-      selosteLahetekirjeeseen: lokalisoituTeksti({ requiredText }),
-      selosteKuulutukselle: lokalisoituTeksti({ requiredText })
+      selosteLahetekirjeeseen: lokalisoituTeksti({
+        requiredText,
+        additionalStringValidations: (schema) =>
+          schema.max(maxSelosteLength, `Selosteelle voidaan kirjoittaa maksimissaan ${maxSelosteLength} merkkiä`),
+      }),
+      selosteKuulutukselle: lokalisoituTeksti({
+        requiredText,
+        additionalStringValidations: (schema) =>
+          schema.max(maxSelosteLength, `Selosteelle voidaan kirjoittaa maksimissaan ${maxSelosteLength} merkkiä`),
+      })
         .when(uudelleenKuulutusKey, {
           is: (uudelleenKuulutus: UudelleenKuulutus | null | undefined) => {
             return uudelleenKuulutus?.tila === UudelleenkuulutusTila.JULKAISTU_PERUUTETTU;

--- a/src/schemas/uudelleenKuulutus.ts
+++ b/src/schemas/uudelleenKuulutus.ts
@@ -1,0 +1,30 @@
+import { UudelleenKuulutus, UudelleenkuulutusTila } from "@services/api";
+import * as Yup from "yup";
+import { lokalisoituTeksti } from "./lokalisoituTeksti";
+
+interface UudelleenKuulutusSchemaProps {
+  requiredText?: string;
+  uudelleenKuulutusKey: string;
+}
+
+export const uudelleenKuulutus = ({ requiredText, uudelleenKuulutusKey }: UudelleenKuulutusSchemaProps) =>
+  Yup.object()
+    .shape({
+      selosteLahetekirjeeseen: lokalisoituTeksti({ requiredText }),
+      selosteKuulutukselle: lokalisoituTeksti({ requiredText })
+        .when(uudelleenKuulutusKey, {
+          is: (uudelleenKuulutus: UudelleenKuulutus | null | undefined) => {
+            return uudelleenKuulutus?.tila === UudelleenkuulutusTila.JULKAISTU_PERUUTETTU;
+          },
+          then: (schema) => schema.required(requiredText),
+          otherwise: (schema) => schema.optional(),
+        })
+        .default(undefined)
+        .optional(),
+    })
+    .when(uudelleenKuulutusKey, {
+      is: (uudelleenKuulutus: UudelleenKuulutus | null | undefined) => !!uudelleenKuulutus,
+      then: (schema) => schema.required(),
+    })
+    .default(undefined)
+    .optional();

--- a/src/services/api/fragmentTypes.json
+++ b/src/services/api/fragmentTypes.json
@@ -129,18 +129,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "HankkeenKuvaukset",
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "HankkeenKuvauksetInput",
-        "possibleTypes": null,
-        "__typename": "__Type"
-      },
-      {
-        "kind": "OBJECT",
         "name": "Hyvaksymispaatos",
         "possibleTypes": null,
         "__typename": "__Type"


### PR DESCRIPTION
- Muokattu hankkeenkuvaus-kentät käyttämää lokalisoituteksti -tyyppiä
- Lisätty uudelleenkuulutustietojen täyttöä tarkistavat validoinnit aloituskuulutus-schemaan
- Muokattu PagePageLayoutia niin, että sille annetaan propsina mitä sivun "ylänurkkaan" halutaan (eg. Uudelleenkuulutuspainike tai Velhosynkronointipainike)
- Lisätty uudelleenkuuluta painike aloituskuulutussivun ylänurkkaan
- Lisää kentät selosteille muokkaustilaan ja lukutilaan 
- Lisätty seloste kuulutukselle kansalaisnäkymään