### PR TITLE
feat: aineistojen synkronointi kansalaispuolelle

### DIFF
--- a/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusHandler.test.ts.snap
+++ b/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusHandler.test.ts.snap
@@ -8,6 +8,7 @@ Object {
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
+    "id": 1,
     "kuulutusPaiva": "2022-01-02",
     "kuulutusYhteystiedot": Object {
       "yhteysTiedot": Array [
@@ -34,6 +35,7 @@ Object {
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
+    "id": 1,
     "kuulutusPaiva": "2022-01-02",
     "kuulutusYhteystiedot": Object {
       "yhteysTiedot": Array [
@@ -52,12 +54,12 @@ Object {
     Object {
       "aloituskuulutusPDFt": Object {
         "RUOTSI": Object {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta RUOTSIKSI.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus RUOTSIKSI.pdf",
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta RUOTSIKSI.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus RUOTSIKSI.pdf",
         },
         "SUOMI": Object {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus.pdf",
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
         },
       },
       "hankkeenKuvaus": Object {
@@ -132,6 +134,7 @@ Object {
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
+    "id": 1,
     "kuulutusPaiva": "2022-01-02",
     "kuulutusYhteystiedot": Object {
       "yhteysTiedot": Array [
@@ -159,6 +162,7 @@ Object {
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
+    "id": 1,
     "kuulutusPaiva": "2022-01-02",
     "kuulutusYhteystiedot": Object {
       "yhteysTiedot": Array [
@@ -178,12 +182,12 @@ Object {
     Object {
       "aloituskuulutusPDFt": Object {
         "RUOTSI": Object {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta RUOTSIKSI.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus RUOTSIKSI.pdf",
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta RUOTSIKSI.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus RUOTSIKSI.pdf",
         },
         "SUOMI": Object {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus.pdf",
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
         },
       },
       "hankkeenKuvaus": Object {
@@ -258,6 +262,7 @@ Object {
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum",
     },
+    "id": 1,
     "kuulutusPaiva": "2022-01-02",
     "kuulutusYhteystiedot": Object {
       "yhteysTiedot": Array [
@@ -277,12 +282,12 @@ Object {
     Object {
       "aloituskuulutusPDFt": Object {
         "RUOTSI": Object {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta RUOTSIKSI.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus RUOTSIKSI.pdf",
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta RUOTSIKSI.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus RUOTSIKSI.pdf",
         },
         "SUOMI": Object {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus.pdf",
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
         },
       },
       "hankkeenKuvaus": Object {

--- a/backend/integrationtest/aloitusKuulutus/aloitusKuulutusHandler.test.ts
+++ b/backend/integrationtest/aloitusKuulutus/aloitusKuulutusHandler.test.ts
@@ -15,6 +15,7 @@ import { pdfGeneratorClient } from "../../src/asiakirja/lambda/pdfGeneratorClien
 import { handleEvent as pdfGenerator } from "../../src/asiakirja/lambda/pdfGeneratorHandler";
 import { replaceFieldsByName } from "../api/testFixtureRecorder";
 import { mockSaveProjektiToVelho } from "../api/testUtil/util";
+import { aineistoService } from "../../src/aineisto/aineistoService";
 
 const { expect } = require("chai");
 
@@ -33,11 +34,17 @@ describe("AloitusKuulutus", () => {
   let readUsersFromSearchUpdaterLambda: sinon.SinonStub;
   let publishProjektiFileStub: sinon.SinonStub;
   let sendEmailsByToimintoStub: sinon.SinonStub;
+  let aineistoServiceStub: sinon.SinonStub;
 
   before(async () => {
     readUsersFromSearchUpdaterLambda = sinon.stub(personSearchUpdaterClient, "readUsersFromSearchUpdaterLambda");
     readUsersFromSearchUpdaterLambda.callsFake(async () => {
       return await personSearchUpdaterHandler.handleEvent();
+    });
+
+    aineistoServiceStub = sinon.stub(aineistoService, "synchronizeProjektiFiles");
+    aineistoServiceStub.callsFake(async () => {
+      console.log("Synkataan aineisto");
     });
 
     publishProjektiFileStub = sinon.stub(fileService, "publishProjektiFile");

--- a/backend/integrationtest/aloitusKuulutus/aloitusKuulutusUudelleenKuulutus.test.ts
+++ b/backend/integrationtest/aloitusKuulutus/aloitusKuulutusUudelleenKuulutus.test.ts
@@ -23,6 +23,7 @@ import assert from "assert";
 import { projektiDatabase } from "../../src/database/projektiDatabase";
 import { assertIsDefined } from "../../src/util/assertions";
 import { testProjektiDatabase } from "../../src/database/testProjektiDatabase";
+import { aineistoService } from "../../src/aineisto/aineistoService";
 
 const { expect } = require("chai");
 
@@ -33,6 +34,7 @@ describe("AloitusKuulutuksen uudelleenkuuluttaminen", () => {
   let oid: string;
   const emailClientStub = new EmailClientStub();
   const pdfGeneratorStub = new PDFGeneratorStub();
+  let aineistoServiceStub: sinon.SinonStub;
 
   before(async () => {
     readUsersFromSearchUpdaterLambda = sinon.stub(personSearchUpdaterClient, "readUsersFromSearchUpdaterLambda");
@@ -45,6 +47,10 @@ describe("AloitusKuulutuksen uudelleenkuuluttaminen", () => {
 
     pdfGeneratorStub.init();
     emailClientStub.init();
+    aineistoServiceStub = sinon.stub(aineistoService, "synchronizeProjektiFiles");
+    aineistoServiceStub.callsFake(async () => {
+      console.log("Synkataan aineisto");
+    });
   });
 
   beforeEach(async () => {

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -1016,7 +1016,7 @@ Object {
       "dokumenttiOid": "1.2.246.578.5.100.2830496143.3575999363",
       "jarjestys": 12,
       "nimi": "new ekatiedosto_eka.pdf",
-      "tiedosto": "/suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf",
+      "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf",
       "tila": "VALMIS",
       "tuotu": "***unittest***",
     },
@@ -1060,7 +1060,7 @@ Object {
       "jarjestys": 11,
       "kategoriaId": "T1xx",
       "nimi": "new karttakuvalla_tiedosto.pdf",
-      "tiedosto": "/suunnitteluvaihe/vuorovaikutus_1/aineisto/karttakuvalla_tiedosto.pdf",
+      "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/aineisto/karttakuvalla_tiedosto.pdf",
       "tila": "VALMIS",
       "tuotu": "***unittest***",
     },
@@ -1582,12 +1582,38 @@ LIITTEET	Kutsu tiedotus-/yleisötilaisuuteen (20T)",
 exports[`Api should search, load and save a project 12`] = `
 Object {
   "yllapito S3 files just after vuorovaikutus published": Object {
-    "aloituskuulutus/T412 Aloituskuulutus.pdf": Object {},
-    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": Object {},
-    "suunnittelusopimus/logo.png": Object {},
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": Object {},
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/karttakuvalla_tiedosto.pdf": Object {},
-    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": Object {},
+    "aloituskuulutus/1/T412 Aloituskuulutus.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-01-02T00:00:00+02:00",
+    },
+    "aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-01-02T00:00:00+02:00",
+    },
+    "suunnittelusopimus/logo.png": FileMetadata {
+      "ContentDisposition": undefined,
+      "ContentType": "image/png",
+      "checksum": "ABC123",
+    },
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''ekatiedosto_eka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/karttakuvalla_tiedosto.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''karttakuvalla_tiedosto.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
+    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TS%20Tie%20Yleisotilaisuus%20kutsu.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
   },
 }
 `;
@@ -1595,30 +1621,40 @@ Object {
 exports[`Api should search, load and save a project 13`] = `
 Object {
   "public S3 files just after vuorovaikutus published": Object {
-    "aloituskuulutus/T412 Aloituskuulutus.pdf": Object {
+    "aloituskuulutus/T412 Aloituskuulutus.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": Object {
+    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "suunnittelusopimus/logo.png": Object {
-      "ContentType": "application/octet-stream",
+    "suunnittelusopimus/logo.png": FileMetadata {
+      "ContentDisposition": undefined,
+      "ContentType": "image/png",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''ekatiedosto_eka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-03-23T00:00:00+02:00",
     },
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/karttakuvalla_tiedosto.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/karttakuvalla_tiedosto.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''karttakuvalla_tiedosto.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-03-23T00:00:00+02:00",
     },
-    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TS%20Tie%20Yleisotilaisuus%20kutsu.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-03-23T00:00:00+02:00",
     },
   },
@@ -1627,18 +1663,32 @@ Object {
 
 exports[`Api should search, load and save a project 14`] = `
 Object {
-  "args": Object {
-    "DistributionId": "unit-test-distribution-id",
-    "InvalidationBatch": Object {
-      "CallerReference": "***unittest***",
-      "Paths": Object {
-        "Items": Array [
-          "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/*",
-        ],
-        "Quantity": 1,
+  "args": Array [
+    Object {
+      "DistributionId": "unit-test-distribution-id",
+      "InvalidationBatch": Object {
+        "CallerReference": "***unittest***",
+        "Paths": Object {
+          "Items": Array [
+            "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/*",
+          ],
+          "Quantity": 1,
+        },
       },
     },
-  },
+    Object {
+      "DistributionId": "unit-test-distribution-id",
+      "InvalidationBatch": Object {
+        "CallerReference": "***unittest***",
+        "Paths": Object {
+          "Items": Array [
+            "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/suunnitteluvaihe/vuorovaikutus_1/*",
+          ],
+          "Quantity": 1,
+        },
+      },
+    },
+  ],
   "stub": "createInvalidation",
 }
 `;
@@ -1646,11 +1696,33 @@ Object {
 exports[`Api should search, load and save a project 15`] = `
 Object {
   "yllapito S3 files vuorovaikutus publish date changed and last aineisto deleted": Object {
-    "aloituskuulutus/T412 Aloituskuulutus.pdf": Object {},
-    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": Object {},
-    "suunnittelusopimus/logo.png": Object {},
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": Object {},
-    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": Object {},
+    "aloituskuulutus/1/T412 Aloituskuulutus.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-01-02T00:00:00+02:00",
+    },
+    "aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-01-02T00:00:00+02:00",
+    },
+    "suunnittelusopimus/logo.png": FileMetadata {
+      "ContentDisposition": undefined,
+      "ContentType": "image/png",
+      "checksum": "ABC123",
+    },
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''ekatiedosto_eka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
+    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TS%20Tie%20Yleisotilaisuus%20kutsu.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
   },
 }
 `;
@@ -1658,26 +1730,34 @@ Object {
 exports[`Api should search, load and save a project 16`] = `
 Object {
   "public S3 files vuorovaikutus publish date changed and last aineisto deleted": Object {
-    "aloituskuulutus/T412 Aloituskuulutus.pdf": Object {
+    "aloituskuulutus/T412 Aloituskuulutus.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": Object {
+    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "suunnittelusopimus/logo.png": Object {
-      "ContentType": "application/octet-stream",
+    "suunnittelusopimus/logo.png": FileMetadata {
+      "ContentDisposition": undefined,
+      "ContentType": "image/png",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''ekatiedosto_eka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-03-24T00:00:00+02:00",
     },
-    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TS%20Tie%20Yleisotilaisuus%20kutsu.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-03-24T00:00:00+02:00",
     },
   },
@@ -2099,7 +2179,7 @@ Object {
           "jarjestys": 1,
           "kategoriaId": "T2xx",
           "nimi": "T222 Meluesteiden periaatekuvat.txt",
-          "tiedosto": "/nahtavillaolo/1/T222 Meluesteiden periaatekuvat.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T222 Meluesteiden periaatekuvat.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2109,7 +2189,7 @@ Object {
           "jarjestys": 2,
           "kategoriaId": "T2xx",
           "nimi": "T213 Teiden hallinnolsten järjestelyjen kartat.txt",
-          "tiedosto": "/nahtavillaolo/1/T213 Teiden hallinnolsten järjestelyjen kartat.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T213 Teiden hallinnolsten järjestelyjen kartat.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2119,7 +2199,7 @@ Object {
           "jarjestys": 3,
           "kategoriaId": "T2xx",
           "nimi": "T224 Siltataulukko.txt",
-          "tiedosto": "/nahtavillaolo/1/T224 Siltataulukko.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T224 Siltataulukko.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2129,7 +2209,7 @@ Object {
           "jarjestys": 4,
           "kategoriaId": "T2xx",
           "nimi": "T211 Piirustusmerkinnät.txt",
-          "tiedosto": "/nahtavillaolo/1/T211 Piirustusmerkinnät.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T211 Piirustusmerkinnät.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2139,7 +2219,7 @@ Object {
           "jarjestys": 5,
           "kategoriaId": "T2xx",
           "nimi": "T212 Yleiskartta.txt",
-          "tiedosto": "/nahtavillaolo/1/T212 Yleiskartta.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T212 Yleiskartta.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2211,7 +2291,7 @@ Object {
           "dokumenttiOid": "1.2.246.578.5.100.2303050596.2160380418",
           "jarjestys": 1,
           "nimi": "tokatiedosto_toka.pdf",
-          "tiedosto": "/nahtavillaolo/1/tokatiedosto_toka.pdf",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/tokatiedosto_toka.pdf",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2235,7 +2315,7 @@ Object {
           "jarjestys": 1,
           "kategoriaId": "T2xx",
           "nimi": "T222 Meluesteiden periaatekuvat.txt",
-          "tiedosto": "/nahtavillaolo/1/T222 Meluesteiden periaatekuvat.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T222 Meluesteiden periaatekuvat.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2245,7 +2325,7 @@ Object {
           "jarjestys": 2,
           "kategoriaId": "T2xx",
           "nimi": "T213 Teiden hallinnolsten järjestelyjen kartat.txt",
-          "tiedosto": "/nahtavillaolo/1/T213 Teiden hallinnolsten järjestelyjen kartat.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T213 Teiden hallinnolsten järjestelyjen kartat.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2255,7 +2335,7 @@ Object {
           "jarjestys": 3,
           "kategoriaId": "T2xx",
           "nimi": "T224 Siltataulukko.txt",
-          "tiedosto": "/nahtavillaolo/1/T224 Siltataulukko.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T224 Siltataulukko.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2265,7 +2345,7 @@ Object {
           "jarjestys": 4,
           "kategoriaId": "T2xx",
           "nimi": "T211 Piirustusmerkinnät.txt",
-          "tiedosto": "/nahtavillaolo/1/T211 Piirustusmerkinnät.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T211 Piirustusmerkinnät.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2275,7 +2355,7 @@ Object {
           "jarjestys": 5,
           "kategoriaId": "T2xx",
           "nimi": "T212 Yleiskartta.txt",
-          "tiedosto": "/nahtavillaolo/1/T212 Yleiskartta.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T212 Yleiskartta.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2331,7 +2411,7 @@ Object {
           "dokumenttiOid": "1.2.246.578.5.100.2303050596.2160380418",
           "jarjestys": 1,
           "nimi": "tokatiedosto_toka.pdf",
-          "tiedosto": "/nahtavillaolo/1/tokatiedosto_toka.pdf",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/tokatiedosto_toka.pdf",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2341,9 +2421,9 @@ Object {
       "nahtavillaoloPDFt": Object {
         "SUOMI": Object {
           "__typename": "NahtavillaoloPDF",
-          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
-          "nahtavillaoloIlmoitusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
-          "nahtavillaoloPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf",
+          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
+          "nahtavillaoloIlmoitusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
+          "nahtavillaoloPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/1/T414 Kuulutus suunnitelman nahtavillaolo.pdf",
         },
         "__typename": "NahtavillaoloPDFt",
       },
@@ -2513,20 +2593,81 @@ Object {
 exports[`Api should search, load and save a project 24`] = `
 Object {
   "yllapito S3 files Nahtavillaolo published": Object {
-    "aloituskuulutus/T412 Aloituskuulutus.pdf": Object {},
-    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": Object {},
-    "nahtavillaolo/1/T211 Piirustusmerkinnät.txt": Object {},
-    "nahtavillaolo/1/T212 Yleiskartta.txt": Object {},
-    "nahtavillaolo/1/T213 Teiden hallinnolsten järjestelyjen kartat.txt": Object {},
-    "nahtavillaolo/1/T222 Meluesteiden periaatekuvat.txt": Object {},
-    "nahtavillaolo/1/T224 Siltataulukko.txt": Object {},
-    "nahtavillaolo/1/tokatiedosto_toka.pdf": Object {},
-    "nahtavillaolo/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf": Object {},
-    "nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf": Object {},
-    "nahtavillaolo/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf": Object {},
-    "suunnittelusopimus/logo.png": Object {},
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": Object {},
-    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": Object {},
+    "aloituskuulutus/1/T412 Aloituskuulutus.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-01-02T00:00:00+02:00",
+    },
+    "aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-01-02T00:00:00+02:00",
+    },
+    "nahtavillaolo/1/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''31T%20Ilmoitus%20kiinteistonomistajat%20nahtaville%20asettaminen.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-06-07T00:00:00+03:00",
+    },
+    "nahtavillaolo/1/T211 Piirustusmerkinnät.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T211%20Piirustusmerkinn%C3%A4t.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "nahtavillaolo/1/T212 Yleiskartta.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T212%20Yleiskartta.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "nahtavillaolo/1/T213 Teiden hallinnolsten järjestelyjen kartat.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T213%20Teiden%20hallinnolsten%20j%C3%A4rjestelyjen%20kartat.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "nahtavillaolo/1/T222 Meluesteiden periaatekuvat.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T222%20Meluesteiden%20periaatekuvat.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "nahtavillaolo/1/T224 Siltataulukko.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T224%20Siltataulukko.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "nahtavillaolo/1/T414 Kuulutus suunnitelman nahtavillaolo.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T414%20Kuulutus%20suunnitelman%20nahtavillaolo.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-06-07T00:00:00+03:00",
+    },
+    "nahtavillaolo/1/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T414_1%20Ilmoitus%20suunnitelman%20nahtavillaolo.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+      "publishDate": "2022-06-07T00:00:00+03:00",
+    },
+    "nahtavillaolo/1/tokatiedosto_toka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''tokatiedosto_toka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
+    "suunnittelusopimus/logo.png": FileMetadata {
+      "ContentDisposition": undefined,
+      "ContentType": "image/png",
+      "checksum": "ABC123",
+    },
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''ekatiedosto_eka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
+    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TS%20Tie%20Yleisotilaisuus%20kutsu.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
+    },
   },
 }
 `;
@@ -2534,65 +2675,88 @@ Object {
 exports[`Api should search, load and save a project 25`] = `
 Object {
   "public S3 files Nahtavillaolo published": Object {
-    "aloituskuulutus/T412 Aloituskuulutus.pdf": Object {
+    "aloituskuulutus/T412 Aloituskuulutus.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": Object {
+    "aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "nahtavillaolo/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf": Object {
+    "nahtavillaolo/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''31T%20Ilmoitus%20kiinteistonomistajat%20nahtaville%20asettaminen.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/T211 Piirustusmerkinnät.txt": Object {
-      "ContentType": "application/octet-stream",
+    "nahtavillaolo/T211 Piirustusmerkinnät.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T211%20Piirustusmerkinn%C3%A4t.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/T212 Yleiskartta.txt": Object {
-      "ContentType": "application/octet-stream",
+    "nahtavillaolo/T212 Yleiskartta.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T212%20Yleiskartta.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/T213 Teiden hallinnolsten järjestelyjen kartat.txt": Object {
-      "ContentType": "application/octet-stream",
+    "nahtavillaolo/T213 Teiden hallinnolsten järjestelyjen kartat.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T213%20Teiden%20hallinnolsten%20j%C3%A4rjestelyjen%20kartat.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/T222 Meluesteiden periaatekuvat.txt": Object {
-      "ContentType": "application/octet-stream",
+    "nahtavillaolo/T222 Meluesteiden periaatekuvat.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T222%20Meluesteiden%20periaatekuvat.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/T224 Siltataulukko.txt": Object {
-      "ContentType": "application/octet-stream",
+    "nahtavillaolo/T224 Siltataulukko.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T224%20Siltataulukko.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf": Object {
+    "nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T414%20Kuulutus%20suunnitelman%20nahtavillaolo.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf": Object {
+    "nahtavillaolo/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T414_1%20Ilmoitus%20suunnitelman%20nahtavillaolo.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "nahtavillaolo/tokatiedosto_toka.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "nahtavillaolo/tokatiedosto_toka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''tokatiedosto_toka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-07T00:00:00+03:00",
     },
-    "suunnittelusopimus/logo.png": Object {
-      "ContentType": "application/octet-stream",
+    "suunnittelusopimus/logo.png": FileMetadata {
+      "ContentDisposition": undefined,
+      "ContentType": "image/png",
+      "checksum": "ABC123",
       "publishDate": "2022-01-02T00:00:00+02:00",
     },
-    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "suunnitteluvaihe/vuorovaikutus_1/aineisto/ekatiedosto_eka.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''ekatiedosto_eka.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-03-24T00:00:00+02:00",
     },
-    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": Object {
-      "ContentType": "application/octet-stream",
+    "suunnitteluvaihe/vuorovaikutus_1/kutsu/TS Tie Yleisotilaisuus kutsu.pdf": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TS%20Tie%20Yleisotilaisuus%20kutsu.pdf",
+      "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-03-24T00:00:00+02:00",
     },
   },
@@ -2718,8 +2882,16 @@ Object {
 exports[`Api should search, load and save a project 28`] = `
 Object {
   "yllapito S3 files Hyvaksymispaatos created": Object {
-    "/1/T113 TS Esite.txt": Object {},
-    "/1/paatos/TYHJÄ.txt": Object {},
+    "/1/T113 TS Esite.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T113%20TS%20Esite.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "/1/paatos/TYHJÄ.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TYHJ%C3%84.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
   },
 }
 `;
@@ -2737,7 +2909,7 @@ Object {
           "jarjestys": 1,
           "kategoriaId": "T1xx",
           "nimi": "T113 TS Esite.txt",
-          "tiedosto": "/hyvaksymispaatos/1/T113 TS Esite.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/T113 TS Esite.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2751,7 +2923,7 @@ Object {
           "dokumenttiOid": "1.2.246.578.5.100.2147637429.4251089044",
           "jarjestys": 1,
           "nimi": "TYHJÄ.txt",
-          "tiedosto": "/hyvaksymispaatos/1/paatos/TYHJÄ.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/paatos/TYHJÄ.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -2823,7 +2995,7 @@ Object {
             "jarjestys": 1,
             "kategoriaId": "T1xx",
             "nimi": "T113 TS Esite.txt",
-            "tiedosto": "/hyvaksymispaatos/1/T113 TS Esite.txt",
+            "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/T113 TS Esite.txt",
             "tila": "VALMIS",
             "tuotu": "***unittest***",
           },
@@ -2838,7 +3010,7 @@ Object {
             "dokumenttiOid": "1.2.246.578.5.100.2147637429.4251089044",
             "jarjestys": 1,
             "nimi": "TYHJÄ.txt",
-            "tiedosto": "/hyvaksymispaatos/1/paatos/TYHJÄ.txt",
+            "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/paatos/TYHJÄ.txt",
             "tila": "VALMIS",
             "tuotu": "***unittest***",
           },
@@ -2846,11 +3018,11 @@ Object {
         "hyvaksymisPaatosVaihePDFt": Object {
           "SUOMI": Object {
             "__typename": "HyvaksymisPaatosVaihePDF",
-            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
           },
           "__typename": "HyvaksymisPaatosVaihePDFt",
         },
@@ -3011,37 +3183,46 @@ Object {
 exports[`Api should search, load and save a project 31`] = `
 Object {
   "public S3 files Hyvaksymispaatos approved": Object {
-    "/T113 TS Esite.txt": Object {
-      "ContentType": "application/octet-stream",
+    "/T113 TS Esite.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T113%20TS%20Esite.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
       "publishDate": "2022-06-09T00:00:00+03:00",
     },
-    "/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf": Object {
+    "/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T431%20Kuulutus%20hyvaksymispaatoksen%20nahtavillaolo.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-09T00:00:00+03:00",
     },
-    "/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf": Object {
+    "/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T431_1%20Ilmoitus%20hyvaksymispaatoksesta%20kunnalle%20ja%20ELYlle.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-09T00:00:00+03:00",
     },
-    "/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf": Object {
+    "/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T431_2%20Ilmoitus%20hyvaksymispaatoksen%20kuulutuksesta.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-09T00:00:00+03:00",
     },
-    "/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf": Object {
+    "/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T431_3%20Ilmoitus%20hyvaksymispaatoksesta%20lausunnon%20antajille.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-09T00:00:00+03:00",
     },
-    "/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf": Object {
+    "/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf": FileMetadata {
       "ContentDisposition": "inline; filename*=UTF-8''T431_4%20Ilmoitus%20hyvaksymispaatoksesta%20muistuttajille.pdf",
       "ContentType": "application/pdf",
+      "checksum": "ABC123",
       "publishDate": "2022-06-09T00:00:00+03:00",
     },
-    "/paatos/TYHJÄ.txt": Object {
-      "ContentType": "application/octet-stream",
+    "/paatos/TYHJÄ.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TYHJ%C3%84.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
       "publishDate": "2022-06-09T00:00:00+03:00",
     },
   },

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -1942,8 +1942,8 @@ Object {
         },
       ],
     },
-    "kuulutusPaiva": "***unittest***",
-    "kuulutusVaihePaattyyPaiva": "***unittest***",
+    "kuulutusPaiva": "2022-06-07",
+    "kuulutusVaihePaattyyPaiva": "2042-06-07",
     "kuulutusYhteystiedot": Object {
       "__typename": "StandardiYhteystiedot",
       "yhteysHenkilot": Array [
@@ -2065,8 +2065,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "***unittest***",
-      "kuulutusVaihePaattyyPaiva": "***unittest***",
+      "kuulutusPaiva": "2022-06-07",
+      "kuulutusVaihePaattyyPaiva": "2042-06-07",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -2261,8 +2261,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "***unittest***",
-      "kuulutusVaihePaattyyPaiva": "***unittest***",
+      "kuulutusPaiva": "2022-06-07",
+      "kuulutusVaihePaattyyPaiva": "2042-06-07",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -2403,8 +2403,8 @@ Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",
       },
-      "kuulutusPaiva": "***unittest***",
-      "kuulutusVaihePaattyyPaiva": "***unittest***",
+      "kuulutusPaiva": "2022-06-07",
+      "kuulutusVaihePaattyyPaiva": "2042-06-07",
       "lisaAineisto": Array [
         Object {
           "__typename": "Aineisto",

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -1942,8 +1942,8 @@ Object {
         },
       ],
     },
-    "kuulutusPaiva": "2022-06-07",
-    "kuulutusVaihePaattyyPaiva": "2042-06-07",
+    "kuulutusPaiva": "***unittest***",
+    "kuulutusVaihePaattyyPaiva": "***unittest***",
     "kuulutusYhteystiedot": Object {
       "__typename": "StandardiYhteystiedot",
       "yhteysHenkilot": Array [
@@ -2065,8 +2065,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "2022-06-07",
-      "kuulutusVaihePaattyyPaiva": "2042-06-07",
+      "kuulutusPaiva": "***unittest***",
+      "kuulutusVaihePaattyyPaiva": "***unittest***",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -2261,8 +2261,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "2022-06-07",
-      "kuulutusVaihePaattyyPaiva": "2042-06-07",
+      "kuulutusPaiva": "***unittest***",
+      "kuulutusVaihePaattyyPaiva": "***unittest***",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -2366,7 +2366,7 @@ Object {
         "__typename": "LokalisoituTeksti",
       },
       "hyvaksyja": "A000112",
-      "hyvaksymisPaiva": "2022-11-25",
+      "hyvaksymisPaiva": "***unittest***",
       "id": 1,
       "ilmoituksenVastaanottajat": Object {
         "__typename": "IlmoituksenVastaanottajat",
@@ -2403,8 +2403,8 @@ Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",
       },
-      "kuulutusPaiva": "2022-06-07",
-      "kuulutusVaihePaattyyPaiva": "2042-06-07",
+      "kuulutusPaiva": "***unittest***",
+      "kuulutusVaihePaattyyPaiva": "***unittest***",
       "lisaAineisto": Array [
         Object {
           "__typename": "Aineisto",

--- a/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
@@ -107,8 +107,16 @@ Object {
 exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 2`] = `
 Object {
   "yllapito S3 files jatkopäätös1 created": Object {
-    "/1/T113 TS Esite.txt": Object {},
-    "/1/paatos/TYHJÄ.txt": Object {},
+    "/1/T113 TS Esite.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T113%20TS%20Esite.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "/1/paatos/TYHJÄ.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TYHJ%C3%84.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
   },
 }
 `;
@@ -126,7 +134,7 @@ Object {
           "jarjestys": 1,
           "kategoriaId": "T1xx",
           "nimi": "T113 TS Esite.txt",
-          "tiedosto": "/jatkopaatos1/1/T113 TS Esite.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T113 TS Esite.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -140,7 +148,7 @@ Object {
           "dokumenttiOid": "1.2.246.578.5.100.2147637429.4251089044",
           "jarjestys": 1,
           "nimi": "TYHJÄ.txt",
-          "tiedosto": "/jatkopaatos1/1/paatos/TYHJÄ.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/paatos/TYHJÄ.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -212,7 +220,7 @@ Object {
             "jarjestys": 1,
             "kategoriaId": "T1xx",
             "nimi": "T113 TS Esite.txt",
-            "tiedosto": "/jatkopaatos1/1/T113 TS Esite.txt",
+            "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T113 TS Esite.txt",
             "tila": "VALMIS",
             "tuotu": "***unittest***",
           },
@@ -227,7 +235,7 @@ Object {
             "dokumenttiOid": "1.2.246.578.5.100.2147637429.4251089044",
             "jarjestys": 1,
             "nimi": "TYHJÄ.txt",
-            "tiedosto": "/jatkopaatos1/1/paatos/TYHJÄ.txt",
+            "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/paatos/TYHJÄ.txt",
             "tila": "VALMIS",
             "tuotu": "***unittest***",
           },
@@ -235,11 +243,11 @@ Object {
         "hyvaksymisPaatosVaihePDFt": Object {
           "SUOMI": Object {
             "__typename": "HyvaksymisPaatosVaihePDF",
-            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
           },
           "__typename": "HyvaksymisPaatosVaihePDFt",
         },
@@ -344,7 +352,7 @@ Object {
         "jarjestys": 1,
         "kategoriaId": "T1xx",
         "nimi": "T113 TS Esite.txt",
-        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T113 TS Esite.txt",
+        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/T113 TS Esite.txt",
         "tuotu": "***unittest***",
       },
     ],
@@ -358,7 +366,7 @@ Object {
         "jarjestys": 1,
         "kategoriaId": undefined,
         "nimi": "TYHJÄ.txt",
-        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/paatos/TYHJÄ.txt",
+        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/paatos/TYHJÄ.txt",
         "tuotu": "***unittest***",
       },
     ],
@@ -418,6 +426,24 @@ Object {
 `;
 
 exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 5`] = `
+Object {
+  "args": Object {
+    "DistributionId": "unit-test-distribution-id",
+    "InvalidationBatch": Object {
+      "CallerReference": "***unittest***",
+      "Paths": Object {
+        "Items": Array [
+          "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/*",
+        ],
+        "Quantity": 1,
+      },
+    },
+  },
+  "stub": "createInvalidation",
+}
+`;
+
+exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 6`] = `
 Object {
   "description": "testImportJatkopaatos2vaiheAineistot",
   "obj": Object {
@@ -525,16 +551,24 @@ Object {
 }
 `;
 
-exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 6`] = `
+exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 7`] = `
 Object {
   "yllapito S3 files jatkopäätös2 created": Object {
-    "/1/T113 TS Esite.txt": Object {},
-    "/1/paatos/TYHJÄ.txt": Object {},
+    "/1/T113 TS Esite.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''T113%20TS%20Esite.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
+    "/1/paatos/TYHJÄ.txt": FileMetadata {
+      "ContentDisposition": "inline; filename*=UTF-8''TYHJ%C3%84.txt",
+      "ContentType": "text/plain",
+      "checksum": "ABC123",
+    },
   },
 }
 `;
 
-exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 7`] = `
+exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 8`] = `
 Object {
   "description": "testJatkoPaatos2VaiheAfterApproval",
   "obj": Object {
@@ -547,7 +581,7 @@ Object {
           "jarjestys": 1,
           "kategoriaId": "T1xx",
           "nimi": "T113 TS Esite.txt",
-          "tiedosto": "/jatkopaatos1/1/T113 TS Esite.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/T113 TS Esite.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -561,7 +595,7 @@ Object {
           "dokumenttiOid": "1.2.246.578.5.100.2147637429.4251089044",
           "jarjestys": 1,
           "nimi": "TYHJÄ.txt",
-          "tiedosto": "/jatkopaatos1/1/paatos/TYHJÄ.txt",
+          "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos1/1/paatos/TYHJÄ.txt",
           "tila": "VALMIS",
           "tuotu": "***unittest***",
         },
@@ -633,7 +667,7 @@ Object {
             "jarjestys": 1,
             "kategoriaId": "T1xx",
             "nimi": "T113 TS Esite.txt",
-            "tiedosto": "/jatkopaatos2/1/T113 TS Esite.txt",
+            "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/T113 TS Esite.txt",
             "tila": "VALMIS",
             "tuotu": "***unittest***",
           },
@@ -648,7 +682,7 @@ Object {
             "dokumenttiOid": "1.2.246.578.5.100.2147637429.4251089044",
             "jarjestys": 1,
             "nimi": "TYHJÄ.txt",
-            "tiedosto": "/jatkopaatos2/1/paatos/TYHJÄ.txt",
+            "tiedosto": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/paatos/TYHJÄ.txt",
             "tila": "VALMIS",
             "tuotu": "***unittest***",
           },
@@ -656,11 +690,11 @@ Object {
         "hyvaksymisPaatosVaihePDFt": Object {
           "SUOMI": Object {
             "__typename": "HyvaksymisPaatosVaihePDF",
-            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
           },
           "__typename": "HyvaksymisPaatosVaihePDFt",
         },
@@ -753,7 +787,7 @@ Object {
 }
 `;
 
-exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 8`] = `
+exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 9`] = `
 Object {
   "description": "publicProjektiJatkoPaatos2VaiheJulkinenAfterApproval",
   "obj": Object {
@@ -765,7 +799,7 @@ Object {
         "jarjestys": 1,
         "kategoriaId": "T1xx",
         "nimi": "T113 TS Esite.txt",
-        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/T113 TS Esite.txt",
+        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/T113 TS Esite.txt",
         "tuotu": "***unittest***",
       },
     ],
@@ -779,7 +813,7 @@ Object {
         "jarjestys": 1,
         "kategoriaId": undefined,
         "nimi": "TYHJÄ.txt",
-        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/1/paatos/TYHJÄ.txt",
+        "tiedosto": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/paatos/TYHJÄ.txt",
         "tuotu": "***unittest***",
       },
     ],
@@ -838,7 +872,25 @@ Object {
 }
 `;
 
-exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 9`] = `
+exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 10`] = `
+Object {
+  "args": Object {
+    "DistributionId": "unit-test-distribution-id",
+    "InvalidationBatch": Object {
+      "CallerReference": "***unittest***",
+      "Paths": Object {
+        "Items": Array [
+          "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/jatkopaatos2/*",
+        ],
+        "Quantity": 1,
+      },
+    },
+  },
+  "stub": "createInvalidation",
+}
+`;
+
+exports[`Jatkopäätökset should go through jatkopäätös1, epäaktiivinen, jatkopäätös2, and epäaktiivinen states successfully 11`] = `
 Object {
   "velho.saveProjekti": Array [
     Array [

--- a/backend/integrationtest/api/__snapshots__/palaute.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/palaute.test.ts.snap
@@ -58,7 +58,11 @@ Array [
 exports[`Palaute should insert and manage feedback 4`] = `
 Object {
   "yllapito S3 files should insert and manage feedback": Object {
-    "/***unittest***/logo.png": Object {},
+    "/***unittest***/logo.png": FileMetadata {
+      "ContentDisposition": undefined,
+      "ContentType": "image/png",
+      "checksum": "ABC123",
+    },
   },
 }
 `;

--- a/backend/integrationtest/api/api.test.ts
+++ b/backend/integrationtest/api/api.test.ts
@@ -84,6 +84,7 @@ describe("Api", () => {
 
     try {
       await deleteProjekti(oid);
+      awsCloudfrontInvalidationStub.reset();
     } catch (ignored) {
       // ignored
     }

--- a/backend/integrationtest/api/api.test.ts
+++ b/backend/integrationtest/api/api.test.ts
@@ -7,7 +7,6 @@ import * as personSearchUpdaterHandler from "../../src/personSearch/lambda/perso
 import { openSearchClientYllapito } from "../../src/projektiSearch/openSearchClient";
 import { UserFixture } from "../../test/fixture/userFixture";
 import { userService } from "../../src/user";
-import { getCloudFront } from "../../src/aws/client";
 import { cleanProjektiS3Files } from "../util/s3Util";
 import {
   deleteProjekti,
@@ -27,10 +26,10 @@ import {
   testSuunnitteluvaihePerustiedot,
   testSuunnitteluvaiheVuorovaikutus,
   testUpdatePublishDateAndDeleteAineisto,
-  verifyCloudfrontWasInvalidated,
   verifyVuorovaikutusSnapshot,
 } from "./testUtil/tests";
 import {
+  CloudFrontStub,
   EmailClientStub,
   mockSaveProjektiToVelho,
   PDFGeneratorStub,
@@ -51,7 +50,6 @@ import {
   testHyvaksymisPaatosVaiheApproval,
 } from "./testUtil/hyvaksymisPaatosVaihe";
 import { FixtureName, recordProjektiTestFixture } from "./testFixtureRecorder";
-import { awsMockResolves } from "../../test/aws/awsMock";
 import { ImportAineistoMock } from "./testUtil/importAineistoMock";
 
 const { expect } = require("chai");
@@ -61,7 +59,7 @@ const oid = "1.2.246.578.5.1.2978288874.2711575506";
 describe("Api", () => {
   let readUsersFromSearchUpdaterLambda: sinon.SinonStub;
   let userFixture: UserFixture;
-  let awsCloudfrontInvalidationStub: sinon.SinonStub;
+  let awsCloudfrontInvalidationStub: CloudFrontStub;
   const emailClientStub = new EmailClientStub();
   const pdfGeneratorStub = new PDFGeneratorStub();
   const importAineistoMock = new ImportAineistoMock();
@@ -80,11 +78,9 @@ describe("Api", () => {
     sinon.stub(openSearchClientYllapito, "putDocument");
 
     importAineistoMock.initStub();
+    awsCloudfrontInvalidationStub = new CloudFrontStub();
     pdfGeneratorStub.init();
     emailClientStub.init();
-
-    awsCloudfrontInvalidationStub = sinon.stub(getCloudFront(), "createInvalidation");
-    awsMockResolves(awsCloudfrontInvalidationStub, {});
 
     try {
       await deleteProjekti(oid);
@@ -135,12 +131,12 @@ describe("Api", () => {
     await importAineistoMock.processQueue();
     emailClientStub.verifyEmailsSent();
     await takeS3Snapshot(oid, "just after vuorovaikutus published");
-    verifyCloudfrontWasInvalidated(awsCloudfrontInvalidationStub);
+    awsCloudfrontInvalidationStub.verifyCloudfrontWasInvalidated();
 
     await testUpdatePublishDateAndDeleteAineisto(oid, userFixture);
     await importAineistoMock.processQueue();
     await takeS3Snapshot(oid, "vuorovaikutus publish date changed and last aineisto deleted");
-    verifyCloudfrontWasInvalidated(awsCloudfrontInvalidationStub);
+    awsCloudfrontInvalidationStub.verifyCloudfrontWasInvalidated();
 
     await sendEmailDigests();
     emailClientStub.verifyEmailsSent();

--- a/backend/integrationtest/api/apiTestFixture.ts
+++ b/backend/integrationtest/api/apiTestFixture.ts
@@ -1,5 +1,6 @@
 import {
   AloitusKuulutus,
+
   AloitusKuulutusInput,
   IlmoitettavaViranomainen,
   IlmoituksenVastaanottajat,

--- a/backend/integrationtest/api/hyvaksymisPaatosHyvaksytty.test.ts
+++ b/backend/integrationtest/api/hyvaksymisPaatosHyvaksytty.test.ts
@@ -33,6 +33,7 @@ describe("Hyväksytyn hyväksymispäätöskuulutuksen jälkeen", () => {
     mockSaveProjektiToVelho();
     try {
       await deleteProjekti(oid);
+      awsCloudfrontInvalidationStub.reset();
     } catch (_ignore) {
       // ignore
     }

--- a/backend/integrationtest/api/hyvaksymisPaatosHyvaksytty.test.ts
+++ b/backend/integrationtest/api/hyvaksymisPaatosHyvaksytty.test.ts
@@ -12,7 +12,7 @@ import { Status } from "../../../common/graphql/apiModel";
 import { ISO_DATE_FORMAT } from "../../src/util/dateUtil";
 import { api } from "./apiClient";
 import { IllegalAccessError } from "../../src/error/IllegalAccessError";
-import { expectJulkinenNotFound, expectToMatchSnapshot, mockSaveProjektiToVelho } from "./testUtil/util";
+import { CloudFrontStub, expectJulkinenNotFound, expectToMatchSnapshot, mockSaveProjektiToVelho } from "./testUtil/util";
 import { assertIsDefined } from "../../src/util/assertions";
 import assert from "assert";
 
@@ -23,9 +23,11 @@ const oid = "1.2.246.578.5.1.2978288874.2711575506";
 
 describe("Hyväksytyn hyväksymispäätöskuulutuksen jälkeen", () => {
   let userFixture: UserFixture;
+  let awsCloudfrontInvalidationStub: CloudFrontStub;
 
   before(async () => {
     userFixture = new UserFixture(userService);
+    awsCloudfrontInvalidationStub = new CloudFrontStub();
 
     await setupLocalDatabase();
     mockSaveProjektiToVelho();
@@ -120,5 +122,7 @@ describe("Hyväksytyn hyväksymispäätöskuulutuksen jälkeen", () => {
         ensimmainenJatkopaatos: { paatoksenPvm: MOCKED_TIMESTAMP, asianumero: "jatkopaatos1_asianumero", aktiivinen: true },
       },
     });
+
+    awsCloudfrontInvalidationStub.verifyCloudfrontWasInvalidated();
   });
 });

--- a/backend/integrationtest/api/jatkopaatos.test.ts
+++ b/backend/integrationtest/api/jatkopaatos.test.ts
@@ -54,6 +54,7 @@ describe("Jatkopäätökset", () => {
     await setupLocalDatabase();
     mockSaveProjektiToVelho();
     await deleteProjekti(oid);
+    awsCloudfrontInvalidationStub.reset();
 
     await useProjektiTestFixture(FixtureName.JATKOPAATOS_1_ALKU);
   });

--- a/backend/integrationtest/api/jatkopaatos.test.ts
+++ b/backend/integrationtest/api/jatkopaatos.test.ts
@@ -17,7 +17,13 @@ import {
 import { api } from "./apiClient";
 import { testCreateHyvaksymisPaatosWithAineistot } from "./testUtil/hyvaksymisPaatosVaihe";
 import { ImportAineistoMock } from "./testUtil/importAineistoMock";
-import { expectJulkinenNotFound, expectToMatchSnapshot, mockSaveProjektiToVelho, takeYllapitoS3Snapshot } from "./testUtil/util";
+import {
+  CloudFrontStub,
+  expectJulkinenNotFound,
+  expectToMatchSnapshot,
+  mockSaveProjektiToVelho,
+  takeYllapitoS3Snapshot,
+} from "./testUtil/util";
 import { expect } from "chai";
 import {
   cleanupHyvaksymisPaatosVaiheJulkaisuJulkinenTimestamps,
@@ -32,11 +38,13 @@ const oid = "1.2.246.578.5.1.2978288874.2711575506";
 describe("Jatkopäätökset", () => {
   let userFixture: UserFixture;
 
+  let awsCloudfrontInvalidationStub: CloudFrontStub;
   const importAineistoMock = new ImportAineistoMock();
 
   before(async () => {
     userFixture = new UserFixture(userService);
     importAineistoMock.initStub();
+    awsCloudfrontInvalidationStub = new CloudFrontStub();
 
     const pdfGeneratorLambdaStub = sinon.stub(pdfGeneratorClient, "generatePDF");
     pdfGeneratorLambdaStub.callsFake(async (event) => {
@@ -46,6 +54,7 @@ describe("Jatkopäätökset", () => {
     await setupLocalDatabase();
     mockSaveProjektiToVelho();
     await deleteProjekti(oid);
+
     await useProjektiTestFixture(FixtureName.JATKOPAATOS_1_ALKU);
   });
 
@@ -89,6 +98,8 @@ describe("Jatkopäätökset", () => {
 
     await addJatkopaatos1WithAineistot();
     await testJatkoPaatos1VaiheApproval(oid, projektiPaallikko, userFixture);
+    await importAineistoMock.processQueue();
+    awsCloudfrontInvalidationStub.verifyCloudfrontWasInvalidated(1);
     await testEpaAktiivinenAfterJatkoPaatos1(oid, projektiPaallikko, userFixture);
 
     userFixture.loginAsAdmin();
@@ -96,6 +107,8 @@ describe("Jatkopäätökset", () => {
     userFixture.loginAsProjektiKayttaja(projektiPaallikko);
     await addJatkopaatos2WithAineistot();
     await testJatkoPaatos2VaiheApproval(oid, projektiPaallikko, userFixture);
+    await importAineistoMock.processQueue();
+    awsCloudfrontInvalidationStub.verifyCloudfrontWasInvalidated(1);
     await testEpaAktiivinenAfterJatkoPaatos2(oid, projektiPaallikko, userFixture);
   });
 });
@@ -107,7 +120,7 @@ export async function testJatkoPaatos1VaiheApproval(
 ): Promise<void> {
   userFixture.loginAsProjektiKayttaja(projektiPaallikko);
   let expectedStatus = Status.JATKOPAATOS_1;
-  let tilasiirtymaTyyppi = TilasiirtymaTyyppi.JATKOPAATOS_1;
+  const tilasiirtymaTyyppi = TilasiirtymaTyyppi.JATKOPAATOS_1;
 
   await api.siirraTila({
     oid,

--- a/backend/integrationtest/api/records/ALOITUSKUULUTUS.json
+++ b/backend/integrationtest/api/records/ALOITUSKUULUTUS.json
@@ -5,6 +5,7 @@
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum"
     },
+    "id": 1,
     "ilmoituksenVastaanottajat": {
       "kunnat": [
         {
@@ -50,8 +51,8 @@
     {
       "aloituskuulutusPDFt": {
         "SUOMI": {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus.pdf"
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus.pdf"
         }
       },
       "hankkeenKuvaus": {

--- a/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
+++ b/backend/integrationtest/api/records/HYVAKSYMISPAATOS_APPROVED.json
@@ -6,6 +6,7 @@
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum"
     },
+    "id": 1,
     "ilmoituksenVastaanottajat": {
       "kunnat": [
         {
@@ -51,8 +52,8 @@
     {
       "aloituskuulutusPDFt": {
         "SUOMI": {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus.pdf"
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus.pdf"
         }
       },
       "hankkeenKuvaus": {
@@ -242,11 +243,11 @@
       ],
       "hyvaksymisPaatosVaihePDFt": {
         "SUOMI": {
-          "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-          "hyvaksymisIlmoitusMuistuttajillePDFPath": "/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-          "hyvaksymisKuulutusPDFPath": "/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-          "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
-          "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf"
+          "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/hyvaksymispaatos/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+          "hyvaksymisIlmoitusMuistuttajillePDFPath": "/hyvaksymispaatos/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+          "hyvaksymisKuulutusPDFPath": "/hyvaksymispaatos/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/hyvaksymispaatos/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/hyvaksymispaatos/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf"
         }
       },
       "id": 1,
@@ -590,9 +591,9 @@
       "muokkaaja": "A000112",
       "nahtavillaoloPDFt": {
         "SUOMI": {
-          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/nahtavillaolo/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
-          "nahtavillaoloIlmoitusPDFPath": "/nahtavillaolo/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
-          "nahtavillaoloPDFPath": "/nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf"
+          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/nahtavillaolo/1/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
+          "nahtavillaoloIlmoitusPDFPath": "/nahtavillaolo/1/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
+          "nahtavillaoloPDFPath": "/nahtavillaolo/1/T414 Kuulutus suunnitelman nahtavillaolo.pdf"
         }
       },
       "tila": "HYVAKSYTTY",

--- a/backend/integrationtest/api/records/JATKOPAATOS_1_ALKU.json
+++ b/backend/integrationtest/api/records/JATKOPAATOS_1_ALKU.json
@@ -6,6 +6,7 @@
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum"
     },
+    "id": 1,
     "ilmoituksenVastaanottajat": {
       "kunnat": [
         {
@@ -51,8 +52,8 @@
     {
       "aloituskuulutusPDFt": {
         "SUOMI": {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus.pdf"
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus.pdf"
         }
       },
       "hankkeenKuvaus": {
@@ -242,11 +243,11 @@
       ],
       "hyvaksymisPaatosVaihePDFt": {
         "SUOMI": {
-          "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-          "hyvaksymisIlmoitusMuistuttajillePDFPath": "/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-          "hyvaksymisKuulutusPDFPath": "/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-          "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
-          "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf"
+          "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/hyvaksymispaatos/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+          "hyvaksymisIlmoitusMuistuttajillePDFPath": "/hyvaksymispaatos/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+          "hyvaksymisKuulutusPDFPath": "/hyvaksymispaatos/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/hyvaksymispaatos/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/hyvaksymispaatos/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf"
         }
       },
       "id": 1,
@@ -575,9 +576,9 @@
       "muokkaaja": "A000112",
       "nahtavillaoloPDFt": {
         "SUOMI": {
-          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/nahtavillaolo/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
-          "nahtavillaoloIlmoitusPDFPath": "/nahtavillaolo/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
-          "nahtavillaoloPDFPath": "/nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf"
+          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/nahtavillaolo/1/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
+          "nahtavillaoloIlmoitusPDFPath": "/nahtavillaolo/1/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
+          "nahtavillaoloPDFPath": "/nahtavillaolo/1/T414 Kuulutus suunnitelman nahtavillaolo.pdf"
         }
       },
       "tila": "HYVAKSYTTY",

--- a/backend/integrationtest/api/records/NAHTAVILLAOLO.json
+++ b/backend/integrationtest/api/records/NAHTAVILLAOLO.json
@@ -5,6 +5,7 @@
       "SAAME": "Saameksi",
       "SUOMI": "Lorem Ipsum"
     },
+    "id": 1,
     "ilmoituksenVastaanottajat": {
       "kunnat": [
         {
@@ -50,8 +51,8 @@
     {
       "aloituskuulutusPDFt": {
         "SUOMI": {
-          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/aloituskuulutus/T412 Aloituskuulutus.pdf"
+          "aloituskuulutusIlmoitusPDFPath": "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+          "aloituskuulutusPDFPath": "/aloituskuulutus/1/T412 Aloituskuulutus.pdf"
         }
       },
       "hankkeenKuvaus": {

--- a/backend/integrationtest/api/testFixtureRecorder.ts
+++ b/backend/integrationtest/api/testFixtureRecorder.ts
@@ -19,7 +19,7 @@ export const MOCKED_DATE = "2022-11-03";
 export async function recordProjektiTestFixture(fixtureName: string | FixtureName, oid: string): Promise<void> {
   const dbProjekti = await projektiDatabase.loadProjektiByOid(oid);
   if (dbProjekti) {
-    cleanupProjekti(dbProjekti);
+    cleanupAnyProjektiData(dbProjekti);
 
     let oldValue: string | undefined;
     try {
@@ -60,13 +60,15 @@ export async function useProjektiTestFixture(fixtureName: string | FixtureName):
 }
 
 export function cleanupAndCloneAPIProjekti(projekti: apiModel.Projekti): apiModel.Projekti {
-  return cleanupProjekti(cloneDeep(projekti));
+  return cleanupAnyProjektiData(cloneDeep(projekti));
 }
 
-function cleanupProjekti<T extends Record<string, any>>(projekti: T): T {
+export function cleanupAnyProjektiData<T extends Record<string, any>>(projekti: T): T {
   replaceFieldsByName(projekti, MOCKED_TIMESTAMP, "tuotu", "paivitetty", "kuulutusVaihePaattyyPaiva", "lahetetty");
   replaceFieldsByName(projekti, MOCKED_DATE, "hyvaksymisPaiva");
   replaceFieldsByName(projekti, "salt123", "salt");
+  replaceFieldsByName(projekti, "ABC123", "checksum");
+  replaceFieldsByName(projekti, undefined, "isSame");
   return projekti;
 }
 
@@ -75,7 +77,11 @@ export function replaceFieldsByName(obj: Record<string, any>, value: unknown, ..
     if (typeof obj[prop] == "object" && obj[prop] !== null) {
       replaceFieldsByName(obj[prop], value, ...fieldNames);
     } else if (fieldNames.indexOf(prop) >= 0) {
-      obj[prop] = value;
+      if (value == undefined) {
+        delete obj[prop];
+      } else {
+        obj[prop] = value;
+      }
     }
   });
 }

--- a/backend/integrationtest/api/testUtil/cleanUpFunctions.ts
+++ b/backend/integrationtest/api/testUtil/cleanUpFunctions.ts
@@ -9,6 +9,7 @@ import {
   Palaute,
   Vuorovaikutus,
 } from "../../../../common/graphql/apiModel";
+import { NahtavillaoloVaiheJulkaisu as DBNahtavillaoloVaiheJulkaisu } from "../../../src/database/model";
 import { cleanupAnyProjektiData } from "../testFixtureRecorder";
 
 export function cleanupGeneratedIdAndTimestampFromFeedbacks(feedbacks?: Palaute[]): Palaute[] | undefined {
@@ -37,15 +38,23 @@ function aineistoCleanupFunc(aineisto: Aineisto) {
 }
 
 export function cleanupNahtavillaoloTimestamps(
-  nahtavillaoloVaihe: NahtavillaoloVaiheJulkaisu | NahtavillaoloVaihe
-): NahtavillaoloVaiheJulkaisu | NahtavillaoloVaihe {
-  nahtavillaoloVaihe.aineistoNahtavilla?.forEach(aineistoCleanupFunc);
-  nahtavillaoloVaihe.lisaAineisto?.forEach(aineistoCleanupFunc);
+  nahtavillaoloVaihe: NahtavillaoloVaiheJulkaisu | NahtavillaoloVaihe | DBNahtavillaoloVaiheJulkaisu
+): NahtavillaoloVaiheJulkaisu | NahtavillaoloVaihe | DBNahtavillaoloVaiheJulkaisu {
+  if (Object.keys(nahtavillaoloVaihe).includes("__typename")) {
+    (nahtavillaoloVaihe as NahtavillaoloVaihe).aineistoNahtavilla?.forEach(aineistoCleanupFunc);
+    (nahtavillaoloVaihe as NahtavillaoloVaihe).lisaAineisto?.forEach(aineistoCleanupFunc);
+  }
+
   const lisaAineistoParametrit = (nahtavillaoloVaihe as NahtavillaoloVaihe).lisaAineistoParametrit;
   if (lisaAineistoParametrit) {
     lisaAineistoParametrit.hash = "***unittest***";
     lisaAineistoParametrit.poistumisPaiva = "***unittest***";
     (nahtavillaoloVaihe as NahtavillaoloVaihe)["lisaAineistoParametrit"] = lisaAineistoParametrit;
+  }
+  nahtavillaoloVaihe.kuulutusPaiva = "***unittest***";
+  nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva = "***unittest***";
+  if ((nahtavillaoloVaihe as DBNahtavillaoloVaiheJulkaisu).hyvaksymisPaiva) {
+    (nahtavillaoloVaihe as DBNahtavillaoloVaiheJulkaisu).hyvaksymisPaiva = "***unittest***";
   }
   return nahtavillaoloVaihe;
 }

--- a/backend/integrationtest/api/testUtil/cleanUpFunctions.ts
+++ b/backend/integrationtest/api/testUtil/cleanUpFunctions.ts
@@ -51,8 +51,6 @@ export function cleanupNahtavillaoloTimestamps(
     lisaAineistoParametrit.poistumisPaiva = "***unittest***";
     (nahtavillaoloVaihe as NahtavillaoloVaihe)["lisaAineistoParametrit"] = lisaAineistoParametrit;
   }
-  nahtavillaoloVaihe.kuulutusPaiva = "***unittest***";
-  nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva = "***unittest***";
   if ((nahtavillaoloVaihe as DBNahtavillaoloVaiheJulkaisu).hyvaksymisPaiva) {
     (nahtavillaoloVaihe as DBNahtavillaoloVaiheJulkaisu).hyvaksymisPaiva = "***unittest***";
   }

--- a/backend/integrationtest/api/testUtil/cleanUpFunctions.ts
+++ b/backend/integrationtest/api/testUtil/cleanUpFunctions.ts
@@ -9,10 +9,12 @@ import {
   Palaute,
   Vuorovaikutus,
 } from "../../../../common/graphql/apiModel";
+import { cleanupAnyProjektiData } from "../testFixtureRecorder";
 
 export function cleanupGeneratedIdAndTimestampFromFeedbacks(feedbacks?: Palaute[]): Palaute[] | undefined {
   return feedbacks
     ? feedbacks.map((palaute) => {
+        cleanupAnyProjektiData(palaute);
         palaute.liite = palaute?.liite?.replace(palaute.id, "***unittest***");
         palaute.id = "***unittest***";
         palaute.vastaanotettu = "***unittest***";
@@ -74,10 +76,10 @@ export function cleanupHyvaksymisPaatosVaiheJulkaisuJulkinenTimestamps(
   return hyvaksymisPaatosVaihe;
 }
 
-export function cleanupGeneratedIds(obj: Record<string, any>): unknown {
-  return Object.keys(obj).reduce((cleanObj, key: string) => {
+export function cleanupGeneratedIds<T extends Record<string, any>>(obj: T): Record<string, any> {
+  return Object.keys(obj).reduce((cleanObj: Record<string, any>, key: string) => {
     const cleanedUpKey: string = key.replace(/[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}/g, "***unittest***");
-    cleanObj[cleanedUpKey] = obj[key];
+    cleanObj[cleanedUpKey] = obj[key] as Record<string, any>;
     return cleanObj;
   }, {} as Record<string, any>);
 }

--- a/backend/integrationtest/api/testUtil/tests.ts
+++ b/backend/integrationtest/api/testUtil/tests.ts
@@ -23,7 +23,6 @@ import { UserFixture } from "../../../test/fixture/userFixture";
 import { detailedDiff } from "deep-object-diff";
 import { parseDate } from "../../../src/util/dateUtil";
 import { cleanupVuorovaikutusTimestamps } from "./cleanUpFunctions";
-import Sinon from "sinon";
 import * as log from "loglevel";
 import { fail } from "assert";
 import { palauteEmailService } from "../../../src/palaute/palauteEmailService";
@@ -31,15 +30,9 @@ import { expectApiError, expectToMatchSnapshot } from "./util";
 import cloneDeep from "lodash/cloneDeep";
 import { fileService } from "../../../src/files/fileService";
 import { testProjektiDatabase } from "../../../src/database/testProjektiDatabase";
-import { expectAwsCalls } from "../../../test/aws/awsMock";
 import { projektiDatabase } from "../../../src/database/projektiDatabase";
 
 const { expect } = require("chai");
-
-export function verifyCloudfrontWasInvalidated(awsCloudfrontInvalidationStub: Sinon.SinonStub): void {
-  expectAwsCalls(awsCloudfrontInvalidationStub, "CallerReference");
-  awsCloudfrontInvalidationStub.resetHistory();
-}
 
 export async function loadProjektiFromDatabase(oid: string, expectedStatus?: Status): Promise<Projekti> {
   const savedProjekti = await api.lataaProjekti(oid);

--- a/backend/integrationtest/api/testUtil/util.ts
+++ b/backend/integrationtest/api/testUtil/util.ts
@@ -140,6 +140,10 @@ export class CloudFrontStub {
     if (expectedNumberOfCalls) {
       expect(this.stub.getCalls()).to.have.length(expectedNumberOfCalls);
     }
+    this.reset();
+  }
+
+  reset(): void {
     this.stub.resetHistory();
   }
 }

--- a/backend/integrationtest/api/testUtil/util.ts
+++ b/backend/integrationtest/api/testUtil/util.ts
@@ -13,6 +13,9 @@ import { GeneratePDFEvent } from "../../../src/asiakirja/lambda/generatePDFEvent
 import { velho } from "../../../src/velho/velhoClient";
 import mocha from "mocha";
 import { NotFoundError } from "../../../src/error/NotFoundError";
+import { cleanupAnyProjektiData } from "../testFixtureRecorder";
+import { getCloudFront } from "../../../src/aws/client";
+import { awsMockResolves, expectAwsCalls } from "../../../test/aws/awsMock";
 
 const { expect } = require("chai");
 
@@ -22,14 +25,17 @@ export async function takeS3Snapshot(oid: string, description: string, path?: st
 }
 
 export async function takeYllapitoS3Snapshot(oid: string, description: string, path?: string): Promise<void> {
+  const obj = await fileService.listYllapitoProjektiFiles(oid, path || "");
   expect({
-    ["yllapito S3 files " + description]: cleanupGeneratedIds(await fileService.listYllapitoProjektiFiles(oid, path || "")),
+    ["yllapito S3 files " + description]: cleanupAnyProjektiData(cleanupGeneratedIds(obj)),
   }).toMatchSnapshot(description);
 }
 
 export async function takePublicS3Snapshot(oid: string, description: string, path?: string): Promise<void> {
   expect({
-    ["public S3 files " + description]: cleanupGeneratedIds(await fileService.listPublicProjektiFiles(oid, path || "", true)),
+    ["public S3 files " + description]: cleanupAnyProjektiData(
+      cleanupGeneratedIds(await fileService.listPublicProjektiFiles(oid, path || "", true))
+    ),
   }).toMatchSnapshot(description);
 }
 
@@ -118,6 +124,23 @@ export class EmailClientStub {
       ).toMatchSnapshot();
       this.emailClientStub.reset();
     }
+  }
+}
+
+export class CloudFrontStub {
+  private stub: sinon.SinonStub;
+
+  constructor() {
+    this.stub = sinon.stub(getCloudFront(), "createInvalidation");
+    awsMockResolves(this.stub, {});
+  }
+
+  verifyCloudfrontWasInvalidated(expectedNumberOfCalls?: number): void {
+    expectAwsCalls(this.stub, "CallerReference");
+    if (expectedNumberOfCalls) {
+      expect(this.stub.getCalls()).to.have.length(expectedNumberOfCalls);
+    }
+    this.stub.resetHistory();
   }
 }
 

--- a/backend/integrationtest/email/email.test.ts
+++ b/backend/integrationtest/email/email.test.ts
@@ -16,6 +16,7 @@ describe.skip("Email", () => {
       },
       oid: "123",
       aloitusKuulutus: {
+        id: 1,
         kuulutusPaiva: "2022-01-01",
         hankkeenKuvaus: {
           SUOMI:

--- a/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
+++ b/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
@@ -590,8 +590,8 @@ Object {
         },
       ],
     },
-    "kuulutusPaiva": "2022-06-07",
-    "kuulutusVaihePaattyyPaiva": "2042-06-07",
+    "kuulutusPaiva": "***unittest***",
+    "kuulutusVaihePaattyyPaiva": "***unittest***",
     "kuulutusYhteystiedot": Object {
       "__typename": "StandardiYhteystiedot",
       "yhteysHenkilot": Array [
@@ -672,8 +672,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "2022-06-07",
-      "kuulutusVaihePaattyyPaiva": "2042-06-07",
+      "kuulutusPaiva": "***unittest***",
+      "kuulutusVaihePaattyyPaiva": "***unittest***",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -755,8 +755,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "2022-06-07",
-      "kuulutusVaihePaattyyPaiva": "2042-06-07",
+      "kuulutusPaiva": "***unittest***",
+      "kuulutusVaihePaattyyPaiva": "***unittest***",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -799,7 +799,7 @@ Object {
         "__typename": "LokalisoituTeksti",
       },
       "hyvaksyja": "A000112",
-      "hyvaksymisPaiva": "2022-11-25",
+      "hyvaksymisPaiva": "***unittest***",
       "id": 1,
       "ilmoituksenVastaanottajat": Object {
         "__typename": "IlmoituksenVastaanottajat",
@@ -836,8 +836,8 @@ Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",
       },
-      "kuulutusPaiva": "2022-06-07",
-      "kuulutusVaihePaattyyPaiva": "2042-06-07",
+      "kuulutusPaiva": "***unittest***",
+      "kuulutusVaihePaattyyPaiva": "***unittest***",
       "lisaAineisto": undefined,
       "muistutusoikeusPaattyyPaiva": "2042-06-08",
       "muokkaaja": "A000112",

--- a/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
+++ b/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
@@ -590,8 +590,8 @@ Object {
         },
       ],
     },
-    "kuulutusPaiva": "***unittest***",
-    "kuulutusVaihePaattyyPaiva": "***unittest***",
+    "kuulutusPaiva": "2022-06-07",
+    "kuulutusVaihePaattyyPaiva": "2042-06-07",
     "kuulutusYhteystiedot": Object {
       "__typename": "StandardiYhteystiedot",
       "yhteysHenkilot": Array [
@@ -672,8 +672,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "***unittest***",
-      "kuulutusVaihePaattyyPaiva": "***unittest***",
+      "kuulutusPaiva": "2022-06-07",
+      "kuulutusVaihePaattyyPaiva": "2042-06-07",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -755,8 +755,8 @@ Object {
           },
         ],
       },
-      "kuulutusPaiva": "***unittest***",
-      "kuulutusVaihePaattyyPaiva": "***unittest***",
+      "kuulutusPaiva": "2022-06-07",
+      "kuulutusVaihePaattyyPaiva": "2042-06-07",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
         "yhteysHenkilot": Array [
@@ -836,8 +836,8 @@ Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",
       },
-      "kuulutusPaiva": "***unittest***",
-      "kuulutusVaihePaattyyPaiva": "***unittest***",
+      "kuulutusPaiva": "2022-06-07",
+      "kuulutusVaihePaattyyPaiva": "2042-06-07",
       "lisaAineisto": undefined,
       "muistutusoikeusPaattyyPaiva": "2042-06-08",
       "muokkaaja": "A000112",

--- a/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
+++ b/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
@@ -208,11 +208,11 @@ Object {
         "hyvaksymisPaatosVaihePDFt": Object {
           "SUOMI": Object {
             "__typename": "HyvaksymisPaatosVaihePDF",
-            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
-            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+            "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+            "hyvaksymisIlmoitusMuistuttajillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+            "hyvaksymisKuulutusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+            "ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
           },
           "__typename": "HyvaksymisPaatosVaihePDFt",
         },
@@ -844,9 +844,9 @@ Object {
       "nahtavillaoloPDFt": Object {
         "SUOMI": Object {
           "__typename": "NahtavillaoloPDF",
-          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
-          "nahtavillaoloIlmoitusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
-          "nahtavillaoloPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf",
+          "nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/1/31T Ilmoitus kiinteistonomistajat nahtaville asettaminen.pdf",
+          "nahtavillaoloIlmoitusPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/1/T414_1 Ilmoitus suunnitelman nahtavillaolo.pdf",
+          "nahtavillaoloPDFPath": "/yllapito/tiedostot/projekti/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/1/T414 Kuulutus suunnitelman nahtavillaolo.pdf",
         },
         "__typename": "NahtavillaoloPDFt",
       },

--- a/backend/src/aineisto/aineistoImporterLambda.ts
+++ b/backend/src/aineisto/aineistoImporterLambda.ts
@@ -6,7 +6,7 @@ import dayjs from "dayjs";
 import { getAxios, setupLambdaMonitoring, wrapXRayAsync } from "../aws/monitoring";
 import { ImportAineistoEvent, ImportAineistoEventType } from "./importAineistoEvent";
 import { projektiDatabase } from "../database/projektiDatabase";
-import { AineistoTila, AloitusKuulutusTila, HyvaksymisPaatosVaiheTila, NahtavillaoloVaiheTila } from "../../../common/graphql/apiModel";
+import { AineistoTila, KuulutusJulkaisuTila } from "../../../common/graphql/apiModel";
 import { aineistoService, synchronizeFilesToPublic } from "./aineistoService";
 import {
   Aineisto,
@@ -118,31 +118,31 @@ async function handleVuorovaikutukset(oid: string, vuorovaikutukset: Vuorovaikut
 }
 
 async function handleAloituskuulutusVaihe(oid: string, julkaisut: AloitusKuulutusJulkaisu[]) {
-  const julkaisu = findJulkaisuWithTila(julkaisut, AloitusKuulutusTila.HYVAKSYTTY);
+  const julkaisu = findJulkaisuWithTila(julkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
   const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
   await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).aloituskuulutus(julkaisu), kuulutusPaiva);
 }
 
 async function handleNahtavillaoloVaihe(oid: string, nahtavillaoloVaiheJulkaisut: NahtavillaoloVaiheJulkaisu[]) {
-  const julkaisu = findJulkaisuWithTila(nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
+  const julkaisu = findJulkaisuWithTila(nahtavillaoloVaiheJulkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
   const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
   await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).nahtavillaoloVaihe(julkaisu), kuulutusPaiva);
 }
 
 async function handleHyvaksymisPaatosVaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[]) {
-  const julkaisu = findJulkaisuWithTila(julkaisut, HyvaksymisPaatosVaiheTila.HYVAKSYTTY);
+  const julkaisu = findJulkaisuWithTila(julkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
   const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
   await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).hyvaksymisPaatosVaihe(julkaisu), kuulutusPaiva);
 }
 
 async function handleJatkoPaatos1Vaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[]) {
-  const julkaisu = findJulkaisuWithTila(julkaisut, HyvaksymisPaatosVaiheTila.HYVAKSYTTY);
+  const julkaisu = findJulkaisuWithTila(julkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
   const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
   await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).jatkoPaatos1Vaihe(julkaisu), kuulutusPaiva);
 }
 
 async function handleJatkoPaatos2Vaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[]) {
-  const julkaisu = findJulkaisuWithTila(julkaisut, HyvaksymisPaatosVaiheTila.HYVAKSYTTY);
+  const julkaisu = findJulkaisuWithTila(julkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
   const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
   await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).jatkoPaatos2Vaihe(julkaisu), kuulutusPaiva);
 }

--- a/backend/src/aineisto/aineistoImporterLambda.ts
+++ b/backend/src/aineisto/aineistoImporterLambda.ts
@@ -6,10 +6,11 @@ import dayjs from "dayjs";
 import { getAxios, setupLambdaMonitoring, wrapXRayAsync } from "../aws/monitoring";
 import { ImportAineistoEvent, ImportAineistoEventType } from "./importAineistoEvent";
 import { projektiDatabase } from "../database/projektiDatabase";
-import { AineistoTila } from "../../../common/graphql/apiModel";
-import { aineistoService } from "./aineistoService";
+import { AineistoTila, AloitusKuulutusTila, HyvaksymisPaatosVaiheTila, NahtavillaoloVaiheTila } from "../../../common/graphql/apiModel";
+import { aineistoService, synchronizeFilesToPublic } from "./aineistoService";
 import {
   Aineisto,
+  AloitusKuulutusJulkaisu,
   DBProjekti,
   HyvaksymisPaatosVaihe,
   HyvaksymisPaatosVaiheJulkaisu,
@@ -19,7 +20,9 @@ import {
 } from "../database/model";
 import { PathTuple, ProjektiPaths } from "../files/ProjektiPath";
 import * as mime from "mime-types";
-import { findJulkaisuWithId } from "../projekti/projektiUtil";
+import { findJulkaisuWithTila } from "../projekti/projektiUtil";
+import { parseDate } from "../util/dateUtil";
+import { projektiAdapter } from "../projekti/adapter/projektiAdapter";
 
 async function handleVuorovaikutusAineisto(oid: string, vuorovaikutus: Vuorovaikutus): Promise<boolean> {
   const filePathInProjekti = new ProjektiPaths(oid).vuorovaikutus(vuorovaikutus).aineisto;
@@ -71,7 +74,7 @@ async function handleAineistot(oid: string, aineistot: Aineisto[] | null | undef
       await aineistoService.deleteAineisto(oid, aineisto, paths.yllapitoPath, paths.publicPath);
       hasChanges = true;
     } else if (aineisto.tila == AineistoTila.ODOTTAA_TUONTIA) {
-      await importAineisto(aineisto, oid, paths.yllapitoPath);
+      await importAineisto(aineisto, oid, paths);
       aineistot.push(aineisto);
       hasChanges = true;
     } else {
@@ -82,7 +85,7 @@ async function handleAineistot(oid: string, aineistot: Aineisto[] | null | undef
   return hasChanges;
 }
 
-async function importAineisto(aineisto: Aineisto, oid: string, filePathInProjekti: string) {
+async function importAineisto(aineisto: Aineisto, oid: string, path: PathTuple) {
   const sourceURL = await velho.getLinkForDocument(aineisto.dokumenttiOid);
   const axiosResponse = await getAxios().get(sourceURL);
   const disposition: string = axiosResponse.headers["content-disposition"];
@@ -93,7 +96,7 @@ async function importAineisto(aineisto: Aineisto, oid: string, filePathInProjekt
   const contentType = mime.lookup(fileName);
   aineisto.tiedosto = await fileService.createFileToProjekti({
     oid,
-    filePathInProjekti,
+    path,
     fileName,
     contentType: contentType || undefined,
     inline: true,
@@ -111,55 +114,37 @@ async function handleVuorovaikutukset(oid: string, vuorovaikutukset: Vuorovaikut
         vuorovaikutukset: [vuorovaikutus],
       });
     }
-
-    if (vuorovaikutus.julkinen) {
-      await aineistoService.synchronizeVuorovaikutusAineistoToPublic(oid, vuorovaikutus);
-    }
   }
 }
 
-async function handleNahtavillaoloVaihe(
-  oid: string,
-  nahtavillaoloVaiheJulkaisut: NahtavillaoloVaiheJulkaisu[],
-  publishNahtavillaoloWithId: number
-) {
-  const nahtavillaoloVaiheJulkaisu = findJulkaisuWithId(nahtavillaoloVaiheJulkaisut, publishNahtavillaoloWithId);
-  if (nahtavillaoloVaiheJulkaisu) {
-    await aineistoService.synchronizeNahtavillaoloVaiheJulkaisuAineistoToPublic(oid, nahtavillaoloVaiheJulkaisu);
-  }
+async function handleAloituskuulutusVaihe(oid: string, julkaisut: AloitusKuulutusJulkaisu[]) {
+  const julkaisu = findJulkaisuWithTila(julkaisut, AloitusKuulutusTila.HYVAKSYTTY);
+  const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
+  await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).aloituskuulutus(julkaisu), kuulutusPaiva);
 }
 
-async function handleHyvaksymisPaatosVaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[], publishJulkaisuWithId: number) {
-  const julkaisu = findJulkaisuWithId(julkaisut, publishJulkaisuWithId);
-  if (julkaisu) {
-    await aineistoService.synchronizeHyvaksymisPaatosVaiheJulkaisuAineistoToPublic(
-      oid,
-      julkaisu,
-      new ProjektiPaths(oid).hyvaksymisPaatosVaihe(julkaisu)
-    );
-  }
+async function handleNahtavillaoloVaihe(oid: string, nahtavillaoloVaiheJulkaisut: NahtavillaoloVaiheJulkaisu[]) {
+  const julkaisu = findJulkaisuWithTila(nahtavillaoloVaiheJulkaisut, NahtavillaoloVaiheTila.HYVAKSYTTY);
+  const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
+  await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).nahtavillaoloVaihe(julkaisu), kuulutusPaiva);
 }
 
-async function handleJatkoPaatos1Vaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[], publishJulkaisuWithId: number) {
-  const julkaisu = findJulkaisuWithId(julkaisut, publishJulkaisuWithId);
-  if (julkaisu) {
-    await aineistoService.synchronizeHyvaksymisPaatosVaiheJulkaisuAineistoToPublic(
-      oid,
-      julkaisu,
-      new ProjektiPaths(oid).jatkoPaatos1Vaihe(julkaisu)
-    );
-  }
+async function handleHyvaksymisPaatosVaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[]) {
+  const julkaisu = findJulkaisuWithTila(julkaisut, HyvaksymisPaatosVaiheTila.HYVAKSYTTY);
+  const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
+  await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).hyvaksymisPaatosVaihe(julkaisu), kuulutusPaiva);
 }
 
-async function handleJatkoPaatos2Vaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[], publishJulkaisuWithId: number) {
-  const julkaisu = findJulkaisuWithId(julkaisut, publishJulkaisuWithId);
-  if (julkaisu) {
-    await aineistoService.synchronizeHyvaksymisPaatosVaiheJulkaisuAineistoToPublic(
-      oid,
-      julkaisu,
-      new ProjektiPaths(oid).jatkoPaatos2Vaihe(julkaisu)
-    );
-  }
+async function handleJatkoPaatos1Vaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[]) {
+  const julkaisu = findJulkaisuWithTila(julkaisut, HyvaksymisPaatosVaiheTila.HYVAKSYTTY);
+  const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
+  await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).jatkoPaatos1Vaihe(julkaisu), kuulutusPaiva);
+}
+
+async function handleJatkoPaatos2Vaihe(oid: string, julkaisut: HyvaksymisPaatosVaiheJulkaisu[]) {
+  const julkaisu = findJulkaisuWithTila(julkaisut, HyvaksymisPaatosVaiheTila.HYVAKSYTTY);
+  const kuulutusPaiva = julkaisu?.kuulutusPaiva ? parseDate(julkaisu.kuulutusPaiva) : undefined;
+  await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).jatkoPaatos2Vaihe(julkaisu), kuulutusPaiva);
 }
 
 async function handleImport(projekti: DBProjekti) {
@@ -182,32 +167,40 @@ async function handleImport(projekti: DBProjekti) {
   });
 }
 
-async function handlePublish(aineistoEvent: ImportAineistoEvent, projekti: DBProjekti) {
+async function synchronizeAll(aineistoEvent: ImportAineistoEvent, projekti: DBProjekti) {
   const oid = projekti.oid;
-  if (
-    aineistoEvent.type == ImportAineistoEventType.PUBLISH_NAHTAVILLAOLO &&
-    aineistoEvent.publishNahtavillaoloWithId &&
-    projekti.nahtavillaoloVaiheJulkaisut
-  ) {
-    await handleNahtavillaoloVaihe(oid, projekti.nahtavillaoloVaiheJulkaisut, aineistoEvent.publishNahtavillaoloWithId);
-  } else if (
-    aineistoEvent.type == ImportAineistoEventType.PUBLISH_HYVAKSYMISPAATOS &&
-    aineistoEvent.publishHyvaksymisPaatosWithId &&
-    projekti.hyvaksymisPaatosVaiheJulkaisut
-  ) {
-    await handleHyvaksymisPaatosVaihe(oid, projekti.hyvaksymisPaatosVaiheJulkaisut, aineistoEvent.publishHyvaksymisPaatosWithId);
-  } else if (
-    aineistoEvent.type == ImportAineistoEventType.PUBLISH_JATKOPAATOS1 &&
-    aineistoEvent.publishJatkoPaatos1WithId &&
-    projekti.jatkoPaatos1VaiheJulkaisut
-  ) {
-    await handleJatkoPaatos1Vaihe(oid, projekti.jatkoPaatos1VaiheJulkaisut, aineistoEvent.publishJatkoPaatos1WithId);
-  } else if (
-    aineistoEvent.type == ImportAineistoEventType.PUBLISH_JATKOPAATOS2 &&
-    aineistoEvent.publishJatkoPaatos2WithId &&
-    projekti.jatkoPaatos2VaiheJulkaisut
-  ) {
-    await handleJatkoPaatos2Vaihe(oid, projekti.jatkoPaatos2VaiheJulkaisut, aineistoEvent.publishJatkoPaatos2WithId);
+  const projektiStatus = projektiAdapter.adaptProjekti(projekti).status;
+  if (!projektiStatus) {
+    throw new Error("Projektin statusta ei voitu määrittää: " + oid);
+  }
+
+  if (projekti.aloitusKuulutusJulkaisut) {
+    await handleAloituskuulutusVaihe(oid, projekti.aloitusKuulutusJulkaisut);
+  }
+
+  if (projekti.vuorovaikutukset) {
+    for (const vuorovaikutus of projekti.vuorovaikutukset) {
+      if (vuorovaikutus.julkinen) {
+        const julkaisuPaiva = vuorovaikutus?.vuorovaikutusJulkaisuPaiva ? parseDate(vuorovaikutus.vuorovaikutusJulkaisuPaiva) : undefined;
+        await synchronizeFilesToPublic(oid, new ProjektiPaths(oid).vuorovaikutus(vuorovaikutus), julkaisuPaiva);
+      }
+    }
+  }
+  if (projekti.nahtavillaoloVaiheJulkaisut) {
+    await handleNahtavillaoloVaihe(oid, projekti.nahtavillaoloVaiheJulkaisut);
+  }
+  if (projekti.hyvaksymisPaatosVaiheJulkaisut) {
+    await handleHyvaksymisPaatosVaihe(oid, projekti.hyvaksymisPaatosVaiheJulkaisut);
+  }
+
+  if (projekti.jatkoPaatos1VaiheJulkaisut) {
+    // Poista julkiset tiedostot jos ollaan epäaktiivinen-tilassa tai toisessa jatkopäätöksessä
+    await handleJatkoPaatos1Vaihe(oid, projekti.jatkoPaatos1VaiheJulkaisut);
+  }
+
+  if (projekti.jatkoPaatos2VaiheJulkaisut) {
+    // Poista julkiset tiedostot jos ollaan epäaktiivinen-tilassa prosessin lopussa
+    await handleJatkoPaatos2Vaihe(oid, projekti.jatkoPaatos2VaiheJulkaisut);
   }
 }
 
@@ -226,9 +219,9 @@ export const handleEvent: SQSHandler = async (event: SQSEvent) => {
 
       if (aineistoEvent.type == ImportAineistoEventType.IMPORT) {
         await handleImport(projekti);
-      } else {
-        await handlePublish(aineistoEvent, projekti);
       }
+      // Synkronoidaan tiedostot aina
+      await synchronizeAll(aineistoEvent, projekti);
     }
   });
 };

--- a/backend/src/aineisto/importAineistoEvent.ts
+++ b/backend/src/aineisto/importAineistoEvent.ts
@@ -1,17 +1,9 @@
 export enum ImportAineistoEventType {
   IMPORT = "IMPORT",
-  PUBLISH_NAHTAVILLAOLO = "PUBLISH_NAHTAVILLAOLO",
-  PUBLISH_HYVAKSYMISPAATOS = "PUBLISH_HYVAKSYMISPAATOS",
-  PUBLISH_JATKOPAATOS1 = "PUBLISH_JATKOPAATOS1",
-  PUBLISH_JATKOPAATOS2 = "PUBLISH_JATKOPAATOS2",
+  SYNCHRONIZE = "SYNCHRONIZE",
 }
 
 export type ImportAineistoEvent = {
   type: ImportAineistoEventType;
   oid: string;
-  publishVuorovaikutusWithNumero?: number;
-  publishNahtavillaoloWithId?: number;
-  publishHyvaksymisPaatosWithId?: number;
-  publishJatkoPaatos1WithId?: number;
-  publishJatkoPaatos2WithId?: number;
 };

--- a/backend/src/database/model/projekti.ts
+++ b/backend/src/database/model/projekti.ts
@@ -26,6 +26,7 @@ export type DBVaylaUser = {
 };
 
 export type AloitusKuulutus = {
+  id: number;
   kuulutusPaiva?: string | null;
   siirtyySuunnitteluVaiheeseen?: string | null;
   hankkeenKuvaus?: LocalizedMap<string>;

--- a/backend/src/files/ProjektiPath.ts
+++ b/backend/src/files/ProjektiPath.ts
@@ -1,10 +1,13 @@
 import {
+  AloitusKuulutus,
+  AloitusKuulutusJulkaisu,
   HyvaksymisPaatosVaihe,
   HyvaksymisPaatosVaiheJulkaisu,
   NahtavillaoloVaihe,
   NahtavillaoloVaiheJulkaisu,
   Vuorovaikutus,
 } from "../database/model";
+import { assertIsDefined } from "../util/assertions";
 
 export abstract class PathTuple {
   protected readonly parent: PathTuple;
@@ -21,11 +24,16 @@ export abstract class PathTuple {
   abstract get publicPath(): string;
 
   get publicFullPath(): string {
-    return this.parent ? this.parent.publicPath + "/" + this.publicPath : "";
+    return this.parent ? this.parent.publicFullPath + "/" + this.publicPath : "";
+  }
+
+  get yllapitoFullPath(): string {
+    return this.parent ? this.parent.yllapitoFullPath + "/" + this.yllapitoPath : "";
   }
 }
 
 export class ProjektiPaths extends PathTuple {
+  static PATH_ALOITUSKUULUTUS = "aloituskuulutus";
   static PATH_NAHTAVILLAOLO = "nahtavillaolo";
   static PATH_HYVAKSYMISPAATOS = "hyvaksymispaatos";
   static PATH_JATKOPAATOS1 = "jatkopaatos1";
@@ -39,34 +47,48 @@ export class ProjektiPaths extends PathTuple {
   }
 
   get yllapitoPath(): string {
+    return "";
+  }
+
+  get yllapitoFullPath(): string {
     return `yllapito/tiedostot/projekti/${this.oid}`;
   }
 
   get publicPath(): string {
-    return `tiedostot/suunnitelma/${this.oid}`;
+    return "";
   }
 
   get publicFullPath(): string {
-    return this.publicPath;
+    return `tiedostot/suunnitelma/${this.oid}`;
+  }
+
+  aloituskuulutus(julkaisu: AloitusKuulutusJulkaisu | undefined): AloituskuulutusPaths {
+    return new AloituskuulutusPaths(this, julkaisu);
   }
 
   vuorovaikutus(vuorovaikutus: Vuorovaikutus): VuorovaikutusPaths {
     return new VuorovaikutusPaths(this, vuorovaikutus);
   }
 
-  nahtavillaoloVaihe(nahtavillaoloVaihe: NahtavillaoloVaihe | NahtavillaoloVaiheJulkaisu): PathTuple {
+  nahtavillaoloVaihe(nahtavillaoloVaihe: NahtavillaoloVaihe | NahtavillaoloVaiheJulkaisu | undefined): PathTuple {
     return new NahtavillaoloVaihePaths(this, nahtavillaoloVaihe);
   }
 
-  hyvaksymisPaatosVaihe(hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu): HyvaksymisPaatosVaihePaths {
+  hyvaksymisPaatosVaihe(
+    hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu | undefined | null
+  ): HyvaksymisPaatosVaihePaths {
     return new HyvaksymisPaatosVaihePaths(this, ProjektiPaths.PATH_HYVAKSYMISPAATOS, hyvaksymisPaatosVaihe);
   }
 
-  jatkoPaatos1Vaihe(hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu): HyvaksymisPaatosVaihePaths {
+  jatkoPaatos1Vaihe(
+    hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu | undefined | null
+  ): HyvaksymisPaatosVaihePaths {
     return new HyvaksymisPaatosVaihePaths(this, ProjektiPaths.PATH_JATKOPAATOS1, hyvaksymisPaatosVaihe);
   }
 
-  jatkoPaatos2Vaihe(hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu): HyvaksymisPaatosVaihePaths {
+  jatkoPaatos2Vaihe(
+    hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu | undefined | null
+  ): HyvaksymisPaatosVaihePaths {
     return new HyvaksymisPaatosVaihePaths(this, ProjektiPaths.PATH_JATKOPAATOS2, hyvaksymisPaatosVaihe);
   }
 }
@@ -90,6 +112,10 @@ class VuorovaikutusPaths extends PathTuple {
   get aineisto(): VuorovaikutusAineisto {
     return new VuorovaikutusAineisto(this);
   }
+
+  get kutsu(): VuorovaikutusKutsu {
+    return new VuorovaikutusKutsu(this);
+  }
 }
 
 class VuorovaikutusAineisto extends PathTuple {
@@ -105,20 +131,65 @@ class VuorovaikutusAineisto extends PathTuple {
     return this.parent.yllapitoPath + "/" + "aineisto";
   }
 
+  get yllapitoFullPath(): string {
+    return this.parent.yllapitoFullPath + "/" + "aineisto";
+  }
+
   get publicFullPath(): string {
     return this.parent.publicFullPath + "/" + "aineisto";
   }
 }
 
-class NahtavillaoloVaihePaths extends PathTuple {
-  private nahtavillaoloVaiheId: number;
-
-  constructor(parent: PathTuple, nahtavillaoloVaihe: NahtavillaoloVaihe | NahtavillaoloVaiheJulkaisu) {
+class VuorovaikutusKutsu extends PathTuple {
+  constructor(parent: PathTuple) {
     super(parent);
-    this.nahtavillaoloVaiheId = nahtavillaoloVaihe.id;
   }
 
   get yllapitoPath(): string {
+    return this.parent.yllapitoPath + "/" + "kutsu";
+  }
+
+  get yllapitoFullPath(): string {
+    return this.parent.yllapitoFullPath + "/" + "kutsu";
+  }
+
+  get publicPath(): string {
+    return this.parent.publicPath + "/" + "kutsu";
+  }
+
+  get publicFullPath(): string {
+    return this.parent.publicFullPath + "/" + "kutsu";
+  }
+}
+
+class AloituskuulutusPaths extends PathTuple {
+  private readonly kuulutusId?: number;
+
+  constructor(parent: PathTuple, kuulutus: AloitusKuulutus | AloitusKuulutusJulkaisu | undefined) {
+    super(parent);
+    this.kuulutusId = kuulutus?.id;
+  }
+
+  get yllapitoPath(): string {
+    assertIsDefined(this.kuulutusId, "AloitusKuulutusJulkaisu.id pitää olla annettu");
+    return ProjektiPaths.PATH_ALOITUSKUULUTUS + "/" + this.kuulutusId;
+  }
+
+  get publicPath(): string {
+    return ProjektiPaths.PATH_ALOITUSKUULUTUS;
+  }
+}
+
+class NahtavillaoloVaihePaths extends PathTuple {
+  private readonly nahtavillaoloVaiheId?: number;
+
+  constructor(parent: PathTuple, nahtavillaoloVaihe: NahtavillaoloVaihe | NahtavillaoloVaiheJulkaisu | undefined) {
+    super(parent);
+    this.nahtavillaoloVaiheId = nahtavillaoloVaihe?.id;
+  }
+
+  get yllapitoPath(): string {
+    assertIsDefined(this.nahtavillaoloVaiheId, "nahtavillaoloVaiheId pitää olla annettu");
     return ProjektiPaths.PATH_NAHTAVILLAOLO + "/" + this.nahtavillaoloVaiheId;
   }
 
@@ -127,17 +198,18 @@ class NahtavillaoloVaihePaths extends PathTuple {
   }
 }
 
-class VersionedPaths<T extends { id: number }> extends PathTuple {
-  private id: number;
-  private folder: string;
+class VersionedPaths<T extends { id: number } | undefined | null> extends PathTuple {
+  private readonly id?: number;
+  private readonly folder: string;
 
-  constructor(parent: PathTuple, folder: string, versionedElement: T) {
+  constructor(parent: PathTuple, folder: string, versionedElement: T | undefined) {
     super(parent);
     this.folder = folder;
-    this.id = versionedElement.id;
+    this.id = versionedElement?.id;
   }
 
   get yllapitoPath(): string {
+    assertIsDefined(this.id, "id pitää olla annettu");
     return this.folder + "/" + this.id;
   }
 
@@ -146,15 +218,23 @@ class VersionedPaths<T extends { id: number }> extends PathTuple {
   }
 }
 
-export class HyvaksymisPaatosVaihePaths extends VersionedPaths<HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu> {
+export class HyvaksymisPaatosVaihePaths extends VersionedPaths<HyvaksymisPaatosVaihe | HyvaksymisPaatosVaiheJulkaisu | undefined | null> {
   get paatos(): PathTuple {
     return new (class extends PathTuple {
+      get yllapitoPath(): string {
+        return this.parent.yllapitoPath + "/" + "paatos";
+      }
+
       get publicPath(): string {
         return this.parent.publicPath + "/" + "paatos";
       }
 
-      get yllapitoPath(): string {
-        return this.parent.yllapitoPath + "/" + "paatos";
+      get publicFullPath(): string {
+        return this.parent.publicFullPath + "/" + "paatos";
+      }
+
+      get yllapitoFullPath(): string {
+        return this.parent.yllapitoFullPath + "/" + "paatos";
       }
     })(this);
   }

--- a/backend/src/handler/tila/abstractHyvaksymisPaatosVaiheTilaManager.ts
+++ b/backend/src/handler/tila/abstractHyvaksymisPaatosVaiheTilaManager.ts
@@ -10,7 +10,7 @@ import { parseAndAddDateTime, parseDate } from "../../util/dateUtil";
 import { HYVAKSYMISPAATOS_DURATION, JATKOPAATOS_DURATION } from "../../projekti/status/statusHandler";
 import { AsiakirjaTyyppi, Kieli } from "../../../../common/graphql/apiModel";
 import { fileService } from "../../files/fileService";
-import { ProjektiPaths } from "../../files/ProjektiPath";
+import { PathTuple } from "../../files/ProjektiPath";
 import { projektiDatabase } from "../../database/projektiDatabase";
 import assert from "assert";
 import { HyvaksymisPaatosKuulutusAsiakirjaTyyppi } from "../../asiakirja/asiakirjaTypes";
@@ -39,13 +39,14 @@ export abstract class AbstractHyvaksymisPaatosVaiheTilaManager extends TilaManag
 
   protected async generatePDFs(
     projekti: DBProjekti,
-    julkaisuWaitingForApproval: HyvaksymisPaatosVaiheJulkaisu
+    julkaisuWaitingForApproval: HyvaksymisPaatosVaiheJulkaisu,
+    path: PathTuple
   ): Promise<LocalizedMap<HyvaksymisPaatosVaihePDF>> {
     const kielitiedot = julkaisuWaitingForApproval.kielitiedot;
 
     async function generatePDFsForLanguage(kieli: Kieli, julkaisu: HyvaksymisPaatosVaiheJulkaisu): Promise<HyvaksymisPaatosVaihePDF> {
       async function createPDFOfType(type: HyvaksymisPaatosKuulutusAsiakirjaTyyppi) {
-        return createPDF(type, julkaisu, projekti, kieli);
+        return createPDF(type, julkaisu, projekti, kieli, path);
       }
 
       // Create PDFs in parallel
@@ -114,7 +115,8 @@ async function createPDF(
   asiakirjaTyyppi: HyvaksymisPaatosKuulutusAsiakirjaTyyppi,
   julkaisu: HyvaksymisPaatosVaiheJulkaisu,
   projekti: DBProjekti,
-  kieli: Kieli
+  kieli: Kieli,
+  path: PathTuple
 ) {
   assert(julkaisu.kuulutusPaiva, "julkaisulta puuttuu kuulutuspäivä");
   assert(projekti.kasittelynTila, "kasittelynTila puuttuu");
@@ -130,12 +132,11 @@ async function createPDF(
   });
   return fileService.createFileToProjekti({
     oid: projekti.oid,
-    filePathInProjekti: ProjektiPaths.PATH_HYVAKSYMISPAATOS,
+    path,
     fileName: pdf.nimi,
     contents: Buffer.from(pdf.sisalto, "base64"),
     inline: true,
     contentType: "application/pdf",
     publicationTimestamp: parseDate(julkaisu.kuulutusPaiva),
-    copyToPublic: true,
   });
 }

--- a/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
+++ b/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
@@ -21,6 +21,7 @@ import assert from "assert";
 import { isKuulutusPaivaInThePast } from "../../projekti/status/projektiJulkinenStatusHandler";
 import dayjs from "dayjs";
 import { assertIsDefined } from "../../util/assertions";
+import { ProjektiPaths } from "../../files/ProjektiPath";
 
 async function createAloituskuulutusPDF(
   asiakirjaTyyppi: AsiakirjaTyyppi,
@@ -38,15 +39,15 @@ async function createAloituskuulutusPDF(
     luonnos: false,
     kayttoOikeudet: projekti.kayttoOikeudet,
   });
+
   return fileService.createFileToProjekti({
     oid: projekti.oid,
-    filePathInProjekti: "aloituskuulutus",
+    path: new ProjektiPaths(projekti.oid).aloituskuulutus(julkaisuWaitingForApproval),
     fileName: pdf.nimi,
     contents: Buffer.from(pdf.sisalto, "base64"),
     inline: true,
     contentType: "application/pdf",
     publicationTimestamp: parseDate(julkaisuWaitingForApproval.kuulutusPaiva),
-    copyToPublic: true,
   });
 }
 

--- a/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
+++ b/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
@@ -22,6 +22,7 @@ import { isKuulutusPaivaInThePast } from "../../projekti/status/projektiJulkinen
 import dayjs from "dayjs";
 import { assertIsDefined } from "../../util/assertions";
 import { ProjektiPaths } from "../../files/ProjektiPath";
+import { aineistoService } from "../../aineisto/aineistoService";
 
 async function createAloituskuulutusPDF(
   asiakirjaTyyppi: AsiakirjaTyyppi,
@@ -152,6 +153,7 @@ class AloitusKuulutusTilaManager extends TilaManager {
       assert(julkaisuWaitingForApproval.kuulutusPaiva, "kuulutusPaiva on oltava tässä kohtaa");
       await fileService.publishProjektiFile(projekti.oid, logoFilePath, logoFilePath, parseDate(julkaisuWaitingForApproval.kuulutusPaiva));
     }
+    await aineistoService.synchronizeProjektiFiles(projekti.oid);
   }
 
   private async generatePDFs(projekti: DBProjekti, julkaisuWaitingForApproval: AloitusKuulutusJulkaisu) {

--- a/backend/src/handler/tila/hyvaksymisPaatosVaiheTilaManager.ts
+++ b/backend/src/handler/tila/hyvaksymisPaatosVaiheTilaManager.ts
@@ -5,6 +5,7 @@ import { projektiDatabase } from "../../database/projektiDatabase";
 import { aineistoService } from "../../aineisto/aineistoService";
 import { IllegalArgumentError } from "../../error/IllegalArgumentError";
 import { AbstractHyvaksymisPaatosVaiheTilaManager } from "./abstractHyvaksymisPaatosVaiheTilaManager";
+import { ProjektiPaths } from "../../files/ProjektiPath";
 
 class HyvaksymisPaatosVaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTilaManager {
   async sendForApproval(projekti: DBProjekti, muokkaaja: NykyinenKayttaja): Promise<void> {
@@ -26,7 +27,7 @@ class HyvaksymisPaatosVaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTila
     julkaisu.tila = KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA;
     julkaisu.muokkaaja = muokkaaja.uid;
 
-    julkaisu.hyvaksymisPaatosVaihePDFt = await this.generatePDFs(projekti, julkaisu);
+    julkaisu.hyvaksymisPaatosVaihePDFt = await this.generatePDFs(projekti, julkaisu, new ProjektiPaths(projekti.oid).hyvaksymisPaatosVaihe(julkaisu));
 
     await projektiDatabase.hyvaksymisPaatosVaiheJulkaisut.insert(projekti.oid, julkaisu);
   }
@@ -44,7 +45,7 @@ class HyvaksymisPaatosVaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTila
     await projektiDatabase.saveProjekti({ oid: projekti.oid, ajastettuTarkistus: this.getNextAjastettuTarkistus(julkaisu, true) });
 
     await projektiDatabase.hyvaksymisPaatosVaiheJulkaisut.update(projekti, julkaisu);
-    await aineistoService.publishHyvaksymisPaatosVaihe(projekti.oid, julkaisu.id);
+    await aineistoService.synchronizeProjektiFiles(projekti.oid);
   }
 
   async reject(projekti: DBProjekti, syy: string): Promise<void> {

--- a/backend/src/handler/tila/jatkoPaatos1VaiheTilaManager.ts
+++ b/backend/src/handler/tila/jatkoPaatos1VaiheTilaManager.ts
@@ -5,6 +5,7 @@ import { projektiDatabase } from "../../database/projektiDatabase";
 import { aineistoService } from "../../aineisto/aineistoService";
 import { IllegalArgumentError } from "../../error/IllegalArgumentError";
 import { AbstractHyvaksymisPaatosVaiheTilaManager } from "./abstractHyvaksymisPaatosVaiheTilaManager";
+import { ProjektiPaths } from "../../files/ProjektiPath";
 
 class JatkoPaatos1VaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTilaManager {
   async sendForApproval(projekti: DBProjekti, muokkaaja: NykyinenKayttaja): Promise<void> {
@@ -26,7 +27,11 @@ class JatkoPaatos1VaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTilaMana
     julkaisu.tila = KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA;
     julkaisu.muokkaaja = muokkaaja.uid;
 
-    julkaisu.hyvaksymisPaatosVaihePDFt = await this.generatePDFs(projekti, julkaisu);
+    julkaisu.hyvaksymisPaatosVaihePDFt = await this.generatePDFs(
+      projekti,
+      julkaisu,
+      new ProjektiPaths(projekti.oid).jatkoPaatos1Vaihe(julkaisu)
+    );
 
     await projektiDatabase.jatkoPaatos1VaiheJulkaisut.insert(projekti.oid, julkaisu);
   }
@@ -44,7 +49,7 @@ class JatkoPaatos1VaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTilaMana
     await projektiDatabase.saveProjekti({ oid: projekti.oid, ajastettuTarkistus: this.getNextAjastettuTarkistus(julkaisu, false) });
 
     await projektiDatabase.jatkoPaatos1VaiheJulkaisut.update(projekti, julkaisu);
-    await aineistoService.publishJatkoPaatos1Vaihe(projekti.oid, julkaisu.id);
+    await aineistoService.synchronizeProjektiFiles(projekti.oid);
   }
 
   async reject(projekti: DBProjekti, syy: string): Promise<void> {

--- a/backend/src/handler/tila/nahtavillaoloTilaManager.ts
+++ b/backend/src/handler/tila/nahtavillaoloTilaManager.ts
@@ -46,13 +46,12 @@ async function createNahtavillaoloVaihePDF(
   });
   return fileService.createFileToProjekti({
     oid: projekti.oid,
-    filePathInProjekti: ProjektiPaths.PATH_NAHTAVILLAOLO,
+    path: new ProjektiPaths(projekti.oid).nahtavillaoloVaihe(julkaisu),
     fileName: pdf.nimi,
     contents: Buffer.from(pdf.sisalto, "base64"),
     inline: true,
     contentType: "application/pdf",
     publicationTimestamp: parseDate(julkaisu.kuulutusPaiva),
-    copyToPublic: true,
   });
 }
 
@@ -145,7 +144,7 @@ class NahtavillaoloTilaManager extends TilaManager {
     julkaisuWaitingForApproval.hyvaksymisPaiva = dateToString(dayjs());
 
     await projektiDatabase.nahtavillaoloVaiheJulkaisut.update(projekti, julkaisuWaitingForApproval);
-    await aineistoService.publishNahtavillaolo(projekti.oid, julkaisuWaitingForApproval.id);
+    await aineistoService.synchronizeProjektiFiles(projekti.oid);
   }
 
   async reject(projekti: DBProjekti, syy: string): Promise<void> {

--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -1,11 +1,4 @@
-import {
-  AloitusKuulutus,
-  AloitusKuulutusJulkaisu,
-  AloitusKuulutusPDF,
-  LocalizedMap,
-  RequiredLocalizedMap,
-  UudelleenKuulutus,
-} from "../../../database/model";
+import { AloitusKuulutus, AloitusKuulutusJulkaisu, RequiredLocalizedMap, UudelleenKuulutus } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 import { KuulutusJulkaisuTila, LokalisoituTeksti, MuokkausTila } from "../../../../../common/graphql/apiModel";
 import {
@@ -19,6 +12,7 @@ import {
 import { adaptSuunnitteluSopimusJulkaisu, FileLocation } from "./adaptSuunitteluSopimus";
 import { fileService } from "../../../files/fileService";
 import { adaptMuokkausTila, findJulkaisuWithTila } from "../../projektiUtil";
+import { ProjektiPaths } from "../../../files/ProjektiPath";
 
 export function adaptAloitusKuulutus(
   kuulutus?: AloitusKuulutus | null,
@@ -28,7 +22,7 @@ export function adaptAloitusKuulutus(
     if (!kuulutus.hankkeenKuvaus) {
       throw new Error("adaptAloituskuulutus: kuulutus.hankkeenKuvaus puuttuu");
     }
-    const { kuulutusYhteystiedot, uudelleenKuulutus: uudelleenKuulutus, ...otherKuulutusFields } = kuulutus;
+    const { kuulutusYhteystiedot, uudelleenKuulutus: uudelleenKuulutus, id: _id, ...otherKuulutusFields } = kuulutus;
     return {
       __typename: "AloitusKuulutus",
       ...otherKuulutusFields,
@@ -83,17 +77,15 @@ export function adaptAloitusKuulutusJulkaisu(
         velho: adaptVelho(velho),
         suunnitteluSopimus: adaptSuunnitteluSopimusJulkaisu(oid, suunnitteluSopimus, FileLocation.YLLAPITO),
         kielitiedot: adaptKielitiedotByAddingTypename(kielitiedot),
-        aloituskuulutusPDFt: adaptJulkaisuPDFPaths(oid, julkaisu.aloituskuulutusPDFt),
+        aloituskuulutusPDFt: adaptJulkaisuPDFPaths(oid, julkaisu),
         uudelleenKuulutus: adaptUudelleenKuulutus(uudelleenKuulutus),
       };
     }
   }
 }
 
-function adaptJulkaisuPDFPaths(
-  oid: string,
-  aloitusKuulutusPDFS: LocalizedMap<AloitusKuulutusPDF> | null | undefined
-): API.AloitusKuulutusPDFt | undefined {
+function adaptJulkaisuPDFPaths(oid: string, aloitusKuulutusJulkaisu: AloitusKuulutusJulkaisu): API.AloitusKuulutusPDFt | undefined {
+  const aloitusKuulutusPDFS = aloitusKuulutusJulkaisu.aloituskuulutusPDFt;
   if (!aloitusKuulutusPDFS) {
     return undefined;
   }
@@ -105,23 +97,11 @@ function adaptJulkaisuPDFPaths(
       result[kieli as API.Kieli] = undefined;
       continue;
     }
+    const aloituskuulutusPath = new ProjektiPaths(oid).aloituskuulutus(aloitusKuulutusJulkaisu);
     result[kieli as API.Kieli] = {
       __typename: "AloitusKuulutusPDF",
-      // getYllapitoPathForProjektiFile molemmat argumentit on määritelty, joten funktio palauttaa ei-undefined arvon
-      // aloitusKuulutusPDFS[kieli].aloituskuulutusPDFPath on määritelty tässä vaiheessa
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      aloituskuulutusPDFPath: fileService.getYllapitoPathForProjektiFile(oid, pdfs.aloituskuulutusPDFPath),
-      // getYllapitoPathForProjektiFile molemmat argumentit on määritelty, joten funktio palauttaa ei-undefined arvon
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      aloituskuulutusIlmoitusPDFPath: fileService.getYllapitoPathForProjektiFile(
-        oid,
-        // aloitusKuulutusPDFS[kieli].aloituskuulutusIlmoitusPDFPath on määritelty tässä vaiheessa
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        pdfs.aloituskuulutusIlmoitusPDFPath
-      ),
+      aloituskuulutusPDFPath: fileService.getYllapitoPathForProjektiFile(aloituskuulutusPath, pdfs.aloituskuulutusPDFPath),
+      aloituskuulutusIlmoitusPDFPath: fileService.getYllapitoPathForProjektiFile(aloituskuulutusPath, pdfs.aloituskuulutusIlmoitusPDFPath),
     };
   }
   return { __typename: "AloitusKuulutusPDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.AloitusKuulutusPDF, ...result };

--- a/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
@@ -16,10 +16,12 @@ import {
   adaptVelho,
 } from "../common";
 import { fileService } from "../../../files/fileService";
+import { PathTuple } from "../../../files/ProjektiPath";
 
 export function adaptHyvaksymisPaatosVaihe(
   hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | null | undefined,
-  hyvaksymisPaatos: Hyvaksymispaatos | null | undefined
+  hyvaksymisPaatos: Hyvaksymispaatos | null | undefined,
+  paths: PathTuple
 ): API.HyvaksymisPaatosVaihe | undefined {
   if (!hyvaksymisPaatosVaihe) {
     return undefined;
@@ -35,8 +37,8 @@ export function adaptHyvaksymisPaatosVaihe(
   return {
     __typename: "HyvaksymisPaatosVaihe",
     ...rest,
-    aineistoNahtavilla: adaptAineistot(aineistoNahtavilla),
-    hyvaksymisPaatos: adaptAineistot(hyvaksymisPaatosAineisto),
+    aineistoNahtavilla: adaptAineistot(aineistoNahtavilla, paths),
+    hyvaksymisPaatos: adaptAineistot(hyvaksymisPaatosAineisto, paths),
     kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kuulutusYhteystiedot),
     ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(ilmoituksenVastaanottajat),
     hyvaksymisPaatoksenPvm: hyvaksymisPaatos?.paatoksenPvm || undefined,
@@ -45,9 +47,9 @@ export function adaptHyvaksymisPaatosVaihe(
 }
 
 export function adaptHyvaksymisPaatosVaiheJulkaisut(
-  oid: string,
   hyvaksymisPaatos: Hyvaksymispaatos | null | undefined,
-  julkaisut?: HyvaksymisPaatosVaiheJulkaisu[] | null | undefined
+  julkaisut: HyvaksymisPaatosVaiheJulkaisu[] | null | undefined,
+  getPathCallback: (julkaisu: HyvaksymisPaatosVaiheJulkaisu) => PathTuple
 ): API.HyvaksymisPaatosVaiheJulkaisu[] | undefined {
   if (julkaisut) {
     return julkaisut.map((julkaisu) => {
@@ -88,14 +90,14 @@ export function adaptHyvaksymisPaatosVaiheJulkaisut(
       if (!kielitiedot) {
         throw new Error("adaptHyvaksymisPaatosVaiheJulkaisut: hyvaksymisPaatos.kielitiedot määrittelemättä");
       }
-
+      const paths = getPathCallback(julkaisu);
       const apijulkaisu: API.HyvaksymisPaatosVaiheJulkaisu = {
         ...fieldsToCopyAsIs,
         __typename: "HyvaksymisPaatosVaiheJulkaisu",
         kielitiedot: adaptKielitiedotByAddingTypename(kielitiedot),
-        hyvaksymisPaatosVaihePDFt: adaptHyvaksymisPaatosVaihePDFPaths(oid, hyvaksymisPaatosVaihePDFt),
-        aineistoNahtavilla: adaptAineistot(aineistoNahtavilla),
-        hyvaksymisPaatos: adaptAineistot(hyvaksymisPaatosAineisto),
+        hyvaksymisPaatosVaihePDFt: adaptHyvaksymisPaatosVaihePDFPaths(hyvaksymisPaatosVaihePDFt, paths),
+        aineistoNahtavilla: adaptAineistot(aineistoNahtavilla, paths),
+        hyvaksymisPaatos: adaptAineistot(hyvaksymisPaatosAineisto, paths),
         hyvaksymisPaatoksenPvm: hyvaksymisPaatos.paatoksenPvm,
         hyvaksymisPaatoksenAsianumero: hyvaksymisPaatos.asianumero,
         yhteystiedot: adaptMandatoryYhteystiedotByAddingTypename(yhteystiedot),
@@ -110,8 +112,8 @@ export function adaptHyvaksymisPaatosVaiheJulkaisut(
 }
 
 function adaptHyvaksymisPaatosVaihePDFPaths(
-  oid: string,
-  hyvaksymisPaatosVaihePDFs: LocalizedMap<HyvaksymisPaatosVaihePDF>
+  hyvaksymisPaatosVaihePDFs: LocalizedMap<HyvaksymisPaatosVaihePDF>,
+  paths: PathTuple
 ): API.HyvaksymisPaatosVaihePDFt | undefined {
   if (!hyvaksymisPaatosVaihePDFs) {
     return undefined;
@@ -119,11 +121,8 @@ function adaptHyvaksymisPaatosVaihePDFPaths(
 
   const result: Partial<API.HyvaksymisPaatosVaihePDFt> = {};
 
-  function getYllapitoPathForFile(path: string): string {
-    // getYllapitoPathForProjektiFile palauttaa stringin, koska oid ja path on määritelty
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return fileService.getYllapitoPathForProjektiFile(oid, path);
+  function getYllapitoPathForFile(filePath: string): string {
+    return fileService.getYllapitoPathForProjektiFile(paths, filePath);
   }
 
   for (const kieli in hyvaksymisPaatosVaihePDFs) {
@@ -131,7 +130,7 @@ function adaptHyvaksymisPaatosVaihePDFPaths(
     if (!pdfs) {
       throw new Error(`adaptHyvaksymisPaatosVaihePDFPaths: hyvaksymisPaatosVaihePDFs[${kieli}] määrittelemättä`);
     }
-    const hyvaksymisPaatosVaihePdf: API.HyvaksymisPaatosVaihePDF = {
+    result[kieli as API.Kieli] = {
       __typename: "HyvaksymisPaatosVaihePDF",
       ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath: getYllapitoPathForFile(
         pdfs.ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath
@@ -143,7 +142,6 @@ function adaptHyvaksymisPaatosVaihePDFPaths(
         pdfs.ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath
       ),
     };
-    result[kieli as API.Kieli] = hyvaksymisPaatosVaihePdf;
   }
   return { __typename: "HyvaksymisPaatosVaihePDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.HyvaksymisPaatosVaihePDF, ...result };
 }

--- a/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
@@ -1,4 +1,4 @@
-import { DBProjekti, LocalizedMap, NahtavillaoloPDF, NahtavillaoloVaihe, NahtavillaoloVaiheJulkaisu } from "../../../database/model";
+import { DBProjekti, NahtavillaoloVaihe, NahtavillaoloVaiheJulkaisu } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 import { KuulutusJulkaisuTila, MuokkausTila } from "../../../../../common/graphql/apiModel";
 import {
@@ -12,6 +12,7 @@ import {
 } from "../common";
 import { fileService } from "../../../files/fileService";
 import { lisaAineistoService } from "../../../aineisto/lisaAineistoService";
+import { ProjektiPaths } from "../../../files/ProjektiPath";
 import { adaptMuokkausTila, findJulkaisuWithTila } from "../../projektiUtil";
 import { adaptUudelleenKuulutus } from "./adaptAloitusKuulutus";
 
@@ -30,12 +31,12 @@ export function adaptNahtavillaoloVaihe(
       hankkeenKuvaus,
       ...rest
     } = nahtavillaoloVaihe;
-
+  const paths = new ProjektiPaths(dbProjekti.oid).nahtavillaoloVaihe(nahtavillaoloVaihe);
     return {
       __typename: "NahtavillaoloVaihe",
       ...rest,
-      aineistoNahtavilla: adaptAineistot(aineistoNahtavilla),
-      lisaAineisto: adaptAineistot(lisaAineisto),
+      aineistoNahtavilla: adaptAineistot(aineistoNahtavilla, paths),
+      lisaAineisto: adaptAineistot(lisaAineisto, paths),
       // dbProjekti.salt on määritelty
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -107,17 +108,18 @@ export function adaptNahtavillaoloVaiheJulkaisu(
       throw new Error("adaptNahtavillaoloVaiheJulkaisut: julkaisu.yhteystiedot määrittelemättä");
     }
 
-    const palautetaan: API.NahtavillaoloVaiheJulkaisu = {
-      ...fieldsToCopyAsIs,
-      __typename: "NahtavillaoloVaiheJulkaisu",
-      tila,
-      hankkeenKuvaus: adaptHankkeenKuvaus(hankkeenKuvaus),
-      kielitiedot: adaptKielitiedotByAddingTypename(kielitiedot),
-      yhteystiedot: adaptMandatoryYhteystiedotByAddingTypename(yhteystiedot),
-      ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(ilmoituksenVastaanottajat),
-      aineistoNahtavilla: adaptAineistot(aineistoNahtavilla),
-      lisaAineisto: adaptAineistot(lisaAineisto),
-      nahtavillaoloPDFt: adaptNahtavillaoloPDFPaths(oid, nahtavillaoloPDFt),
+    const paths = new ProjektiPaths(oid).nahtavillaoloVaihe(julkaisu);
+      const palautetaan: API.NahtavillaoloVaiheJulkaisu = {
+        ...fieldsToCopyAsIs,
+        __typename: "NahtavillaoloVaiheJulkaisu",
+        tila,
+        hankkeenKuvaus: adaptHankkeenKuvaus(hankkeenKuvaus),
+        kielitiedot: adaptKielitiedotByAddingTypename(kielitiedot),
+        yhteystiedot: adaptMandatoryYhteystiedotByAddingTypename(yhteystiedot),
+        ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(ilmoituksenVastaanottajat),
+        aineistoNahtavilla: adaptAineistot(aineistoNahtavilla, paths),
+      lisaAineisto: adaptAineistot(lisaAineisto, paths),
+      nahtavillaoloPDFt: adaptNahtavillaoloPDFPaths(oid, julkaisu),
       velho: adaptVelho(velho),
       uudelleenKuulutus: adaptUudelleenKuulutus(uudelleenKuulutus),
     };
@@ -126,36 +128,31 @@ export function adaptNahtavillaoloVaiheJulkaisu(
   return undefined;
 }
 
-function adaptNahtavillaoloPDFPaths(oid: string, nahtavillaoloPDFs: LocalizedMap<NahtavillaoloPDF>): API.NahtavillaoloPDFt | undefined {
+function adaptNahtavillaoloPDFPaths(
+  oid: string,
+  nahtavillaoloVaiheJulkaisu: NahtavillaoloVaiheJulkaisu
+): API.NahtavillaoloPDFt | undefined {
+  const nahtavillaoloPDFs = nahtavillaoloVaiheJulkaisu.nahtavillaoloPDFt;
   if (!nahtavillaoloPDFs) {
     return undefined;
   }
 
+  const paths = new ProjektiPaths(oid).nahtavillaoloVaihe(nahtavillaoloVaiheJulkaisu);
   const result: Partial<API.NahtavillaoloPDFt> = {};
   for (const kieli in nahtavillaoloPDFs) {
     const pdfs = nahtavillaoloPDFs[kieli as API.Kieli];
     if (!pdfs) {
       throw new Error(`adaptNahtavillaoloPDFPaths: nahtavillaoloPDFs[${kieli}] määrittelemättä`);
     }
-    const nahtavillaoloPdf: API.NahtavillaoloPDF = {
+    result[kieli as API.Kieli] = {
       __typename: "NahtavillaoloPDF",
-      // getYllapitoPathForProjektiFile molemmat argumentit on määritelty, joten funktio palauttaa ei-undefined arvon
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      nahtavillaoloPDFPath: fileService.getYllapitoPathForProjektiFile(oid, pdfs.nahtavillaoloPDFPath),
-      // getYllapitoPathForProjektiFile molemmat argumentit on määritelty, joten funktio palauttaa ei-undefined arvon
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      nahtavillaoloIlmoitusPDFPath: fileService.getYllapitoPathForProjektiFile(oid, pdfs.nahtavillaoloIlmoitusPDFPath),
-      // getYllapitoPathForProjektiFile molemmat argumentit on määritelty, joten funktio palauttaa ei-undefined arvon
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
+      nahtavillaoloPDFPath: fileService.getYllapitoPathForProjektiFile(paths, pdfs.nahtavillaoloPDFPath),
+      nahtavillaoloIlmoitusPDFPath: fileService.getYllapitoPathForProjektiFile(paths, pdfs.nahtavillaoloIlmoitusPDFPath),
       nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath: fileService.getYllapitoPathForProjektiFile(
-        oid,
+        paths,
         pdfs.nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath
       ),
     };
-    result[kieli as API.Kieli] = nahtavillaoloPdf;
   }
   return { __typename: "NahtavillaoloPDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.NahtavillaoloPDF, ...result };
 }

--- a/backend/src/projekti/adapter/adaptToAPI/adaptSuunitteluSopimus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptSuunitteluSopimus.ts
@@ -1,6 +1,7 @@
 import { DBVaylaUser, SuunnitteluSopimus, SuunnitteluSopimusJulkaisu } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 import { fileService } from "../../../files/fileService";
+import { ProjektiPaths } from "../../../files/ProjektiPath";
 
 export function adaptSuunnitteluSopimus(
   oid: string,
@@ -15,7 +16,7 @@ export function adaptSuunnitteluSopimus(
       __typename: "SuunnitteluSopimus",
       kunta: suunnitteluSopimus.kunta,
       yhteysHenkilo: suunnitteluSopimus.yhteysHenkilo || "", // "" here to not break old test data because of missing value in mandatory field
-      logo: fileService.getYllapitoPathForProjektiFile(oid, suunnitteluSopimus.logo),
+      logo: "/" + fileService.getYllapitoPathForProjektiFile(new ProjektiPaths(oid), suunnitteluSopimus.logo),
     };
   }
   return suunnitteluSopimus;
@@ -38,9 +39,9 @@ export function adaptSuunnitteluSopimusJulkaisu(
 
     let logo: SuunnitteluSopimusJulkaisu["logo"];
     if (fileLocation === FileLocation.PUBLIC) {
-      logo = fileService.getPublicPathForProjektiFile(oid, suunnitteluSopimus.logo);
+      logo = "/" + fileService.getPublicPathForProjektiFile(new ProjektiPaths(oid), suunnitteluSopimus.logo);
     } else {
-      logo = fileService.getYllapitoPathForProjektiFile(oid, suunnitteluSopimus.logo);
+      logo = "/" + fileService.getYllapitoPathForProjektiFile(new ProjektiPaths(oid), suunnitteluSopimus.logo);
     }
 
     return {
@@ -68,7 +69,7 @@ export function adaptSuunnitteluSopimusJulkaisuJulkinen(
     return {
       __typename: "SuunnitteluSopimusJulkaisu",
       kunta: suunnitteluSopimus.kunta,
-      logo: fileService.getPublicPathForProjektiFile(oid, suunnitteluSopimus.logo),
+      logo: "/" + fileService.getPublicPathForProjektiFile(new ProjektiPaths(oid), suunnitteluSopimus.logo),
       email: suunnitteluSopimus.email,
       etunimi: suunnitteluSopimus.etunimi,
       sukunimi: suunnitteluSopimus.sukunimi,

--- a/backend/src/projekti/adapter/adaptToDB/adaptAloitusKuulutusToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptAloitusKuulutusToSave.ts
@@ -1,13 +1,14 @@
 import * as API from "../../../../../common/graphql/apiModel";
 import { UudelleenKuulutusInput } from "../../../../../common/graphql/apiModel";
 import { AloitusKuulutus, UudelleenKuulutus } from "../../../database/model";
-import { adaptHankkeenKuvausToSave, adaptIlmoituksenVastaanottajatToSave, adaptStandardiYhteystiedotToSave } from "./common";
+import { adaptHankkeenKuvausToSave, adaptIlmoituksenVastaanottajatToSave, adaptStandardiYhteystiedotToSave, getId } from "./common";
 import { IllegalArgumentError } from "../../../error/IllegalArgumentError";
 import mergeWith from "lodash/mergeWith";
 
 export function adaptAloitusKuulutusToSave(
   dbAloituskuulutus: AloitusKuulutus | undefined | null,
-  aloitusKuulutus: API.AloitusKuulutusInput | undefined | null
+  aloitusKuulutus: API.AloitusKuulutusInput | undefined | null,
+  aloitusKuulutusJulkaisutCount: number | undefined
 ): AloitusKuulutus | undefined {
   if (aloitusKuulutus) {
     const { hankkeenKuvaus, ilmoituksenVastaanottajat, kuulutusYhteystiedot, uudelleenKuulutus, ...rest } = aloitusKuulutus;
@@ -20,8 +21,12 @@ export function adaptAloitusKuulutusToSave(
     if (!ilmoituksenVastaanottajat) {
       throw new IllegalArgumentError("Aloituskuulutuksella on oltava ilmoituksenVastaanottajat!");
     }
+
+    const id = getId(dbAloituskuulutus, aloitusKuulutusJulkaisutCount);
+
     return {
       ...rest,
+      id,
       ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajatToSave(ilmoituksenVastaanottajat), //pakko tukea vielä tätä
       hankkeenKuvaus: adaptHankkeenKuvausToSave(hankkeenKuvaus),
       kuulutusYhteystiedot: adaptStandardiYhteystiedotToSave(kuulutusYhteystiedot),

--- a/backend/src/projekti/adapter/adaptToDB/adaptNahtavillaoloVaiheToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptNahtavillaoloVaiheToSave.ts
@@ -6,6 +6,7 @@ import {
   adaptHankkeenKuvausToSave,
   adaptIlmoituksenVastaanottajatToSave,
   adaptStandardiYhteystiedotToSave,
+  getId,
 } from "./common";
 import mergeWith from "lodash/mergeWith";
 import { adaptUudelleenKuulutusToSave } from "./adaptAloitusKuulutusToSave";
@@ -40,15 +41,7 @@ export function adaptNahtavillaoloVaiheToSave(
   const lisaAineisto = lisaAineistoInput
     ? adaptAineistotToSave(dbNahtavillaoloVaihe?.lisaAineisto, lisaAineistoInput, projektiAdaptationResult)
     : undefined;
-
-  let id = dbNahtavillaoloVaihe?.id;
-  if (!id) {
-    if (nahtavillaoloVaiheJulkaisutCount) {
-      id = nahtavillaoloVaiheJulkaisutCount + 1;
-    } else {
-      id = 1;
-    }
-  }
+  const id = getId(dbNahtavillaoloVaihe, nahtavillaoloVaiheJulkaisutCount);
 
   const uusiNahtavillaolovaihe: NahtavillaoloVaihe = {
     kuulutusPaiva,

--- a/backend/src/projekti/adapter/adaptToDB/common.ts
+++ b/backend/src/projekti/adapter/adaptToDB/common.ts
@@ -168,3 +168,23 @@ export function adaptHankkeenKuvausToSave(
   });
   return kuvaus;
 }
+
+export function getId(
+  vaihe:
+    | {
+        id: number | undefined;
+      }
+    | undefined
+    | null,
+  julkaisutCount: number | undefined
+) {
+  let id = vaihe?.id;
+  if (!id) {
+    if (julkaisutCount) {
+      id = julkaisutCount + 1;
+    } else {
+      id = 1;
+    }
+  }
+  return id;
+}

--- a/backend/src/projekti/adapter/common/adaptAineistot.ts
+++ b/backend/src/projekti/adapter/common/adaptAineistot.ts
@@ -1,19 +1,33 @@
 import dayjs, { Dayjs } from "dayjs";
 import { Aineisto } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
+import { fileService } from "../../../files/fileService";
+import { PathTuple } from "../../../files/ProjektiPath";
 
-export function adaptAineistot(aineistot?: Aineisto[] | null, julkaisuPaiva?: Dayjs): API.Aineisto[] | undefined {
+export function adaptAineistot(
+  aineistot: Aineisto[] | undefined | null,
+  paths: PathTuple,
+  julkaisuPaiva?: Dayjs
+): API.Aineisto[] | undefined {
   if (julkaisuPaiva && julkaisuPaiva.isAfter(dayjs())) {
     return undefined;
   }
   if (aineistot && aineistot.length > 0) {
     return aineistot
       .filter((aineisto) => aineisto.tila != API.AineistoTila.ODOTTAA_POISTOA)
-      .map((aineisto) => ({
-        __typename: "Aineisto",
-        ...aineisto,
-        dokumenttiOid: aineisto.dokumenttiOid,
-      }));
+      .map((aineisto) => {
+        const apiAineisto: API.Aineisto = {
+          __typename: "Aineisto",
+          ...aineisto,
+          dokumenttiOid: aineisto.dokumenttiOid,
+        };
+
+        if (aineisto.tiedosto) {
+          apiAineisto.tiedosto = fileService.getYllapitoPathForProjektiFile(paths, aineisto.tiedosto);
+        }
+
+        return apiAineisto;
+      });
   }
   return undefined;
 }

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -1,17 +1,14 @@
 import {
   Aineisto,
   AloitusKuulutusJulkaisu,
-  AloitusKuulutusPDF,
   DBProjekti,
   DBVaylaUser,
   Hyvaksymispaatos,
   HyvaksymisPaatosVaiheJulkaisu,
-  LocalizedMap,
   NahtavillaoloVaiheJulkaisu,
   StandardiYhteystiedot,
   Velho,
   Vuorovaikutus,
-  VuorovaikutusPDF,
   VuorovaikutusTilaisuus,
 } from "../../database/model";
 import * as API from "../../../../common/graphql/apiModel";
@@ -80,19 +77,19 @@ class ProjektiAdapterJulkinen {
     const nahtavillaoloVaihe = ProjektiAdapterJulkinen.adaptNahtavillaoloVaiheJulkaisu(dbProjekti);
     const suunnitteluSopimus = adaptRootSuunnitteluSopimusJulkaisu(dbProjekti);
     const hyvaksymisPaatosVaihe = ProjektiAdapterJulkinen.adaptHyvaksymisPaatosVaihe(
-      dbProjekti,
       dbProjekti.hyvaksymisPaatosVaiheJulkaisut,
-      dbProjekti.kasittelynTila?.hyvaksymispaatos
+      dbProjekti.kasittelynTila?.hyvaksymispaatos,
+      (julkaisu) => new ProjektiPaths(dbProjekti.oid).hyvaksymisPaatosVaihe(julkaisu)
     );
     const jatkoPaatos1Vaihe = ProjektiAdapterJulkinen.adaptHyvaksymisPaatosVaihe(
-      dbProjekti,
       dbProjekti.jatkoPaatos1VaiheJulkaisut,
-      dbProjekti.kasittelynTila?.ensimmainenJatkopaatos
+      dbProjekti.kasittelynTila?.ensimmainenJatkopaatos,
+      (julkaisu) => new ProjektiPaths(dbProjekti.oid).jatkoPaatos1Vaihe(julkaisu)
     );
     const jatkoPaatos2Vaihe = ProjektiAdapterJulkinen.adaptHyvaksymisPaatosVaihe(
-      dbProjekti,
       dbProjekti.jatkoPaatos2VaiheJulkaisut,
-      dbProjekti.kasittelynTila?.toinenJatkopaatos
+      dbProjekti.kasittelynTila?.toinenJatkopaatos,
+      (julkaisu) => new ProjektiPaths(dbProjekti.oid).jatkoPaatos2Vaihe(julkaisu)
     );
 
     const projekti: API.ProjektiJulkinen = {
@@ -156,7 +153,7 @@ class ProjektiAdapterJulkinen {
         velho: adaptVelho(velho),
         suunnitteluSopimus: adaptSuunnitteluSopimusJulkaisuJulkinen(oid, suunnitteluSopimus),
         kielitiedot: adaptKielitiedotByAddingTypename(kielitiedot),
-        aloituskuulutusPDFt: this.adaptJulkaisuPDFPaths(oid, julkaisu.aloituskuulutusPDFt),
+        aloituskuulutusPDFt: this.adaptJulkaisuPDFPaths(oid, julkaisu),
         tila,
         uudelleenKuulutus: adaptUudelleenKuulutus(uudelleenKuulutus),
       };
@@ -164,10 +161,8 @@ class ProjektiAdapterJulkinen {
     return undefined;
   }
 
-  adaptJulkaisuPDFPaths(
-    oid: string,
-    aloitusKuulutusPDFS: LocalizedMap<AloitusKuulutusPDF> | null | undefined
-  ): API.AloitusKuulutusPDFt | undefined {
+  adaptJulkaisuPDFPaths(oid: string, aloitusKuulutus: AloitusKuulutusJulkaisu): API.AloitusKuulutusPDFt | undefined {
+    const aloitusKuulutusPDFS = aloitusKuulutus.aloituskuulutusPDFt;
     if (!aloitusKuulutusPDFS) {
       return undefined;
     }
@@ -180,10 +175,14 @@ class ProjektiAdapterJulkinen {
     for (const kieli in aloitusKuulutusPDFS) {
       const pdfs = aloitusKuulutusPDFS[kieli as API.Kieli];
       if (pdfs) {
+        const aloituskuulutusPath = new ProjektiPaths(oid).aloituskuulutus(aloitusKuulutus);
         result[kieli as API.Kieli] = {
           __typename: "AloitusKuulutusPDF",
-          aloituskuulutusPDFPath: fileService.getPublicPathForProjektiFile(oid, pdfs.aloituskuulutusPDFPath),
-          aloituskuulutusIlmoitusPDFPath: fileService.getPublicPathForProjektiFile(oid, pdfs.aloituskuulutusIlmoitusPDFPath),
+          aloituskuulutusPDFPath: fileService.getPublicPathForProjektiFile(aloituskuulutusPath, pdfs.aloituskuulutusPDFPath),
+          aloituskuulutusIlmoitusPDFPath: fileService.getPublicPathForProjektiFile(
+            aloituskuulutusPath,
+            pdfs.aloituskuulutusIlmoitusPDFPath
+          ),
         };
       }
     }
@@ -251,7 +250,7 @@ class ProjektiAdapterJulkinen {
 
       let apiAineistoNahtavilla: API.Aineisto[] | undefined = undefined;
       if (!isKuulutusNahtavillaVaiheOver(julkaisu)) {
-        apiAineistoNahtavilla = adaptAineistotJulkinen(dbProjekti.oid, aineistoNahtavilla, paths);
+        apiAineistoNahtavilla = adaptAineistotJulkinen(aineistoNahtavilla, paths);
       }
 
       const julkaisuJulkinen: API.NahtavillaoloVaiheJulkaisuJulkinen = {
@@ -273,9 +272,9 @@ class ProjektiAdapterJulkinen {
   }
 
   private static adaptHyvaksymisPaatosVaihe(
-    dbProjekti: DBProjekti,
     paatosVaiheJulkaisut: HyvaksymisPaatosVaiheJulkaisu[] | undefined | null,
-    hyvaksymispaatos: Hyvaksymispaatos | undefined | null
+    hyvaksymispaatos: Hyvaksymispaatos | undefined | null,
+    getPathCallback: (julkaisu: HyvaksymisPaatosVaiheJulkaisu) => PathTuple
   ): API.HyvaksymisPaatosVaiheJulkaisuJulkinen | undefined {
     const julkaisu = findApprovedHyvaksymisPaatosVaihe(paatosVaiheJulkaisut);
     if (julkaisu) {
@@ -310,13 +309,13 @@ class ProjektiAdapterJulkinen {
       if (!yhteystiedot) {
         throw new Error("adaptHyvaksymisPaatosVaihe: julkaisu.yhteystiedot määrittelemättä");
       }
-      const paths = new ProjektiPaths(dbProjekti.oid).hyvaksymisPaatosVaihe(julkaisu);
+      const paths = getPathCallback(julkaisu);
 
       let apiHyvaksymisPaatosAineisto: API.Aineisto[] | undefined = undefined;
       let apiAineistoNahtavilla: API.Aineisto[] | undefined = undefined;
       if (!isKuulutusNahtavillaVaiheOver(julkaisu)) {
-        apiHyvaksymisPaatosAineisto = adaptAineistotJulkinen(dbProjekti.oid, hyvaksymisPaatos, paths);
-        apiAineistoNahtavilla = adaptAineistotJulkinen(dbProjekti.oid, aineistoNahtavilla, paths);
+        apiHyvaksymisPaatosAineisto = adaptAineistotJulkinen(hyvaksymisPaatos, paths);
+        apiAineistoNahtavilla = adaptAineistotJulkinen(aineistoNahtavilla, paths);
       }
       return {
         __typename: "HyvaksymisPaatosVaiheJulkaisuJulkinen",
@@ -379,15 +378,13 @@ function isUnsetOrInPast(julkaisuPaiva?: dayjs.Dayjs) {
 
 /**
  *
- * @param oid
  * @param aineistot
  * @param paths
  * @param julkaisuPaiva Jos ei asetettu, aineistolla ei ole ajastettua julkaisua, joten se on aina julkista
  */
 function adaptAineistotJulkinen(
-  oid: string,
   aineistot: Aineisto[] | null | undefined,
-  paths: PathTuple | undefined,
+  paths: PathTuple,
   julkaisuPaiva?: Dayjs
 ): API.Aineisto[] | undefined {
   if (isUnsetOrInPast(julkaisuPaiva) && aineistot && aineistot.length > 0) {
@@ -398,11 +395,7 @@ function adaptAineistotJulkinen(
           throw new Error("adaptAineistotJulkinen: aineisto.tiedosto määrittelemättä");
         }
         const { nimi, dokumenttiOid, jarjestys, kategoriaId } = aineisto;
-        let publicFilePath = aineisto.tiedosto;
-        if (paths) {
-          publicFilePath = aineisto.tiedosto.replace(paths.yllapitoPath, paths.publicPath);
-        } // Replace ylläpito path with public path
-        const tiedosto = fileService.getPublicPathForProjektiFile(oid, publicFilePath);
+        const tiedosto = fileService.getPublicPathForProjektiFile(paths, aineisto.tiedosto);
         return {
           __typename: "Aineisto",
           dokumenttiOid,
@@ -431,6 +424,7 @@ function adaptVuorovaikutukset(dbProjekti: DBProjekti): API.VuorovaikutusJulkine
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const julkaisuPaiva = parseDate(vuorovaikutus.vuorovaikutusJulkaisuPaiva);
+      const vuorovaikutusPaths = new ProjektiPaths(dbProjekti.oid).vuorovaikutus(vuorovaikutus);
       const vuorovaikutusJulkinen: API.VuorovaikutusJulkinen = {
         __typename: "VuorovaikutusJulkinen",
         vuorovaikutusNumero: vuorovaikutus.vuorovaikutusNumero,
@@ -439,10 +433,10 @@ function adaptVuorovaikutukset(dbProjekti: DBProjekti): API.VuorovaikutusJulkine
         vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(vuorovaikutus.vuorovaikutusTilaisuudet, dbProjekti),
         videot: adaptLinkkiListByAddingTypename(vuorovaikutus.videot),
         suunnittelumateriaali: adaptLinkkiByAddingTypename(vuorovaikutus.suunnittelumateriaali),
-        esittelyaineistot: adaptAineistotJulkinen(dbProjekti.oid, vuorovaikutus.esittelyaineistot, undefined, julkaisuPaiva),
-        suunnitelmaluonnokset: adaptAineistotJulkinen(dbProjekti.oid, vuorovaikutus.suunnitelmaluonnokset, undefined, julkaisuPaiva),
+        esittelyaineistot: adaptAineistotJulkinen(vuorovaikutus.esittelyaineistot, vuorovaikutusPaths.aineisto, julkaisuPaiva),
+        suunnitelmaluonnokset: adaptAineistotJulkinen(vuorovaikutus.suunnitelmaluonnokset, vuorovaikutusPaths.aineisto, julkaisuPaiva),
         yhteystiedot: adaptStandardiYhteystiedotToAPIYhteystiedot(dbProjekti, vuorovaikutus.esitettavatYhteystiedot, true),
-        vuorovaikutusPDFt: adaptVuorovaikutusPDFPaths(dbProjekti.oid, vuorovaikutus.vuorovaikutusPDFt),
+        vuorovaikutusPDFt: adaptVuorovaikutusPDFPaths(dbProjekti.oid, vuorovaikutus),
       };
       return vuorovaikutusJulkinen;
     });
@@ -517,10 +511,8 @@ function isKuulutusNahtavillaVaiheOver(
   return !nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva || parseDate(nahtavillaoloVaihe.kuulutusVaihePaattyyPaiva).isBefore(dayjs());
 }
 
-function adaptVuorovaikutusPDFPaths(
-  oid: string,
-  vuorovaikutuspdfs: LocalizedMap<VuorovaikutusPDF> | undefined
-): API.VuorovaikutusPDFt | undefined {
+function adaptVuorovaikutusPDFPaths(oid: string, vuorovaikutus: Vuorovaikutus): API.VuorovaikutusPDFt | undefined {
+  const vuorovaikutuspdfs = vuorovaikutus.vuorovaikutusPDFt;
   if (!vuorovaikutuspdfs) {
     return undefined;
   }
@@ -533,7 +525,7 @@ function adaptVuorovaikutusPDFPaths(
     if (pdfs) {
       result[kieli as API.Kieli] = {
         __typename: "VuorovaikutusPDF",
-        kutsuPDFPath: fileService.getPublicPathForProjektiFile(oid, pdfs.kutsuPDFPath),
+        kutsuPDFPath: fileService.getPublicPathForProjektiFile(new ProjektiPaths(oid).vuorovaikutus(vuorovaikutus), pdfs.kutsuPDFPath),
       };
     }
   }

--- a/backend/src/vuorovaikutus/vuorovaikutusService.ts
+++ b/backend/src/vuorovaikutus/vuorovaikutusService.ts
@@ -4,7 +4,7 @@ import { DBProjekti, IlmoituksenVastaanottajat, Vuorovaikutus } from "../databas
 import { fileService } from "../files/fileService";
 import { projektiDatabase } from "../database/projektiDatabase";
 import { emailClient } from "../email/email";
-import { ProjektiPaths } from "../files/ProjektiPath";
+import { PathTuple, ProjektiPaths } from "../files/ProjektiPath";
 import assert from "assert";
 import { pdfGeneratorClient } from "../asiakirja/lambda/pdfGeneratorClient";
 import { AsiakirjanMuoto, determineAsiakirjaMuoto } from "../asiakirja/asiakirjaTypes";
@@ -15,7 +15,7 @@ async function generateKutsuPDF(
   projektiInDB: DBProjekti,
   vuorovaikutus: Vuorovaikutus,
   kieli: API.Kieli,
-  vuorovaikutusKutsuPath: string
+  vuorovaikutusKutsuPath: PathTuple
 ) {
   const velho = projektiInDB.velho;
   const kielitiedot = projektiInDB.kielitiedot;
@@ -38,7 +38,7 @@ async function generateKutsuPDF(
 
   const fullFilePathInProjekti = await fileService.createFileToProjekti({
     oid,
-    filePathInProjekti: vuorovaikutusKutsuPath,
+    path: vuorovaikutusKutsuPath,
     fileName: pdf.nimi,
     contents: Buffer.from(pdf.sisalto, "base64"),
     inline: true,
@@ -66,7 +66,7 @@ class VuorovaikutusService {
     if (!projektiInDB.kielitiedot) {
       throw new Error(`handleVuorovaikutsuKutsu: projektille oid:lla ${oid} ei löydy kielitietoja`);
     }
-    const vuorovaikutusKutsuPath: string = new ProjektiPaths(oid).vuorovaikutus(vuorovaikutus).yllapitoPath + "/kutsu";
+    const vuorovaikutusKutsuPath = new ProjektiPaths(oid).vuorovaikutus(vuorovaikutus).kutsu;
 
     const attachments = [];
 

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -335,6 +335,7 @@ Array [
         "SAAME": "Saameksi",
         "SUOMI": "Lorem Ipsum",
       },
+      "id": 1,
       "ilmoituksenVastaanottajat": Object {
         "kunnat": Array [
           Object {
@@ -575,73 +576,10 @@ exports[`apiHandler handleEvent tallennaProjekti should modify permissions from 
 Object {
   "args": Array [
     Object {
-      "Bucket": "hassu-localstack-public",
+      "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
       "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-public",
-      "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
-      "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-public",
-      "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
-      "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-public",
-      "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
-      "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-public",
-      "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
-      "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-public",
-      "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
-      "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-public",
-      "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
-      "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-public",
-      "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
-      "ContentType": "application/pdf",
-      "Key": "tiedostot/suunnitelma/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -650,7 +588,7 @@ Object {
       "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
       "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -659,7 +597,7 @@ Object {
       "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
       "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -668,16 +606,7 @@ Object {
       "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
       "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
-      "Metadata": Object {
-        "publication-timestamp": "2022-01-02T00:00:00+02:00",
-      },
-    },
-    Object {
-      "Bucket": "hassu-localstack-yllapito",
-      "ContentDisposition": "inline; filename*=UTF-8''T412%20Aloituskuulutus.pdf",
-      "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -686,7 +615,7 @@ Object {
       "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
       "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -695,7 +624,7 @@ Object {
       "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
       "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -704,7 +633,7 @@ Object {
       "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
       "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -713,7 +642,7 @@ Object {
       "Bucket": "hassu-localstack-yllapito",
       "ContentDisposition": "inline; filename*=UTF-8''T412_1%20Ilmoitus%20aloituskuulutuksesta.pdf",
       "ContentType": "application/pdf",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
       "Metadata": Object {
         "publication-timestamp": "2022-01-02T00:00:00+02:00",
       },
@@ -743,11 +672,11 @@ Object {
   "args": Array [
     Object {
       "Bucket": "hassu-localstack-yllapito",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
     },
     Object {
       "Bucket": "hassu-localstack-yllapito",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
     },
   ],
   "stub": "getObject",
@@ -769,19 +698,19 @@ Object {
   "args": Array [
     Object {
       "Bucket": "hassu-localstack-yllapito",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
     },
     Object {
       "Bucket": "hassu-localstack-yllapito",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
     },
     Object {
       "Bucket": "hassu-localstack-yllapito",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
     },
     Object {
       "Bucket": "hassu-localstack-yllapito",
-      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+      "Key": "yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
     },
   ],
   "stub": "deleteObject",
@@ -856,8 +785,8 @@ Object {
     "aloituskuulutusPDFt": Object {
       "SUOMI": Object {
         "__typename": "AloitusKuulutusPDF",
-        "aloituskuulutusIlmoitusPDFPath": "/yllapito/tiedostot/projekti/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-        "aloituskuulutusPDFPath": "/yllapito/tiedostot/projekti/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+        "aloituskuulutusIlmoitusPDFPath": "/yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+        "aloituskuulutusPDFPath": "/yllapito/tiedostot/projekti/1/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
       },
       "__typename": "AloitusKuulutusPDFt",
     },

--- a/backend/test/apiHandler.test.ts
+++ b/backend/test/apiHandler.test.ts
@@ -209,8 +209,8 @@ describe("apiHandler", () => {
                   ...julkaisu,
                   aloituskuulutusPDFt: {
                     SUOMI: {
-                      aloituskuulutusIlmoitusPDFPath: "/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-                      aloituskuulutusPDFPath: "/aloituskuulutus/T412 Aloituskuulutus.pdf",
+                      aloituskuulutusIlmoitusPDFPath: "/aloituskuulutus/1/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
+                      aloituskuulutusPDFPath: "/aloituskuulutus/1/T412 Aloituskuulutus.pdf",
                     },
                   },
                 },

--- a/backend/test/apiHandler.test.ts
+++ b/backend/test/apiHandler.test.ts
@@ -32,6 +32,7 @@ import { handleEvent as pdfGenerator } from "../src/asiakirja/lambda/pdfGenerato
 import { getS3 } from "../src/aws/client";
 import { awsMockResolves, expectAwsCalls } from "./aws/awsMock";
 import { kuntametadata } from "../../common/kuntametadata";
+import { aineistoService } from "../src/aineisto/aineistoService";
 
 const { expect, assert } = require("chai");
 
@@ -60,6 +61,7 @@ describe("apiHandler", () => {
   let persistFileToProjektiStub: sinon.SinonStub;
   let sendEmailStub: sinon.SinonStub;
   let pdfGeneratorLambdaStub: sinon.SinonStub;
+  let aineistoServiceStub: sinon.SinonStub;
 
   before(() => {
     userFixture = new UserFixture(userService);
@@ -84,6 +86,11 @@ describe("apiHandler", () => {
     sendEmailStub.resolves();
 
     pdfGeneratorLambdaStub = sinon.stub(pdfGeneratorClient, "generatePDF");
+
+    aineistoServiceStub = sinon.stub(aineistoService, "synchronizeProjektiFiles");
+    aineistoServiceStub.callsFake(async () => {
+      console.log("Synkataan aineisto");
+    });
   });
 
   after(() => {

--- a/backend/test/aws/awsMock.ts
+++ b/backend/test/aws/awsMock.ts
@@ -13,6 +13,9 @@ export function awsMockResolves<T>(stub: sinon.SinonStub, returnValue?: T): void
 
 export function expectAwsCalls(stub: sinon.SinonStub, ...cleanupFieldNames: string[]): void {
   const calls = stub.getCalls();
+  if (calls.length == 0) {
+    return;
+  }
   const args = calls
     .map((call) => {
       const { Body: _Body, ...rest } = call.args[0];

--- a/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
+++ b/backend/test/database/__snapshots__/projektiDatabase.test.ts.snap
@@ -20,6 +20,7 @@ Object {
         "SAAME": "Saameksi",
         "SUOMI": "Lorem Ipsum",
       },
+      "id": 1,
       "kuulutusPaiva": "2022-01-02",
       "kuulutusYhteystiedot": Object {
         "yhteysTiedot": Array [

--- a/backend/test/files/__snapshots__/fileService.test.ts.snap
+++ b/backend/test/files/__snapshots__/fileService.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "Bucket": "hassu-localstack-yllapito",
     "ContentDisposition": "inline; filename*=UTF-8''test%20%C3%A4%C3%A4kk%C3%B6sill%C3%A4.pdf",
     "ContentType": "application/pdf",
-    "Key": "yllapito/tiedostot/projekti/1/testfilepath/test ääkkösillä.pdf",
+    "Key": "yllapito/tiedostot/projekti/1/test ääkkösillä.pdf",
     "Metadata": Object {
       "publication-timestamp": "2000-01-01T12:34:00+02:00",
     },

--- a/backend/test/files/__snapshots__/projektiPaths.test.ts.snap
+++ b/backend/test/files/__snapshots__/projektiPaths.test.ts.snap
@@ -5,23 +5,61 @@ Array [
   "tiedostot/suunnitelma/123",
   "tiedostot/suunnitelma/123/suunnitteluvaihe/vuorovaikutus_456",
   "tiedostot/suunnitelma/123/suunnitteluvaihe/vuorovaikutus_456/aineisto",
+  "tiedostot/suunnitelma/123/suunnitteluvaihe/vuorovaikutus_456/kutsu",
   "tiedostot/suunnitelma/123/nahtavillaolo",
+  "tiedostot/suunnitelma/123/hyvaksymispaatos",
+  "tiedostot/suunnitelma/123/hyvaksymispaatos/paatos",
+  "tiedostot/suunnitelma/123/jatkopaatos1",
+  "tiedostot/suunnitelma/123/jatkopaatos1/paatos",
+  "tiedostot/suunnitelma/123/jatkopaatos2",
+  "tiedostot/suunnitelma/123/jatkopaatos2/paatos",
 ]
 `;
 
 exports[`ProjektiPaths should create public projekti relative paths successfully 1`] = `
 Array [
-  "tiedostot/suunnitelma/123",
+  "",
   "suunnitteluvaihe/vuorovaikutus_456",
   "suunnitteluvaihe/vuorovaikutus_456/aineisto",
+  "suunnitteluvaihe/vuorovaikutus_456/kutsu",
   "nahtavillaolo",
+  "hyvaksymispaatos",
+  "hyvaksymispaatos/paatos",
+  "jatkopaatos1",
+  "jatkopaatos1/paatos",
+  "jatkopaatos2",
+  "jatkopaatos2/paatos",
+]
+`;
+
+exports[`ProjektiPaths should create yllapito full paths successfully 1`] = `
+Array [
+  "yllapito/tiedostot/projekti/123",
+  "yllapito/tiedostot/projekti/123/suunnitteluvaihe/vuorovaikutus_456",
+  "yllapito/tiedostot/projekti/123/suunnitteluvaihe/vuorovaikutus_456/kutsu",
+  "yllapito/tiedostot/projekti/123/suunnitteluvaihe/vuorovaikutus_456/aineisto",
+  "yllapito/tiedostot/projekti/123/nahtavillaolo/7",
+  "yllapito/tiedostot/projekti/123/hyvaksymispaatos/8",
+  "yllapito/tiedostot/projekti/123/hyvaksymispaatos/8/paatos",
+  "yllapito/tiedostot/projekti/123/jatkopaatos1/8",
+  "yllapito/tiedostot/projekti/123/jatkopaatos1/8/paatos",
+  "yllapito/tiedostot/projekti/123/jatkopaatos2/8",
+  "yllapito/tiedostot/projekti/123/jatkopaatos2/8/paatos",
 ]
 `;
 
 exports[`ProjektiPaths should create yllapito paths successfully 1`] = `
 Array [
-  "yllapito/tiedostot/projekti/123",
+  "",
   "suunnitteluvaihe/vuorovaikutus_456",
+  "suunnitteluvaihe/vuorovaikutus_456/kutsu",
+  "suunnitteluvaihe/vuorovaikutus_456/aineisto",
   "nahtavillaolo/7",
+  "hyvaksymispaatos/8",
+  "hyvaksymispaatos/8/paatos",
+  "jatkopaatos1/8",
+  "jatkopaatos1/8/paatos",
+  "jatkopaatos2/8",
+  "jatkopaatos2/8/paatos",
 ]
 `;

--- a/backend/test/files/fileService.test.ts
+++ b/backend/test/files/fileService.test.ts
@@ -6,6 +6,7 @@ import { uuid } from "../../src/util/uuid";
 import { parseDate } from "../../src/util/dateUtil";
 import { getS3 } from "../../src/aws/client";
 import { awsMockResolves, expectAwsCalls } from "../aws/awsMock";
+import { ProjektiPaths } from "../../src/files/ProjektiPath";
 
 const { expect } = require("chai");
 
@@ -55,14 +56,14 @@ describe("UploadService", () => {
 
     const pathInProjekti = await fileService.createFileToProjekti({
       oid: "1",
-      filePathInProjekti: "testfilepath",
+      path: new ProjektiPaths("1"),
       fileName: "test ääkkösillä.pdf",
       contents: Buffer.from("foobar", "base64"),
       inline: true,
       contentType: "application/pdf",
       publicationTimestamp: parseDate("2000-01-01T12:34"),
     });
-    expect(pathInProjekti).to.eq("/testfilepath/test ääkkösillä.pdf");
+    expect(pathInProjekti).to.eq("/test ääkkösillä.pdf");
 
     expect(putObjectStub).to.be.calledOnce;
     expectAwsCalls(putObjectStub);

--- a/backend/test/files/projektiPaths.test.ts
+++ b/backend/test/files/projektiPaths.test.ts
@@ -9,7 +9,31 @@ describe("ProjektiPaths", () => {
     expect([
       new ProjektiPaths("123").yllapitoPath,
       new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).yllapitoPath,
+      new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).kutsu.yllapitoPath,
+      new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).aineisto.yllapitoPath,
       new ProjektiPaths("123").nahtavillaoloVaihe({ id: 7 }).yllapitoPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).yllapitoPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).paatos.yllapitoPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).yllapitoPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).paatos.yllapitoPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).yllapitoPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).paatos.yllapitoPath,
+    ]).toMatchSnapshot();
+  });
+
+  it("should create yllapito full paths successfully", function () {
+    expect([
+      new ProjektiPaths("123").yllapitoFullPath,
+      new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).yllapitoFullPath,
+      new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).kutsu.yllapitoFullPath,
+      new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).aineisto.yllapitoFullPath,
+      new ProjektiPaths("123").nahtavillaoloVaihe({ id: 7 }).yllapitoFullPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).yllapitoFullPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).paatos.yllapitoFullPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).yllapitoFullPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).paatos.yllapitoFullPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).yllapitoFullPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).paatos.yllapitoFullPath,
     ]).toMatchSnapshot();
   });
 
@@ -18,7 +42,14 @@ describe("ProjektiPaths", () => {
       new ProjektiPaths("123").publicPath,
       new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).publicPath,
       new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).aineisto.publicPath,
+      new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).kutsu.publicPath,
       new ProjektiPaths("123").nahtavillaoloVaihe({ id: 7 }).publicPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).publicPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).paatos.publicPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).publicPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).paatos.publicPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).publicPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).paatos.publicPath,
     ]).toMatchSnapshot();
   });
 
@@ -27,7 +58,14 @@ describe("ProjektiPaths", () => {
       new ProjektiPaths("123").publicFullPath,
       new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).publicFullPath,
       new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).aineisto.publicFullPath,
+      new ProjektiPaths("123").vuorovaikutus({ vuorovaikutusNumero: 456 }).kutsu.publicFullPath,
       new ProjektiPaths("123").nahtavillaoloVaihe({ id: 7 }).publicFullPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).publicFullPath,
+      new ProjektiPaths("123").hyvaksymisPaatosVaihe({ id: 8 }).paatos.publicFullPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).publicFullPath,
+      new ProjektiPaths("123").jatkoPaatos1Vaihe({ id: 8 }).paatos.publicFullPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).publicFullPath,
+      new ProjektiPaths("123").jatkoPaatos2Vaihe({ id: 8 }).paatos.publicFullPath,
     ]).toMatchSnapshot();
   });
 });

--- a/backend/test/fixture/projektiFixture.ts
+++ b/backend/test/fixture/projektiFixture.ts
@@ -238,6 +238,7 @@ export class ProjektiFixture {
         logo: "logo.gif",
       },
       aloitusKuulutus: {
+        id: 1,
         kuulutusPaiva: "2022-01-02",
         hankkeenKuvaus: {
           SUOMI: "Lorem Ipsum",
@@ -345,6 +346,7 @@ export class ProjektiFixture {
         },
       ],
       aloitusKuulutus: {
+        id: 1,
         hankkeenKuvaus: {
           SUOMI:
             "Suunnittelu kohde on osa Hyvinkää-Hanko sähköistyshanketta, jossa toteutetaan myös tasoristeysten toimenpiteitä. Hyväksytyssä ratasuunnitelmassa kyseisessä kohdassa on hyväksytty suunnitelmaratkaisuna Kisan seisakkeen ja Leksvallin tasoristeysten poistaminen parantamalla Helmströmin tasoristeyksen kohdalle uusi tasoristeys. Nyt käynnistetään Rata-suunnitelman päivitys kyseisessä kohdassa ja suunnitellaan kaikkien kolmen tasoristeyksen poistaminen uudella Leksvallin ylikulkusillalla.",
@@ -515,6 +517,7 @@ export class ProjektiFixture {
       },
     ],
     aloitusKuulutus: {
+      id: 1,
       hankkeenKuvaus: {
         SUOMI:
           "Suunnittelu kohde on osa Hyvinkää-Hanko sähköistyshanketta, jossa toteutetaan myös tasoristeysten toimenpiteitä. Hyväksytyssä ratasuunnitelmassa kyseisessä kohdassa on hyväksytty suunnitelmaratkaisuna Kisan seisakkeen ja Leksvallin tasoristeysten poistaminen parantamalla Helmströmin tasoristeyksen kohdalle uusi tasoristeys. Nyt käynnistetään Rata-suunnitelman päivitys kyseisessä kohdassa ja suunnitellaan kaikkien kolmen tasoristeyksen poistaminen uudella Leksvallin ylikulkusillalla.",

--- a/backend/test/projektiSearch/projektiSearchService2.test.ts
+++ b/backend/test/projektiSearch/projektiSearchService2.test.ts
@@ -76,6 +76,7 @@ const projektiKunSuunnitteluvaiheOnTallennettuJulkaistavaksi: DBProjekti = {
   tyyppi: ProjektiTyyppi.TIE,
   suunnittelustaVastaavaViranomainen: undefined,
   aloitusKuulutus: {
+    id: 1,
     kuulutusPaiva: "2022-10-10",
     siirtyySuunnitteluVaiheeseen: "2022-11-09",
     hankkeenKuvaus: {

--- a/cypress/integration/2-perusta-projekti/008-nahtavillaolovaihe-perustiedot.spec.js
+++ b/cypress/integration/2-perusta-projekti/008-nahtavillaolovaihe-perustiedot.spec.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 import { typeIntoFields } from "../../support/util";
 import { ProjektiTestCommand } from "../../../common/testUtil.dev";
-import { hyvaksyNahtavillaoloKuulutus, lisaaNahtavillaoloAineistot, taytaNahtavillaoloPerustiedot } from './nahtavillaolo';
+import { hyvaksyNahtavillaoloKuulutus, lisaaNahtavillaoloAineistot, taytaNahtavillaoloPerustiedot } from '../../support/nahtavillaolo';
 
 const oid = Cypress.env("oid");
 const projektiNimi = Cypress.env("projektiNimi");

--- a/cypress/integration/2-perusta-projekti/009-hyvaksyntavaihe.spec.js
+++ b/cypress/integration/2-perusta-projekti/009-hyvaksyntavaihe.spec.js
@@ -2,7 +2,7 @@
 import dayjs from "dayjs";
 import { formatDate } from "../../../src/util/dateUtils";
 import { ProjektiTestCommand } from "../../../common/testUtil.dev";
-import { lisaaPaatosJaAineistot, tallennaKasittelynTilaJaSiirraMenneisyyteen } from "./hyvaksyntavaihe";
+import { lisaaPaatosJaAineistot, tallennaKasittelynTilaJaSiirraMenneisyyteen } from "../../support/hyvaksyntavaihe";
 
 const projektiNimi = Cypress.env("projektiNimi");
 const oid = Cypress.env("oid");

--- a/cypress/integration/2-perusta-projekti/009-hyvaksyntavaihe.spec.js
+++ b/cypress/integration/2-perusta-projekti/009-hyvaksyntavaihe.spec.js
@@ -21,12 +21,12 @@ describe("9 - Projektin hyvaksymispaatosavaiheen kuulutustiedot", () => {
   it("Tallenna kasittelyn tila ja siirra menneisyyteen", { scrollBehavior: "center" }, () => {
     cy.login("A1");
 
-    cy.visit(Cypress.env("host") + ProjektiTestCommand.oid(oid).resetHyvaksymisvaihe(), { timeout: 30000 });
     cy.visit(Cypress.env("host") + "/yllapito/projekti/" + oid + "/kasittelyntila", {
       timeout: 30000,
       retryOnNetworkFailure: true,
       retryOnStatusCodeFailure: true,
     });
+    cy.visit(Cypress.env("host") + ProjektiTestCommand.oid(oid).resetHyvaksymisvaihe(), { timeout: 30000 });
     cy.reload(); // extra reload to avoid white page
 
     tallennaKasittelynTilaJaSiirraMenneisyyteen(oid, projektiNimi, asianumero);

--- a/cypress/integration/2-perusta-projekti/011-jatkopaatos.spec.js
+++ b/cypress/integration/2-perusta-projekti/011-jatkopaatos.spec.js
@@ -8,7 +8,7 @@ const projektiNimi = Cypress.env("projektiNimi");
 const oid = Cypress.env("oid");
 const asianumero = "VÄYLÄ/1234/03.04.05/2023";
 
-describe("10 - Projektin jatkopaatos1vaiheen kuulutustiedot", () => {
+describe("11 - Projektin jatkopaatos1vaiheen kuulutustiedot", () => {
   before(() => {
     cy.abortEarly();
   });

--- a/cypress/integration/4-migraatio/1-migraatio.spec.js
+++ b/cypress/integration/4-migraatio/1-migraatio.spec.js
@@ -13,8 +13,8 @@ import {
   hyvaksyNahtavillaoloKuulutus,
   lisaaNahtavillaoloAineistot,
   taytaNahtavillaoloPerustiedot,
-} from "../2-perusta-projekti/nahtavillaolo";
-import { lisaaPaatosJaAineistot, tallennaKasittelynTilaJaSiirraMenneisyyteen } from "../2-perusta-projekti/hyvaksyntavaihe";
+} from "../../support/nahtavillaolo";
+import { lisaaPaatosJaAineistot, tallennaKasittelynTilaJaSiirraMenneisyyteen } from "../../support/hyvaksyntavaihe";
 import { formatDate } from "../../../src/util/dateUtils";
 import dayjs from "dayjs";
 

--- a/cypress/support/hyvaksyntavaihe.js
+++ b/cypress/support/hyvaksyntavaihe.js
@@ -1,6 +1,6 @@
-import { formatDate } from "../../../src/util/dateUtils";
+import { formatDate } from "../../src/util/dateUtils";
 import dayjs from "dayjs";
-import { selectAllAineistotFromCategory } from "../../support/util";
+import { selectAllAineistotFromCategory } from "./util";
 
 export function tallennaKasittelynTilaJaSiirraMenneisyyteen(oid, projektiNimi, asianumero) {
   cy.visit(Cypress.env("host") + "/yllapito/projekti/" + oid + "/kasittelyntila", {

--- a/cypress/support/nahtavillaolo.js
+++ b/cypress/support/nahtavillaolo.js
@@ -1,6 +1,6 @@
-import { formatDate } from "../../../src/util/dateUtils";
+import { formatDate } from "../../src/util/dateUtils";
 import dayjs from "dayjs";
-import { selectAllAineistotFromCategory, typeIntoFields } from "../../support/util";
+import { selectAllAineistotFromCategory, typeIntoFields } from "./util";
 
 export function taytaNahtavillaoloPerustiedot(oid, selectorToTextMap) {
   cy.get("#kuulutuksentiedot_tab").click();

--- a/src/components/projekti/HassuAineistoNimiExtLink.tsx
+++ b/src/components/projekti/HassuAineistoNimiExtLink.tsx
@@ -1,5 +1,5 @@
 import ExtLink from "@components/ExtLink";
-import { useProjekti } from "src/hooks/useProjekti";
+
 interface Props {
   addTopMargin?: boolean;
   tiedostoPolku?: string | null;
@@ -12,8 +12,7 @@ const HassuAineistoNimiExtLink = ({
   addTopMargin,
   ...extlinkProps
 }: Props & Omit<React.ComponentProps<typeof ExtLink>, "children">) => {
-  const { data: projekti } = useProjekti();
-  const href = tiedostoPolku && projekti ? `/yllapito/tiedostot/projekti/${projekti.oid}/${tiedostoPolku}` : undefined;
+  const href = tiedostoPolku || undefined;
   return (
     <ExtLink
       sx={addTopMargin ? { marginTop: 4 } : undefined}

--- a/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
+++ b/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
@@ -4,7 +4,6 @@ import Notification, { NotificationType } from "@components/notification/Notific
 import capitalize from "lodash/capitalize";
 import replace from "lodash/replace";
 import lowerCase from "lodash/lowerCase";
-import AloituskuulutusPDFEsikatselu from "./AloituskuulutusPDFEsikatselu";
 import AloituskuulutusTiedostot from "./AloituskuulutusTiedostot";
 import IlmoituksenVastaanottajat from "./IlmoituksenVastaanottajat";
 import { examineKuulutusPaiva } from "src/util/aloitusKuulutusUtil";
@@ -19,6 +18,8 @@ import { formatDate } from "../../../util/dateUtils";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
 import { formatNimi } from "../../../util/userUtil";
 import { yhteystietoVirkamiehelleTekstiksi } from "src/util/kayttajaTransformationUtil";
+import { Link } from "@mui/material";
+import { splitFilePath } from "src/util/fileUtil";
 
 interface Props {
   projekti?: ProjektiLisatiedolla;
@@ -42,6 +43,16 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
   const { ensisijainenKieli, toissijainenKieli } = aloituskuulutusjulkaisu.kielitiedot || {};
 
   const epaaktiivinen = projektiOnEpaaktiivinen(projekti);
+
+  const getPdft = (kieli: Kieli | undefined | null) => {
+    if (!aloituskuulutusjulkaisu || !aloituskuulutusjulkaisu.aloituskuulutusPDFt || !kieli) {
+      return undefined;
+    }
+    return aloituskuulutusjulkaisu.aloituskuulutusPDFt[kieli];
+  };
+
+  const ensisijaisetPDFt = getPdft(aloituskuulutusjulkaisu.kielitiedot?.ensisijainenKieli);
+  const toissijaisetPDFt = getPdft(aloituskuulutusjulkaisu.kielitiedot?.toissijainenKieli);
 
   return (
     <>
@@ -114,7 +125,44 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
       </Section>
       <Section>
         {aloituskuulutusjulkaisu.tila !== KuulutusJulkaisuTila.HYVAKSYTTY && (
-          <AloituskuulutusPDFEsikatselu oid={projekti.oid} aloituskuulutusjulkaisu={aloituskuulutusjulkaisu} />
+          <SectionContent>
+            <p className="vayla-label">Ladattavat kuulutukset ja ilmoitukset</p>
+            <p>Kuulutus ja ilmoitus ensisijaisella kielellä ({lowerCase(aloituskuulutusjulkaisu.kielitiedot?.ensisijainenKieli)})</p>
+            {ensisijaisetPDFt && (
+              <div className="flex flex-col mb-4">
+                <div>
+                  <Link underline="none" href={ensisijaisetPDFt.aloituskuulutusPDFPath} target="_blank">
+                    {splitFilePath(ensisijaisetPDFt.aloituskuulutusPDFPath).fileName}
+                  </Link>
+                </div>
+                <div>
+                  <Link underline="none" href={ensisijaisetPDFt.aloituskuulutusIlmoitusPDFPath} target="_blank">
+                    {splitFilePath(ensisijaisetPDFt.aloituskuulutusIlmoitusPDFPath).fileName}
+                  </Link>
+                </div>
+              </div>
+            )}
+
+            {aloituskuulutusjulkaisu.kielitiedot?.toissijainenKieli && (
+              <div className="content mb-4">
+                <p>Kuulutus ja ilmoitus toissijaisella kielellä ({lowerCase(aloituskuulutusjulkaisu.kielitiedot?.toissijainenKieli)})</p>
+                {toissijaisetPDFt && (
+                  <div className="flex flex-col">
+                    <div>
+                      <Link underline="none" href={toissijaisetPDFt.aloituskuulutusPDFPath} target="_blank">
+                        {splitFilePath(toissijaisetPDFt.aloituskuulutusPDFPath).fileName}
+                      </Link>
+                    </div>
+                    <div>
+                      <Link underline="none" href={toissijaisetPDFt.aloituskuulutusIlmoitusPDFPath} target="_blank">
+                        {splitFilePath(toissijaisetPDFt.aloituskuulutusIlmoitusPDFPath).fileName}
+                      </Link>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </SectionContent>
         )}
         {aloituskuulutusjulkaisu.tila === KuulutusJulkaisuTila.HYVAKSYTTY && (
           <AloituskuulutusTiedostot aloituskuulutusjulkaisu={aloituskuulutusjulkaisu} oid={projekti.oid} epaaktiivinen={epaaktiivinen} />

--- a/src/pages/api/test/[oid].dev.ts
+++ b/src/pages/api/test/[oid].dev.ts
@@ -53,14 +53,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   });
 
+  const jatkoPaatos2VaiheFields: Partial<DBProjekti> = {
+    jatkoPaatos2Vaihe: null,
+    jatkoPaatos2VaiheJulkaisut: null,
+  };
+
   const jatkoPaatos1VaiheFields: Partial<DBProjekti> = {
     jatkoPaatos1Vaihe: null,
     jatkoPaatos1VaiheJulkaisut: null,
+    ...jatkoPaatos2VaiheFields,
   };
 
   const hyvaksymisPaatosVaiheFields: Partial<DBProjekti> = {
     hyvaksymisPaatosVaihe: null,
     hyvaksymisPaatosVaiheJulkaisut: null,
+    ...jatkoPaatos1VaiheFields,
   };
 
   const nahtavillaoloVaiheFields: Partial<DBProjekti> = {

--- a/src/pages/suunnitelma/[oid]/suunnittelu.tsx
+++ b/src/pages/suunnitelma/[oid]/suunnittelu.tsx
@@ -154,7 +154,7 @@ const VuorovaikutusTiedot: FunctionComponent<{
                   <ExtLink
                     style={{ display: "block", marginTop: "0.5em" }}
                     key={aineisto.dokumenttiOid}
-                    href={`/tiedostot/suunnitelma/${projektiOid}${aineisto.tiedosto}`}
+                    href={aineisto.tiedosto}
                   >
                     {aineisto.tiedosto.split("/").reduce((_acc, cur) => cur, "")}
                   </ExtLink>
@@ -170,7 +170,7 @@ const VuorovaikutusTiedot: FunctionComponent<{
                   <ExtLink
                     style={{ display: "block", marginTop: "0.5em" }}
                     key={aineisto.dokumenttiOid}
-                    href={`/tiedostot/suunnitelma/${projektiOid}${aineisto.tiedosto}`}
+                    href={aineisto.tiedosto}
                   >
                     {aineisto.tiedosto.split("/").reduce((_acc, cur) => cur, "")}
                   </ExtLink>


### PR DESCRIPTION
* ProjektiPaths-luokka otettu käyttöön lähes kaikkialla polkujen muodostamista varten
* ProjektiPaths-luokan käyttöönotossa huomattu, että APIn palauttamat polut olivat mitä sattuu
* Uudelleenjulkaisun jälkeen kansalaispuolelle tulee nyt polut oikein
* Tiedostojen synkronointi toteutettu yhden tiskin periaatteella, eli koska tahansa kun synkronoinnin ajaa, lopputulos on se mitä haluttiin. Myöhemmin synkronointiajo ajastetaan uudelleenkuulutusten julkaisuaikojen, sekä epäaktiiviseksi siirtymisten mukaan