### PR TITLE
feat: estä suunnittelusop. muuttaminen a.k.:n julk. jälkeen

### DIFF
--- a/backend/src/projekti/adapter/adaptToDB/adaptSuunnitteluSopimusToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptSuunnitteluSopimusToSave.ts
@@ -9,5 +9,5 @@ export function adaptSuunnitteluSopimusToSave(
     const { logo, ...rest } = suunnitteluSopimusInput;
     return { ...rest, logo: logo || projekti.suunnitteluSopimus?.logo };
   }
-  return suunnitteluSopimusInput as undefined;
+  return suunnitteluSopimusInput;
 }

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -28,7 +28,6 @@ import {
 import { applyProjektiStatus } from "../status/projektiStatusHandler";
 import { adaptKasittelynTilaToSave } from "./adaptToDB/adaptKasittelynTilaToSave";
 import { ProjektiAdaptationResult } from "./projektiAdaptationResult";
-import { IllegalArgumentError } from "../../error/IllegalArgumentError";
 
 export class ProjektiAdapter {
   public adaptProjekti(dbProjekti: DBProjekti, virhetiedot?: API.ProjektiVirhe): API.Projekti {
@@ -173,18 +172,6 @@ export class ProjektiAdapter {
       }
     );
 
-    if (
-      (projekti.suunnitteluSopimus === null && !!dbProjekti.suunnitteluSopimus) ||
-      (!!dbProjekti.suunnitteluSopimus &&
-        !projekti.suunnitteluSopimus &&
-        [API.AloitusKuulutusTila.HYVAKSYTTY, API.AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA].includes(
-          projekti?.aloitusKuulutusJulkaisut?.[projekti.aloitusKuulutusJulkaisut.length - 1].tila as API.AloitusKuulutusTila
-        ))
-    ) {
-      throw new IllegalArgumentError(
-        "Suunnittelusopimuksen olemassaoloa ei voi muuttaa, jos aloituskuulutus on jo julkaistu tai se odottaa hyväksyntää!"
-      );
-    }
     projektiAdaptationResult.setProjekti(dbProjekti);
     return projektiAdaptationResult;
   }

--- a/backend/src/projekti/projektiValidator.ts
+++ b/backend/src/projekti/projektiValidator.ts
@@ -101,7 +101,7 @@ function validateUudelleenKuulutus(
 function validateSuunnitteluSopimus(dbProjekti: DBProjekti, input: TallennaProjektiInput) {
   const isSuunnitteluSopimusAddedOrDeleted =
     (input.suunnitteluSopimus === null && !!dbProjekti.suunnitteluSopimus) ||
-    (!!dbProjekti.suunnitteluSopimus && !input.suunnitteluSopimus);
+    (!!input.suunnitteluSopimus && !dbProjekti.suunnitteluSopimus);
 
   const latestAloituskuulutusJulkaisuTila = dbProjekti?.aloitusKuulutusJulkaisut?.[dbProjekti.aloitusKuulutusJulkaisut.length - 1].tila;
   const isLatestJulkaisuPendingApprovalOrApproved =

--- a/backend/src/projekti/projektiValidator.ts
+++ b/backend/src/projekti/projektiValidator.ts
@@ -1,5 +1,11 @@
 import { DBProjekti, UudelleenKuulutus } from "../database/model";
-import { KayttajaTyyppi, Projekti, TallennaProjektiInput, UudelleenKuulutusInput } from "../../../common/graphql/apiModel";
+import {
+  AloitusKuulutusTila,
+  KayttajaTyyppi,
+  Projekti,
+  TallennaProjektiInput,
+  UudelleenKuulutusInput,
+} from "../../../common/graphql/apiModel";
 import { requirePermissionMuokkaa } from "../user";
 import { requireAdmin, requireOmistaja } from "../user/userService";
 import { projektiAdapter } from "./adapter/projektiAdapter";
@@ -89,10 +95,31 @@ function validateUudelleenKuulutus(
   }
 }
 
+/**
+ * Validoi, että suunnittelusopimusta ei poisteta tai lisätä sen jälkeen kun aloituskuulutusjulkaisu on hyväksynnässä tai hyväksytty
+ */
+function validateSuunnitteluSopimus(dbProjekti: DBProjekti, input: TallennaProjektiInput) {
+  const isSuunnitteluSopimusAddedOrDeleted =
+    (input.suunnitteluSopimus === null && !!dbProjekti.suunnitteluSopimus) ||
+    (!!dbProjekti.suunnitteluSopimus && !input.suunnitteluSopimus);
+
+  const latestAloituskuulutusJulkaisuTila = dbProjekti?.aloitusKuulutusJulkaisut?.[dbProjekti.aloitusKuulutusJulkaisut.length - 1].tila;
+  const isLatestJulkaisuPendingApprovalOrApproved =
+    !!latestAloituskuulutusJulkaisuTila &&
+    [AloitusKuulutusTila.HYVAKSYTTY, AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA].includes(latestAloituskuulutusJulkaisuTila);
+
+  if (isSuunnitteluSopimusAddedOrDeleted && isLatestJulkaisuPendingApprovalOrApproved) {
+    throw new IllegalArgumentError(
+      "Suunnittelusopimuksen olemassaoloa ei voi muuttaa, jos aloituskuulutus on jo julkaistu tai se odottaa hyväksyntää!"
+    );
+  }
+}
+
 export function validateTallennaProjekti(projekti: DBProjekti, input: TallennaProjektiInput): void {
   requirePermissionMuokkaa(projekti);
   const apiProjekti = projektiAdapter.adaptProjekti(projekti);
   validateKasittelynTila(projekti, apiProjekti, input);
   validateVarahenkiloModifyPermissions(projekti, input);
   validateUudelleenKuulutus(projekti.aloitusKuulutus?.uudelleenKuulutus, input.aloitusKuulutus?.uudelleenKuulutus);
+  validateSuunnitteluSopimus(projekti, input);
 }

--- a/backend/test/projekti/projektiAdapter.test.ts
+++ b/backend/test/projekti/projektiAdapter.test.ts
@@ -98,4 +98,16 @@ describe("projektiAdapter", () => {
     });
     expect(result.projekti.suunnitteluVaihe).not.to.be.undefined;
   });
+
+  it("should prevent suunnittelusopimus from being removed if aloituskuulutus is published", async () => {
+    const projekti = fixture.dbProjekti2();
+
+    // Validate that there is an error if trying to publish suunnitteluvaihe before there is a published aloituskuulutusjulkaisu
+    expect(
+      projektiAdapter.adaptProjektiToSave(projekti, {
+        oid: projekti.oid,
+        suunnitteluSopimus: null,
+      })
+    ).to.be.rejectedWith(IllegalArgumentError);
+  });
 });

--- a/backend/test/projekti/projektiAdapter.test.ts
+++ b/backend/test/projekti/projektiAdapter.test.ts
@@ -8,7 +8,7 @@ import * as sinon from "sinon";
 import { personSearch } from "../../src/personSearch/personSearchClient";
 import { PersonSearchFixture } from "../personSearch/lambda/personSearchFixture";
 import { Kayttajas } from "../../src/personSearch/kayttajas";
-import { SuunnitteluVaiheTila } from "../../../common/graphql/apiModel";
+import { AloitusKuulutusTila, SuunnitteluVaiheTila } from "../../../common/graphql/apiModel";
 
 const { expect } = require("chai");
 
@@ -107,6 +107,90 @@ describe("projektiAdapter", () => {
       projektiAdapter.adaptProjektiToSave(projekti, {
         oid: projekti.oid,
         suunnitteluSopimus: null,
+      })
+    ).to.be.rejectedWith(IllegalArgumentError);
+  });
+
+  it("should allow suunnittelusopimus being removed if aloituskuulutus is not published", async () => {
+    const projekti = fixture.dbProjekti2();
+    delete projekti.aloitusKuulutusJulkaisut;
+
+    const result = await projektiAdapter.adaptProjektiToSave(projekti, {
+      oid: projekti.oid,
+      suunnitteluSopimus: null,
+    });
+    expect(result.projekti.suunnitteluSopimus).equals(null);
+  });
+
+  it("should precent suunnittelusopimus from being removed if latest aloituskuulutusjulkaisu is waiting for approval", async () => {
+    const projekti = fixture.dbProjekti2();
+    projekti.aloitusKuulutusJulkaisut?.push({
+      ...projekti.aloitusKuulutusJulkaisut[projekti.aloitusKuulutusJulkaisut.length - 1],
+      tila: AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA,
+    });
+
+    // Validate that there is an error if trying to publish suunnitteluvaihe before there is a published aloituskuulutusjulkaisu
+    expect(
+      projektiAdapter.adaptProjektiToSave(projekti, {
+        oid: projekti.oid,
+        suunnitteluSopimus: null,
+      })
+    ).to.be.rejectedWith(IllegalArgumentError);
+  });
+
+  it("should prevent suunnittelusopimus from being added if aloituskuulutus is published", async () => {
+    const projekti = fixture.dbProjekti2();
+    delete projekti.suunnitteluSopimus;
+    // Validate that there is an error if trying to publish suunnitteluvaihe before there is a published aloituskuulutusjulkaisu
+    expect(
+      projektiAdapter.adaptProjektiToSave(projekti, {
+        oid: projekti.oid,
+        suunnitteluSopimus: {
+          kunta: 1,
+          logo: "123.jpg",
+          yhteysHenkilo: fixture.mattiMeikalainenDBVaylaUser().kayttajatunnus,
+        },
+      })
+    ).to.be.rejectedWith(IllegalArgumentError);
+  });
+
+  it("should allow suunnittelusopimus being added if aloituskuulutus is not published", async () => {
+    const projekti = fixture.dbProjekti2();
+    delete projekti.suunnitteluSopimus;
+    delete projekti.aloitusKuulutusJulkaisut;
+
+    const result = await projektiAdapter.adaptProjektiToSave(projekti, {
+      oid: projekti.oid,
+      suunnitteluSopimus: {
+        kunta: 1,
+        logo: "123.jpg",
+        yhteysHenkilo: fixture.mattiMeikalainenDBVaylaUser().kayttajatunnus,
+      },
+    });
+    expect(result.projekti.suunnitteluSopimus).to.be.eql({
+      kunta: 1,
+      logo: "123.jpg",
+      yhteysHenkilo: fixture.mattiMeikalainenDBVaylaUser().kayttajatunnus,
+    });
+  });
+
+  it("should precent suunnittelusopimus from being removed if latest aloituskuulutusjulkaisu is waiting for approval", async () => {
+    const projekti = fixture.dbProjekti2();
+    delete projekti.suunnitteluSopimus;
+    projekti.aloitusKuulutusJulkaisut?.push({
+      ...projekti.aloitusKuulutusJulkaisut[projekti.aloitusKuulutusJulkaisut.length - 1],
+      tila: AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA,
+    });
+
+    // Validate that there is an error if trying to publish suunnitteluvaihe before there is a published aloituskuulutusjulkaisu
+    expect(
+      projektiAdapter.adaptProjektiToSave(projekti, {
+        oid: projekti.oid,
+        suunnitteluSopimus: {
+          kunta: 1,
+          logo: "123.jpg",
+          yhteysHenkilo: fixture.mattiMeikalainenDBVaylaUser().kayttajatunnus,
+        },
       })
     ).to.be.rejectedWith(IllegalArgumentError);
   });

--- a/src/components/projekti/ProjektiSunnittelusopimusTiedot.tsx
+++ b/src/components/projekti/ProjektiSunnittelusopimusTiedot.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useEffect, useState } from "react";
-import { Projekti } from "@services/api";
+import { AloitusKuulutusTila, Projekti } from "@services/api";
 import RadioButton from "@components/form/RadioButton";
 import Select, { SelectOption } from "@components/form/Select";
 import { Controller, useFormContext } from "react-hook-form";
@@ -14,6 +14,7 @@ import HassuStack from "@components/layout/HassuStack";
 import useTranslation from "next-translate/useTranslation";
 import { kuntametadata } from "../../../common/kuntametadata";
 import { formatNimi } from "../../util/userUtil";
+import Notification, { NotificationType } from "@components/notification/Notification";
 
 interface Props {
   projekti?: Projekti | null;
@@ -33,6 +34,12 @@ export default function ProjektiPerustiedot({ projekti }: Props): ReactElement {
   const [kuntaOptions, setKuntaOptions] = useState<SelectOption[]>([]);
   const { lang } = useTranslation();
 
+  const disabled = !!(
+    projekti?.aloitusKuulutusJulkaisu &&
+    projekti?.aloitusKuulutusJulkaisu.tila &&
+    [AloitusKuulutusTila.HYVAKSYTTY, AloitusKuulutusTila.ODOTTAA_HYVAKSYNTAA].includes(projekti.aloitusKuulutusJulkaisu.tila)
+  );
+
   useEffect(() => {
     setKuntaOptions(kuntametadata.kuntaOptions(lang));
   }, [lang]);
@@ -49,12 +56,19 @@ export default function ProjektiPerustiedot({ projekti }: Props): ReactElement {
   return (
     <Section smallGaps>
       <h4 className="vayla-small-title">Suunnittelusopimus</h4>
+      {disabled && (
+        <Notification type={NotificationType.INFO}>
+          Et voi muuttaa suunnittelusopimuksen olemassaoloa, koska aloituskuulutus on julkaistu tai odottaa hyväksyntää. Voit kuitenkin
+          muuttaa kunnan edustajan tietoja.
+        </Notification>
+      )}
       <FormGroup
         label="Onko kyseessä suunnittelusopimuksella toteutettava suunnitteluhanke? *"
         flexDirection="row"
         errorMessage={errors.suunnittelusopimusprojekti?.message}
       >
         <RadioButton
+          disabled={disabled}
           label="Kyllä"
           value="true"
           {...register("suunnittelusopimusprojekti")}
@@ -63,6 +77,7 @@ export default function ProjektiPerustiedot({ projekti }: Props): ReactElement {
           }}
         />
         <RadioButton
+          disabled={disabled}
           label="Ei"
           value="false"
           {...register("suunnittelusopimusprojekti")}


### PR DESCRIPTION
fe+be+testit (ei cypress-testejä)