### PR TITLE
feat: API:sta tulevien virheilmoitusten välittäminen käyttöliittymälle

### DIFF
--- a/common/abstractApi.ts
+++ b/common/abstractApi.ts
@@ -331,7 +331,7 @@ export abstract class AbstractApi {
 
   abstract callAPI(operation: OperationConfig, variables?: any): Promise<any>;
 
-  setOneTimeForwardHeaders(headers: IncomingHttpHeaders) {
+  setOneTimeForwardHeaders(headers: IncomingHttpHeaders): void {
     this.oneTimeHeaders = { cookie: headers.cookie, authorization: headers.authorization };
   }
 }

--- a/i18n.js
+++ b/i18n.js
@@ -2,7 +2,7 @@ module.exports = {
   locales: ["fi", "sv"],
   defaultLocale: "fi",
   pages: {
-    "*": ["common", "projekti", "footer"],
+    "*": ["common", "projekti", "footer", "error"],
     "/": ["etusivu"],
     "rgx:^/suunnitelma/": ["projekti-side-bar"],
     "/yllapito/perusta": ["velho-haku"],

--- a/src/components/ApiProvider.tsx
+++ b/src/components/ApiProvider.tsx
@@ -1,0 +1,52 @@
+import React, { createContext, ReactNode } from "react";
+import { api } from "@services/api";
+import { API } from "@services/api/commonApi";
+import useSnackbars from "src/hooks/useSnackbars";
+import { createApiWithAdditionalErrorHandling } from "@services/api/permanentApi";
+import { ErrorResponse } from "apollo-link-error";
+import { useRouter } from "next/router";
+import useTranslation from "next-translate/useTranslation";
+import { Translate } from "next-translate";
+
+export const ApiContext = createContext<API>(api);
+
+interface Props {
+  children?: ReactNode;
+}
+
+type GenerateErrorMessage = (errorResponse: ErrorResponse, isYllapito: boolean, t: Translate) => string;
+const generateErrorMessage: GenerateErrorMessage = (errorResponse, isYllapito, t) => {
+  const operationName = errorResponse.operation.operationName;
+  let errorMessage = isYllapito ? `Odottamaton virhe toiminnossa '${operationName}'.` : t("error:yleinen");
+
+  // Ei nayteta korrelaatio IDeita kansalaisille
+  const showCorrelationId = process.env.ENVIRONMENT !== "prod" || isYllapito;
+
+  if (showCorrelationId) {
+    const correlationId: string | undefined = (errorResponse.response?.errors?.[0] as any)?.errorInfo?.correlationId;
+    errorMessage = errorMessage.concat(
+      " ",
+      `Välitä tunnistetieto '${correlationId}' järjestelmän ylläpitäjälle vikailmoituksen yhteydessä.`
+    );
+  }
+  return errorMessage;
+};
+
+function ApiProvider({ children }: Props) {
+  const { showErrorMessage } = useSnackbars();
+  const router = useRouter();
+  const isYllapito = router.asPath.startsWith("/yllapito");
+  const { t } = useTranslation("error");
+
+  return (
+    <ApiContext.Provider
+      value={createApiWithAdditionalErrorHandling((errorResponse) => {
+        showErrorMessage(generateErrorMessage(errorResponse, isYllapito, t));
+      })}
+    >
+      {children}
+    </ApiContext.Provider>
+  );
+}
+
+export { ApiProvider };

--- a/src/components/HassuSnackbarProvider.tsx
+++ b/src/components/HassuSnackbarProvider.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, ReactNode, useState } from "react";
-import Snackbar from "@mui/material/Snackbar";
-import Alert, { AlertColor } from "@mui/material/Alert";
+import Snackbar, { SnackbarProps } from "@mui/material/Snackbar";
+import Alert, { AlertColor, AlertProps } from "@mui/material/Alert";
 
-type ShowMessage = (message: string, severity?: string, duration?: number) => void;
+type ShowMessage = (message: string, msgSeverity: AlertProps["severity"], msgDuration: SnackbarProps["autoHideDuration"]) => void;
 type ShowSuccessMessage = (message: string) => void;
 type ShowErrorMessage = (message: string) => void;
 type ShowInfoMessage = (message: string) => void;
@@ -11,7 +11,12 @@ export const SnackbarContext = createContext<{
   showSuccessMessage: ShowSuccessMessage;
   showErrorMessage: ShowErrorMessage;
   showInfoMessage: ShowInfoMessage;
-}>({ showMessage: () => undefined, showSuccessMessage: () => undefined, showErrorMessage: () => undefined, showInfoMessage: () => undefined });
+}>({
+  showMessage: () => undefined,
+  showSuccessMessage: () => undefined,
+  showErrorMessage: () => undefined,
+  showInfoMessage: () => undefined,
+});
 
 interface Props {
   children?: ReactNode;
@@ -19,11 +24,15 @@ interface Props {
 
 function SnackbarProvider({ children }: Props) {
   const [open, setOpen] = useState(false);
-  const [message, setMessage] = useState("Tähän oma viesti");
-  const [duration, setDuration] = useState(2000);
-  const [severity, setSeverity] = useState("success");
+  const [message, setMessage] = useState("");
+  const [duration, setDuration] = useState<SnackbarProps["autoHideDuration"]>(2000);
+  const [severity, setSeverity] = useState<AlertProps["severity"]>("success");
 
-  const showMessage = (msg = "", msgSeverity = "success", msgDuration = 2000) => {
+  const showMessage = (
+    msg = "",
+    msgSeverity: AlertProps["severity"] = "success",
+    msgDuration: SnackbarProps["autoHideDuration"] = 2000
+  ) => {
     setMessage(msg);
     setSeverity(msgSeverity);
     setDuration(msgDuration);
@@ -35,14 +44,21 @@ function SnackbarProvider({ children }: Props) {
   };
 
   const showErrorMessage = (msg: string) => {
-    showMessage(msg, "error", 5000);
+    showMessage(msg, "error", null);
   };
 
   const showInfoMessage = (msg: string) => {
     showMessage(msg, "info", 3000);
   };
 
-  const handleClose = () => {
+  const handleSnackbarClose: SnackbarProps["onClose"] = (_event, closeReason) => {
+    if (closeReason === "clickaway") {
+      return;
+    }
+    setOpen(false);
+  };
+
+  const handleAlertClose: AlertProps["onClose"] = () => {
     setOpen(false);
   };
 
@@ -58,13 +74,13 @@ function SnackbarProvider({ children }: Props) {
         }}
         autoHideDuration={duration}
         open={open}
-        onClose={handleClose}
+        onClose={handleSnackbarClose}
       >
         <Alert
           sx={{ marginTop: "15px", width: "100%" }}
           variant="filled"
           elevation={6}
-          onClose={handleClose}
+          onClose={handleAlertClose}
           severity={severity as AlertColor}
         >
           {message}

--- a/src/components/HassuSnackbarProvider.tsx
+++ b/src/components/HassuSnackbarProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useState } from "react";
+import React, { createContext, ReactNode, useCallback, useMemo, useState } from "react";
 import Snackbar, { SnackbarProps } from "@mui/material/Snackbar";
 import Alert, { AlertColor, AlertProps } from "@mui/material/Alert";
 
@@ -6,12 +6,15 @@ type ShowMessage = (message: string, msgSeverity: AlertProps["severity"], msgDur
 type ShowSuccessMessage = (message: string) => void;
 type ShowErrorMessage = (message: string) => void;
 type ShowInfoMessage = (message: string) => void;
-export const SnackbarContext = createContext<{
+
+type SnackbarContextValue = {
   showMessage: ShowMessage;
   showSuccessMessage: ShowSuccessMessage;
   showErrorMessage: ShowErrorMessage;
   showInfoMessage: ShowInfoMessage;
-}>({
+};
+
+export const SnackbarContext = createContext<SnackbarContextValue>({
   showMessage: () => undefined,
   showSuccessMessage: () => undefined,
   showErrorMessage: () => undefined,
@@ -28,41 +31,43 @@ function SnackbarProvider({ children }: Props) {
   const [duration, setDuration] = useState<SnackbarProps["autoHideDuration"]>(2000);
   const [severity, setSeverity] = useState<AlertProps["severity"]>("success");
 
-  const showMessage = (
-    msg = "",
-    msgSeverity: AlertProps["severity"] = "success",
-    msgDuration: SnackbarProps["autoHideDuration"] = 2000
-  ) => {
-    setMessage(msg);
-    setSeverity(msgSeverity);
-    setDuration(msgDuration);
-    setOpen(true);
-  };
+  const value: SnackbarContextValue = useMemo(() => {
+    const showMessage = (
+      msg = "",
+      msgSeverity: AlertProps["severity"] = "success",
+      msgDuration: SnackbarProps["autoHideDuration"] = 2000
+    ) => {
+      setMessage(msg);
+      setSeverity(msgSeverity);
+      setDuration(msgDuration);
+      setOpen(true);
+    };
 
-  const showSuccessMessage = (msg: string) => {
-    showMessage(msg, "success", 2000);
-  };
+    const showSuccessMessage = (msg: string) => {
+      showMessage(msg, "success", 2000);
+    };
 
-  const showErrorMessage = (msg: string) => {
-    showMessage(msg, "error", null);
-  };
+    const showErrorMessage = (msg: string) => {
+      showMessage(msg, "error", null);
+    };
 
-  const showInfoMessage = (msg: string) => {
-    showMessage(msg, "info", 3000);
-  };
+    const showInfoMessage = (msg: string) => {
+      showMessage(msg, "info", 3000);
+    };
 
-  const handleSnackbarClose: SnackbarProps["onClose"] = (_event, closeReason) => {
+    return { showMessage, showSuccessMessage, showErrorMessage, showInfoMessage };
+  }, []);
+
+  const handleSnackbarClose: SnackbarProps["onClose"] = useCallback((_event, closeReason) => {
     if (closeReason === "clickaway") {
       return;
     }
     setOpen(false);
-  };
+  }, []);
 
-  const handleAlertClose: AlertProps["onClose"] = () => {
+  const handleAlertClose: AlertProps["onClose"] = useCallback(() => {
     setOpen(false);
-  };
-
-  const value = { showMessage, showSuccessMessage, showErrorMessage, showInfoMessage };
+  }, []);
 
   return (
     <SnackbarContext.Provider value={value}>

--- a/src/components/ProjektiListaus.tsx
+++ b/src/components/ProjektiListaus.tsx
@@ -1,13 +1,15 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { api, Kieli, ProjektiHakutulosDokumentti, ProjektiHakutulosJulkinen } from "@services/api";
+import { Kieli, ProjektiHakutulosDokumentti, ProjektiHakutulosJulkinen } from "@services/api";
 import log from "loglevel";
 import HassuTable from "./HassuTable";
 import useTranslation from "next-translate/useTranslation";
 import { formatDate } from "src/util/dateUtils";
 import { useHassuTable } from "src/hooks/useHassuTable";
 import { Column } from "react-table";
+import useApi from "src/hooks/useApi";
 
 export default function ProjektiListaus() {
+  const api = useApi();
   const [hakutulos, setHakutulos] = useState<ProjektiHakutulosJulkinen>();
   const { t } = useTranslation();
 
@@ -31,7 +33,7 @@ export default function ProjektiListaus() {
     }
 
     fetchProjektit();
-  }, []);
+  }, [api]);
 
   const columns = useMemo<Column<ProjektiHakutulosDokumentti>[]>(
     () => [

--- a/src/components/projekti/PaivitaVelhoTiedotButton.tsx
+++ b/src/components/projekti/PaivitaVelhoTiedotButton.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState, VoidFunctionComponent } from "react";
 import Button from "@components/button/Button";
-import { api } from "@services/api";
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
 import { KeyedMutator } from "swr";
 import useSnackbars from "src/hooks/useSnackbars";
 import log from "loglevel";
 import HassuSpinner from "@components/HassuSpinner";
+import useApi from "src/hooks/useApi";
 
 const PaivitaVelhoTiedotButton: VoidFunctionComponent<{ projektiOid: string; reloadProjekti: KeyedMutator<ProjektiLisatiedolla | null> }> =
   ({ projektiOid, reloadProjekti }) => {
@@ -20,6 +20,7 @@ const PaivitaVelhoTiedotButton: VoidFunctionComponent<{ projektiOid: string; rel
 
     const [loading, setLoading] = useState(false);
     const { showSuccessMessage, showErrorMessage } = useSnackbars();
+    const api = useApi();
 
     const uudelleenLataaProjekit = useCallback(async () => {
       const isMounted = mountedRef.current;
@@ -42,7 +43,7 @@ const PaivitaVelhoTiedotButton: VoidFunctionComponent<{ projektiOid: string; rel
           }
         }
       }
-    }, [projektiOid, reloadProjekti, showErrorMessage, showSuccessMessage]);
+    }, [api, projektiOid, reloadProjekti, showErrorMessage, showSuccessMessage]);
 
     return (
       <>

--- a/src/components/projekti/UudelleenkuulutaButton.tsx
+++ b/src/components/projekti/UudelleenkuulutaButton.tsx
@@ -2,9 +2,10 @@ import Button from "@components/button/Button";
 import HassuDialog from "@components/HassuDialog";
 import HassuSpinner from "@components/HassuSpinner";
 import { DialogActions, DialogContent, DialogProps } from "@mui/material";
-import { api, TilaSiirtymaInput, TilasiirtymaToiminto } from "@services/api";
+import { TilaSiirtymaInput, TilasiirtymaToiminto } from "@services/api";
 import log from "loglevel";
 import React, { useCallback, useEffect, useRef, useState, VoidFunctionComponent } from "react";
+import useApi from "src/hooks/useApi";
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
 import useSnackbars from "src/hooks/useSnackbars";
 import { KeyedMutator } from "swr";
@@ -54,6 +55,8 @@ const UudelleenkuulutaModal: VoidFunctionComponent<DialogProps & { buttonProps: 
 
   const closeDialog: React.MouseEventHandler<HTMLButtonElement> = useCallback((e) => onClose?.(e, "escapeKeyDown"), [onClose]);
 
+  const api = useApi();
+
   const avaaUudelleenkuulutettavaksi: React.MouseEventHandler<HTMLButtonElement> = useCallback(
     async (event) => {
       const isMounted = mountedRef.current;
@@ -82,7 +85,7 @@ const UudelleenkuulutaModal: VoidFunctionComponent<DialogProps & { buttonProps: 
         setIsLoading(false);
       }
     },
-    [closeDialog, oid, reloadProjekti, showErrorMessage, showSuccessMessage, tyyppi]
+    [api, closeDialog, oid, reloadProjekti, showErrorMessage, showSuccessMessage, tyyppi]
   );
 
   return (

--- a/src/components/projekti/VelhoAineistoNimiExtLink.tsx
+++ b/src/components/projekti/VelhoAineistoNimiExtLink.tsx
@@ -1,6 +1,6 @@
-import { api } from "@services/api";
 import ExtLink from "@components/ExtLink";
 import log from "loglevel";
+import useApi from "src/hooks/useApi";
 import { useProjekti } from "src/hooks/useProjekti";
 
 interface Props {
@@ -11,6 +11,7 @@ interface Props {
 
 const VelhoAineistoNimiExtLink = ({ aineistoNimi, aineistoOid, addTopMargin }: Props) => {
   const { data: projekti } = useProjekti();
+  const api = useApi();
   return (
     <ExtLink
       as="button"

--- a/src/components/projekti/common/AineistojenValitseminenDialog.tsx
+++ b/src/components/projekti/common/AineistojenValitseminenDialog.tsx
@@ -3,7 +3,7 @@ import Button from "@components/button/Button";
 import HassuDialog from "@components/HassuDialog";
 import { DialogActions, DialogContent, Divider, Stack } from "@mui/material";
 import HassuAccordion from "@components/HassuAccordion";
-import { AineistoInput, api, VelhoAineisto, VelhoAineistoKategoria } from "@services/api";
+import { AineistoInput, VelhoAineisto, VelhoAineistoKategoria } from "@services/api";
 import { useProjekti } from "src/hooks/useProjekti";
 import { formatDateTime } from "src/util/dateUtils";
 import HassuSpinner from "@components/HassuSpinner";
@@ -14,6 +14,7 @@ import { useHassuTable } from "src/hooks/useHassuTable";
 import { Column } from "react-table";
 import { useForm } from "react-hook-form";
 import VelhoAineistoNimiExtLink from "../VelhoAineistoNimiExtLink";
+import useApi from "src/hooks/useApi";
 
 interface FormData {
   aineistoKategoriat: VelhoAineistoKategoria[];
@@ -33,6 +34,7 @@ export default function AineistojenValitseminenDialog({ onSubmit, infoText, ...m
   const [fetchedAineistoKategoriat, setFetchedAineistoKategoriat] = useState<VelhoAineistoKategoria[]>();
 
   const { setValue, watch, handleSubmit, getValues } = useForm<FormData>(useFormOptions);
+  const api = useApi();
 
   useEffect(() => {
     if (projekti && open) {
@@ -44,7 +46,7 @@ export default function AineistojenValitseminenDialog({ onSubmit, infoText, ...m
       };
       haeAineistotDialogiin();
     }
-  }, [projekti, setFetchedAineistoKategoriat, open]);
+  }, [projekti, setFetchedAineistoKategoriat, open, api]);
 
   const aineistoKategoriatWatch = watch("aineistoKategoriat");
 

--- a/src/components/projekti/kansalaisnakyma/PalauteLomakeDialogi.tsx
+++ b/src/components/projekti/kansalaisnakyma/PalauteLomakeDialogi.tsx
@@ -8,7 +8,7 @@ import { FormProvider, useForm, UseFormProps, Controller, FieldError } from "rea
 import { palauteSchema } from "src/schemas/vuorovaikutus";
 import { yupResolver } from "@hookform/resolvers/yup";
 import useTranslation from "next-translate/useTranslation";
-import { VuorovaikutusJulkinen, PalauteInput, api } from "@services/api";
+import { VuorovaikutusJulkinen, PalauteInput } from "@services/api";
 import { formatDate } from "src/util/dateUtils";
 import TextInput from "@components/form/TextInput";
 import Textarea from "@components/form/Textarea";
@@ -19,6 +19,7 @@ import axios from "axios";
 import HassuSpinner from "@components/HassuSpinner";
 import useSnackbars from "src/hooks/useSnackbars";
 import log from "loglevel";
+import useApi from "src/hooks/useApi";
 
 interface Props {
   open: boolean;
@@ -70,16 +71,21 @@ export default function PalauteLomakeDialogi({ open, onClose, projektiOid, vuoro
     reset,
   } = useFormReturn;
 
-  const talletaTiedosto = useCallback(async (tiedosto: File) => {
-    const contentType = (tiedosto as Blob).type || "application/octet-stream";
-    const response = await api.valmisteleTiedostonLataus(tiedosto.name, contentType);
-    await axios.put(response.latausLinkki, tiedosto, {
-      headers: {
-        "Content-Type": contentType,
-      },
-    });
-    return response.tiedostoPolku;
-  }, []);
+  const api = useApi();
+
+  const talletaTiedosto = useCallback(
+    async (tiedosto: File) => {
+      const contentType = (tiedosto as Blob).type || "application/octet-stream";
+      const response = await api.valmisteleTiedostonLataus(tiedosto.name, contentType);
+      await axios.put(response.latausLinkki, tiedosto, {
+        headers: {
+          "Content-Type": contentType,
+        },
+      });
+      return response.tiedostoPolku;
+    },
+    [api]
+  );
 
   const save = useCallback(
     async (formData: PalauteFormInput) => {
@@ -103,7 +109,7 @@ export default function PalauteLomakeDialogi({ open, onClose, projektiOid, vuoro
       }
       setFormIsSubmitting(false);
     },
-    [tiedosto, projektiOid, showSuccessMessage, t, onClose, reset, talletaTiedosto, showErrorMessage]
+    [tiedosto, api, projektiOid, showSuccessMessage, t, onClose, reset, talletaTiedosto, showErrorMessage]
   );
 
   return (

--- a/src/components/projekti/nahtavillaolo/kuulutuksentiedot/KuulutusJaJulkaisuPaiva.tsx
+++ b/src/components/projekti/nahtavillaolo/kuulutuksentiedot/KuulutusJaJulkaisuPaiva.tsx
@@ -3,11 +3,12 @@ import SectionContent from "@components/layout/SectionContent";
 import React, { useCallback } from "react";
 import { useFormContext } from "react-hook-form";
 import log from "loglevel";
-import { api, LaskuriTyyppi } from "@services/api";
+import { LaskuriTyyppi } from "@services/api";
 import useSnackbars from "src/hooks/useSnackbars";
 import HassuGrid from "@components/HassuGrid";
 import { HassuDatePickerWithController } from "@components/form/HassuDatePicker";
 import { today } from "src/util/dateUtils";
+import useApi from "src/hooks/useApi";
 
 type FormFields = {
   nahtavillaoloVaihe: {
@@ -21,6 +22,7 @@ export default function KuulutusJaJulkaisuPaiva() {
   const { setValue } = useFormContext<FormFields>();
 
   const { showErrorMessage } = useSnackbars();
+  const api = useApi();
 
   const getPaattymispaiva = useCallback(
     async (value: string) => {
@@ -45,7 +47,7 @@ export default function KuulutusJaJulkaisuPaiva() {
         log.error("Muistutuspäivän laskennassa virhe", error);
       }
     },
-    [setValue, showErrorMessage]
+    [api, setValue, showErrorMessage]
   );
 
   return (

--- a/src/components/projekti/nahtavillaolo/kuulutuksentiedot/Painikkeet.tsx
+++ b/src/components/projekti/nahtavillaolo/kuulutuksentiedot/Painikkeet.tsx
@@ -2,7 +2,7 @@ import Button from "@components/button/Button";
 import HassuSpinner from "@components/HassuSpinner";
 import Section from "@components/layout/Section";
 import { Stack } from "@mui/material";
-import { api, MuokkausTila } from "@services/api";
+import { MuokkausTila } from "@services/api";
 import log from "loglevel";
 import { useRouter } from "next/router";
 import React, { useState, useCallback, useRef, useEffect } from "react";
@@ -13,6 +13,7 @@ import { TilasiirtymaToiminto, TilasiirtymaTyyppi, KuulutusJulkaisuTila, Projekt
 import { ProjektiLisatiedolla } from "src/hooks/useProjekti";
 import { KuulutuksenTiedotFormValues } from "./KuulutuksenTiedot";
 import Modaalit from "./Modaalit";
+import useApi from "src/hooks/useApi";
 
 type PalautusValues = {
   syy: string;
@@ -40,13 +41,15 @@ export default function Painikkeet({ projekti }: Props) {
 
   const { handleSubmit, reset } = useFormContext<KuulutuksenTiedotFormValues>();
 
+  const api = useApi();
+
   const saveSuunnitteluvaihe = useCallback(
     async (formData: KuulutuksenTiedotFormValues) => {
       await api.tallennaProjekti(formData);
       if (reloadProjekti) await reloadProjekti();
       reset(formData);
     },
-    [reloadProjekti, reset]
+    [api, reloadProjekti, reset]
   );
 
   const saveDraft = async (formData: KuulutuksenTiedotFormValues) => {
@@ -83,7 +86,7 @@ export default function Painikkeet({ projekti }: Props) {
         setOpenHyvaksy(false);
       }
     },
-    [setIsFormSubmitting, reloadProjekti, showSuccessMessage, showErrorMessage, setOpen, projekti]
+    [projekti, api, reloadProjekti, showSuccessMessage, showErrorMessage]
   );
 
   const lahetaHyvaksyttavaksi = useCallback(

--- a/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/NahtavillaoloPainikkeet.tsx
+++ b/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/NahtavillaoloPainikkeet.tsx
@@ -2,10 +2,11 @@ import Button from "@components/button/Button";
 import HassuSpinner from "@components/HassuSpinner";
 import Section from "@components/layout/Section";
 import { Stack } from "@mui/material";
-import { api, TallennaProjektiInput } from "@services/api";
+import { TallennaProjektiInput } from "@services/api";
 import log from "loglevel";
 import React, { useState } from "react";
 import { useFormContext } from "react-hook-form";
+import useApi from "src/hooks/useApi";
 import { useProjekti } from "src/hooks/useProjekti";
 import useSnackbars from "src/hooks/useSnackbars";
 import deleteFieldArrayIds from "src/util/deleteFieldArrayIds";
@@ -32,6 +33,7 @@ export default function NahtavillaoloPainikkeet() {
   const { showSuccessMessage, showErrorMessage } = useSnackbars();
 
   const { handleSubmit, reset } = useFormContext<NahtavilleAsetettavatAineistotFormValues>();
+  const api = useApi();
 
   const saveSuunnitteluvaihe = async (formData: NahtavilleAsetettavatAineistotFormValues) => {
     const tallennaProjektiInput: TallennaProjektiInput = mapFormValuesToTallennaProjektiInput(formData);

--- a/src/components/projekti/paatos/aineistot/HyvaksymisPaatosVaihePainikkeet.tsx
+++ b/src/components/projekti/paatos/aineistot/HyvaksymisPaatosVaihePainikkeet.tsx
@@ -2,10 +2,11 @@ import Button from "@components/button/Button";
 import HassuSpinner from "@components/HassuSpinner";
 import Section from "@components/layout/Section";
 import { Stack } from "@mui/material";
-import { api, TallennaProjektiInput } from "@services/api";
+import { TallennaProjektiInput } from "@services/api";
 import log from "loglevel";
 import React, { useState } from "react";
 import { useFormContext } from "react-hook-form";
+import useApi from "src/hooks/useApi";
 import { useProjekti } from "src/hooks/useProjekti";
 import useSnackbars from "src/hooks/useSnackbars";
 import deleteFieldArrayIds from "src/util/deleteFieldArrayIds";
@@ -30,6 +31,7 @@ export default function PaatosPainikkeet({ paatosTyyppi }: { paatosTyyppi: Paato
   const { showSuccessMessage, showErrorMessage } = useSnackbars();
 
   const { handleSubmit, reset } = useFormContext<HyvaksymisPaatosVaiheAineistotFormValues>();
+  const api = useApi();
 
   const saveSuunnitteluvaihe = async (formData: TallennaProjektiInput) => {
     await api.tallennaProjekti(formData);

--- a/src/components/projekti/paatos/kuulutuksenTiedot/KuulutusJaJulkaisuPaiva.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/KuulutusJaJulkaisuPaiva.tsx
@@ -4,16 +4,19 @@ import React, { useCallback } from "react";
 import { useFormContext } from "react-hook-form";
 import dayjs from "dayjs";
 import log from "loglevel";
-import { api, LaskuriTyyppi } from "@services/api";
+import { LaskuriTyyppi } from "@services/api";
 import useSnackbars from "src/hooks/useSnackbars";
 import HassuGrid from "@components/HassuGrid";
 import { HassuDatePickerWithController } from "@components/form/HassuDatePicker";
 import { KuulutuksenTiedotFormValues } from "@components/projekti/paatos/kuulutuksenTiedot/index";
+import useApi from "src/hooks/useApi";
 
 export default function KuulutusJaJulkaisuPaiva() {
   const { setValue, control } = useFormContext<KuulutuksenTiedotFormValues>();
 
   const { showErrorMessage } = useSnackbars();
+
+  const api = useApi();
 
   const getPaattymispaiva = useCallback(
     async (value: string) => {
@@ -25,7 +28,7 @@ export default function KuulutusJaJulkaisuPaiva() {
         log.error("Kuulutusvaiheen päättymispäivän laskennassa virhe", error);
       }
     },
-    [setValue, showErrorMessage]
+    [api, setValue, showErrorMessage]
   );
 
   return (

--- a/src/components/projekti/paatos/kuulutuksenTiedot/Painikkeet.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/Painikkeet.tsx
@@ -2,7 +2,7 @@ import Button from "@components/button/Button";
 import HassuSpinner from "@components/HassuSpinner";
 import Section from "@components/layout/Section";
 import { Stack } from "@mui/material";
-import { api, HyvaksymisPaatosVaihe, HyvaksymisPaatosVaiheJulkaisu, MuokkausTila, Status } from "@services/api";
+import { HyvaksymisPaatosVaihe, HyvaksymisPaatosVaiheJulkaisu, MuokkausTila, Status } from "@services/api";
 import log from "loglevel";
 import { useRouter } from "next/router";
 import React, { useState, useCallback, useRef, useEffect } from "react";
@@ -16,6 +16,7 @@ import Modaalit from "./Modaalit";
 import { projektiMeetsMinimumStatus } from "src/hooks/useIsOnAllowedProjektiRoute";
 import { paatosSpecificTilasiirtymaTyyppiMap, PaatosTyyppi } from "src/util/getPaatosSpecificData";
 import { convertFormDataToTallennaProjektiInput } from "./KuulutuksenJaIlmoituksenEsikatselu";
+import useApi from "src/hooks/useApi";
 
 type PalautusValues = {
   syy: string;
@@ -46,13 +47,15 @@ export default function Painikkeet({ projekti, julkaisu, paatosTyyppi, julkaisem
 
   const { handleSubmit, reset } = useFormContext<KuulutuksenTiedotFormValues>();
 
+  const api = useApi();
+
   const saveHyvaksymisPaatosVaihe = useCallback(
     async (formData: KuulutuksenTiedotFormValues) => {
       await api.tallennaProjekti(convertFormDataToTallennaProjektiInput(formData, paatosTyyppi));
       if (reloadProjekti) await reloadProjekti();
       reset(formData);
     },
-    [paatosTyyppi, reloadProjekti, reset]
+    [api, paatosTyyppi, reloadProjekti, reset]
   );
 
   const saveDraft = async (formData: KuulutuksenTiedotFormValues) => {
@@ -89,7 +92,7 @@ export default function Painikkeet({ projekti, julkaisu, paatosTyyppi, julkaisem
         setOpenHyvaksy(false);
       }
     },
-    [projekti, paatosTyyppi, reloadProjekti, showSuccessMessage, showErrorMessage]
+    [projekti, api, paatosTyyppi, reloadProjekti, showSuccessMessage, showErrorMessage]
   );
 
   const lahetaHyvaksyttavaksi = useCallback(

--- a/src/components/projekti/suunnitteluvaihe/SaapuneetKysymyksetJaPalautteet.tsx
+++ b/src/components/projekti/suunnitteluvaihe/SaapuneetKysymyksetJaPalautteet.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useCallback, useEffect, useMemo, useState } from "react";
-import { api, Palaute, Projekti } from "@services/api";
+import { Palaute, Projekti } from "@services/api";
 import Section from "@components/layout/Section";
 import SectionContent from "@components/layout/SectionContent";
 import HassuTable from "@components/HassuTable";
@@ -10,6 +10,8 @@ import dayjs from "dayjs";
 import { Link } from "@mui/material";
 import ButtonLink from "@components/button/ButtonLink";
 import { useHassuTable } from "src/hooks/useHassuTable";
+import useApi from "src/hooks/useApi";
+
 interface Props {
   projekti: Projekti;
 }
@@ -17,10 +19,12 @@ interface Props {
 export default function SaapuneetKysymyksetJaPalautteet({ projekti }: Props): ReactElement {
   const [palautteet, setPalautteet] = useState<Palaute[]>();
 
+  const api = useApi();
+
   const paivitaPalautteet = useCallback(async () => {
     const palauteLista = await api.listaaPalautteet(projekti.oid);
     setPalautteet(palauteLista);
-  }, [projekti.oid]);
+  }, [api, projekti.oid]);
 
   useEffect(() => {
     paivitaPalautteet();
@@ -117,6 +121,7 @@ interface KasittelePalauteCheckboxProps {
 function KasittelePalauteCheckbox({ palaute, oid, paivitaPalautteet }: KasittelePalauteCheckboxProps): ReactElement {
   const { showSuccessMessage, showErrorMessage } = useSnackbars();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const api = useApi();
 
   const merkitseKasittelyynOtetuksi = useCallback(async () => {
     setIsSubmitting(true);
@@ -130,7 +135,7 @@ function KasittelePalauteCheckbox({ palaute, oid, paivitaPalautteet }: Kasittele
     setIsSubmitting(false);
     if (paivitaPalautteet) paivitaPalautteet();
     showSuccessMessage("Palaute merkitty käsiteltäväksi.");
-  }, [paivitaPalautteet, showSuccessMessage, oid, palaute.id, showErrorMessage]);
+  }, [paivitaPalautteet, showSuccessMessage, api, oid, palaute.id, showErrorMessage]);
 
   return (
     <>

--- a/src/components/projekti/suunnitteluvaihe/SuunnitteluvaiheenPerustiedot.tsx
+++ b/src/components/projekti/suunnitteluvaihe/SuunnitteluvaiheenPerustiedot.tsx
@@ -3,7 +3,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import { maxHankkeenkuvausLength, suunnittelunPerustiedotSchema } from "src/schemas/suunnittelunPerustiedot";
 import SectionContent from "@components/layout/SectionContent";
 import Textarea from "@components/form/Textarea";
-import { KuulutusJulkaisuTila, api, Kieli, SuunnitteluVaiheInput, SuunnitteluVaiheTila, TallennaProjektiInput } from "@services/api";
+import { KuulutusJulkaisuTila, Kieli, SuunnitteluVaiheInput, SuunnitteluVaiheTila, TallennaProjektiInput } from "@services/api";
 import Section from "@components/layout/Section";
 import lowerCase from "lodash/lowerCase";
 import { ReactElement, useMemo, useState } from "react";
@@ -20,6 +20,7 @@ import { ProjektiLisatiedolla, useProjekti } from "src/hooks/useProjekti";
 import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import { KeyedMutator } from "swr";
 import { pickBy } from "lodash";
+import useApi from "src/hooks/useApi";
 
 type ProjektiFields = Pick<TallennaProjektiInput, "oid">;
 type RequiredProjektiFields = Required<{
@@ -139,6 +140,8 @@ function SuunnitteluvaiheenPerustiedotForm({ projekti, reloadProjekti }: Suunnit
     }
     setIsFormSubmitting(false);
   };
+
+  const api = useApi();
 
   const saveSuunnitteluvaihe = async (formData: FormValues) => {
     await api.tallennaProjekti(formData);

--- a/src/components/projekti/suunnitteluvaihe/SuunnitteluvaiheenVuorovaikuttaminen.tsx
+++ b/src/components/projekti/suunnitteluvaihe/SuunnitteluvaiheenVuorovaikuttaminen.tsx
@@ -3,7 +3,6 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import SectionContent from "@components/layout/SectionContent";
 import {
   TallennaProjektiInput,
-  api,
   VuorovaikutusInput,
   VuorovaikutusTilaisuusInput,
   LinkkiInput,
@@ -41,6 +40,7 @@ import { lowerCase } from "lodash";
 import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import { KeyedMutator } from "swr";
 import projektiKayttajaToYhteystieto from "src/util/kayttajaTransformationUtil";
+import useApi from "src/hooks/useApi";
 
 type ProjektiFields = Pick<TallennaProjektiInput, "oid">;
 
@@ -189,6 +189,8 @@ function SuunnitteluvaiheenVuorovaikuttaminenForm({
 
   useLeaveConfirm(isDirty);
 
+  const api = useApi();
+
   const saveSunnitteluvaihe = useCallback(
     async (formData: VuorovaikutusFormValues) => {
       setIsFormSubmitting(true);
@@ -196,7 +198,7 @@ function SuunnitteluvaiheenVuorovaikuttaminenForm({
       if (reloadProjekti) await reloadProjekti();
       reset(formData);
     },
-    [reset, reloadProjekti]
+    [api, reloadProjekti, reset]
   );
 
   const saveDraft = useCallback(

--- a/src/hooks/useApi.tsx
+++ b/src/hooks/useApi.tsx
@@ -1,0 +1,6 @@
+import { useContext } from "react";
+import { ApiContext } from "@components/ApiProvider";
+
+const useApi = () => useContext(ApiContext);
+
+export default useApi;

--- a/src/hooks/useCurrentUser.tsx
+++ b/src/hooks/useCurrentUser.tsx
@@ -1,14 +1,21 @@
 import useSWR from "swr";
-import { api, apiConfig } from "@services/api";
+import { apiConfig } from "@services/api";
 import { isEqual, omit } from "lodash";
+import useApi from "./useApi";
+import { API } from "@services/api/commonApi";
+import { useMemo } from "react";
 
 export function useCurrentUser() {
+  const api = useApi();
+
+  const userLoader = useMemo(() => getUserLoader(api), [api]);
+
   return useSWR([apiConfig.nykyinenKayttaja.graphql], userLoader, {
     compare: (a, b) => isEqual(omit(a, "keksit"), omit(b, "keksit")),
   });
 }
 
-async function userLoader(_: string) {
+const getUserLoader = (api: API) => async (_: string) => {
   const kayttaja = await api.getCurrentUser();
   if (kayttaja?.keksit) {
     kayttaja.keksit.forEach((cookie) => {
@@ -16,6 +23,6 @@ async function userLoader(_: string) {
     });
   }
   return kayttaja;
-}
+};
 
 export default useCurrentUser;

--- a/src/hooks/useKirjaamoOsoitteet.tsx
+++ b/src/hooks/useKirjaamoOsoitteet.tsx
@@ -1,12 +1,18 @@
 import useSWR from "swr";
-import { api, apiConfig } from "@services/api";
+import { apiConfig } from "@services/api";
+import useApi from "./useApi";
+import { API } from "@services/api/commonApi";
+import { useMemo } from "react";
 
 export function useKirjaamoOsoitteet() {
+  const api = useApi();
+
+  const kirjaamoOsoitteetLoader = useMemo(() => getKirjaamoOsoitteetLoader(api), [api]);
   return useSWR([apiConfig.listKirjaamoOsoitteet.graphql], kirjaamoOsoitteetLoader);
 }
 
-async function kirjaamoOsoitteetLoader(_: string) {
+const getKirjaamoOsoitteetLoader = (api: API) => async (_: string) => {
   return await api.listKirjaamoOsoitteet();
-}
+};
 
 export default useKirjaamoOsoitteet;

--- a/src/hooks/useLisaAineisto.tsx
+++ b/src/hooks/useLisaAineisto.tsx
@@ -1,30 +1,34 @@
 import useSWR from "swr";
-import { api, apiConfig } from "@services/api";
+import { apiConfig } from "@services/api";
 import { useRouter } from "next/router";
+import useApi from "./useApi";
+import { API } from "@services/api/commonApi";
+import { useMemo } from "react";
 
 export function useLisaAineisto() {
+  const api = useApi();
   const { query } = useRouter();
   const oid = typeof query.oid === "string" ? query.oid : undefined;
   const hash = typeof query.hash === "string" ? query.hash : undefined;
-  const nahtavillaoloVaiheId =
-    typeof query.id === "string" && !Number.isNaN(Number(query.id)) ? parseInt(query.id) : undefined;
+  const nahtavillaoloVaiheId = typeof query.id === "string" && !Number.isNaN(Number(query.id)) ? parseInt(query.id) : undefined;
   const poistumisPaiva = typeof query.poistumisPaiva === "string" ? query.poistumisPaiva : undefined;
 
-  return useSWR(
-    [apiConfig.listaaLisaAineisto.graphql, oid, hash, nahtavillaoloVaiheId, poistumisPaiva],
-    lisaAineistoLoader
-  );
+  const lisaAineistoLoader = useMemo(() => getLisaAineistoLoader(api), [api]);
+
+  return useSWR([apiConfig.listaaLisaAineisto.graphql, oid, hash, nahtavillaoloVaiheId, poistumisPaiva], lisaAineistoLoader);
 }
 
-async function lisaAineistoLoader(
-  _query: string,
-  oid: string | undefined,
-  hash: string | undefined,
-  nahtavillaoloVaiheId: number | undefined,
-  poistumisPaiva: string | undefined
-) {
-  if (!oid || !hash || !nahtavillaoloVaiheId || !poistumisPaiva) {
-    return null;
-  }
-  return await api.listaaLisaAineisto(oid, { hash, nahtavillaoloVaiheId, poistumisPaiva });
-}
+const getLisaAineistoLoader =
+  (api: API) =>
+  async (
+    _query: string,
+    oid: string | undefined,
+    hash: string | undefined,
+    nahtavillaoloVaiheId: number | undefined,
+    poistumisPaiva: string | undefined
+  ) => {
+    if (!oid || !hash || !nahtavillaoloVaiheId || !poistumisPaiva) {
+      return null;
+    }
+    return await api.listaaLisaAineisto(oid, { hash, nahtavillaoloVaiheId, poistumisPaiva });
+  };

--- a/src/hooks/useProjektiJulkinen.tsx
+++ b/src/hooks/useProjektiJulkinen.tsx
@@ -1,9 +1,16 @@
 import useSWR from "swr";
-import { api, apiConfig, ProjektiJulkinen } from "@services/api";
+import { apiConfig, ProjektiJulkinen } from "@services/api";
 import { useRouter } from "next/router";
+import useApi from "./useApi";
+import { API } from "@services/api/commonApi";
+import { useMemo } from "react";
 
 export function useProjektiJulkinen() {
   const router = useRouter();
+  const api = useApi();
+
+  const projektiLoader = useMemo(() => getProjektiLoader(api), [api]);
+
   if (router.asPath.startsWith("/yllapito")) {
     throw new Error("Inproper route for the use of useProjektiJulkinen hook");
   }
@@ -11,9 +18,11 @@ export function useProjektiJulkinen() {
   return useSWR([apiConfig.lataaProjekti.graphql, oid], projektiLoader, { revalidateOnReconnect: true, revalidateIfStale: true });
 }
 
-async function projektiLoader(_query: string, oid: string | undefined): Promise<ProjektiJulkinen | null> {
-  if (!oid) {
-    return null;
-  }
-  return await api.lataaProjektiJulkinen(oid);
-}
+const getProjektiLoader =
+  (api: API) =>
+  async (_query: string, oid: string | undefined): Promise<ProjektiJulkinen | null> => {
+    if (!oid) {
+      return null;
+    }
+    return await api.lataaProjektiJulkinen(oid);
+  };

--- a/src/locales/fi/error.json
+++ b/src/locales/fi/error.json
@@ -1,0 +1,4 @@
+{
+  "yleinen": "Järjestelmässä tapahtui odottamaton virhe.",
+  "tyyppi": {}
+}

--- a/src/locales/sv/error.json
+++ b/src/locales/sv/error.json
@@ -1,0 +1,4 @@
+{
+  "yleinen": "RUOTSIKSI Järjestelmässä tapahtui odottamaton virhe",
+  "tyyppi": {}
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -18,6 +18,7 @@ import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import HassuMuiThemeProvider from "@components/layout/HassuMuiThemeProvider";
 import "dayjs/locale/fi";
 import "dayjs/locale/sv";
+import { ApiProvider } from "@components/ApiProvider";
 
 log.setDefaultLevel("DEBUG");
 
@@ -25,26 +26,34 @@ function App({ Component, pageProps }: AppProps) {
   const { lang, t } = useTranslation("common");
 
   return (
-    <SWRConfig value={{ revalidateOnFocus: false, revalidateIfStale: false, revalidateOnReconnect: false }}>
-      <LocalizationProvider
-        dateAdapter={AdapterDayjs}
-        adapterLocale={lang}
-        localeText={{ okButtonLabel: t("OK"), cancelButtonLabel: t("peruuta") }}
-      >
-        <I18nProvider lang={lang} namespaces={{ commonFI, commonSV }}>
-          <Head>
-            <title>Hassu</title>
-          </Head>
-          <HassuMuiThemeProvider>
-            <SnackbarProvider>
-              <Layout>
-                <Component {...pageProps} />
-              </Layout>
-            </SnackbarProvider>
-          </HassuMuiThemeProvider>
-        </I18nProvider>
-      </LocalizationProvider>
-    </SWRConfig>
+    <SnackbarProvider>
+      <I18nProvider lang={lang} namespaces={{ commonFI, commonSV }}>
+        <ApiProvider>
+          <SWRConfig
+            value={{
+              revalidateOnFocus: false,
+              revalidateIfStale: false,
+              revalidateOnReconnect: false,
+            }}
+          >
+            <LocalizationProvider
+              dateAdapter={AdapterDayjs}
+              adapterLocale={lang}
+              localeText={{ okButtonLabel: t("OK"), cancelButtonLabel: t("peruuta") }}
+            >
+              <Head>
+                <title>Hassu</title>
+              </Head>
+              <HassuMuiThemeProvider>
+                <Layout>
+                  <Component {...pageProps} />
+                </Layout>
+              </HassuMuiThemeProvider>
+            </LocalizationProvider>
+          </SWRConfig>
+        </ApiProvider>
+      </I18nProvider>
+    </SnackbarProvider>
   );
 }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { api, Kieli, ProjektiHakutulosJulkinen } from "@services/api";
+import { Kieli, ProjektiHakutulosJulkinen } from "@services/api";
 import useTranslation from "next-translate/useTranslation";
 import Hakulomake from "@components/kansalaisenEtusivu/Hakulomake";
 import Hakutulokset from "@components/kansalaisenEtusivu/Hakutulokset";
@@ -10,6 +10,7 @@ import Sivutus from "@components/kansalaisenEtusivu/Sivutus";
 import { useRouter } from "next/router";
 import { SelectOption } from "@components/form/Select";
 import { kuntametadata } from "../../common/kuntametadata";
+import useApi from "src/hooks/useApi";
 
 const SIVUN_KOKO = 10;
 
@@ -49,6 +50,8 @@ function Etusivu({ query, maakuntaOptions, kuntaOptions }: Props) {
     return Math.ceil((hakutulos?.hakutulosMaara || 0) / SIVUN_KOKO);
   }, [hakutulos]);
 
+  const api = useApi();
+
   useEffect(() => {
     async function fetchProjektit() {
       try {
@@ -79,7 +82,7 @@ function Etusivu({ query, maakuntaOptions, kuntaOptions }: Props) {
     }
 
     fetchProjektit();
-  }, [setLadataan, setHakutulos, sivu, vapaasanahaku, kunta, maakunta, vaylamuoto, maakuntaOptions, kuntaOptions]);
+  }, [setLadataan, setHakutulos, sivu, vapaasanahaku, kunta, maakunta, vaylamuoto, maakuntaOptions, kuntaOptions, api]);
 
   return (
     <Grid container rowSpacing={4} columnSpacing={4}>

--- a/src/pages/yllapito/perusta/[oid].tsx
+++ b/src/pages/yllapito/perusta/[oid].tsx
@@ -3,7 +3,7 @@ import { ProjektiLisatiedolla, useProjekti } from "src/hooks/useProjekti";
 import { useRouter } from "next/router";
 import ProjektiPerustiedot from "@components/projekti/ProjektiPerustiedot";
 import KayttoOikeusHallinta from "@components/projekti/KayttoOikeusHallinta";
-import { api, TallennaProjektiInput, ProjektiKayttajaInput } from "@services/api";
+import { TallennaProjektiInput, ProjektiKayttajaInput } from "@services/api";
 import * as Yup from "yup";
 import { useState } from "react";
 import { FormProvider, useForm, UseFormReturn } from "react-hook-form";
@@ -20,6 +20,7 @@ import Section from "@components/layout/Section";
 import HassuSpinner from "@components/HassuSpinner";
 import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import { KeyedMutator } from "swr";
+import useApi from "src/hooks/useApi";
 
 // Extend TallennaProjektiInput by making fields other than muistiinpano nonnullable and required
 type RequiredFields = Pick<TallennaProjektiInput, "oid" | "kayttoOikeudet">;
@@ -100,6 +101,8 @@ const PerustaProjektiForm: FunctionComponent<PerustaProjektiFormProps> = ({ proj
   } = useFormReturn as UseFormReturn<FormValues>;
 
   useLeaveConfirm(isDirty && !formIsSubmitting);
+
+  const api = useApi();
 
   const submitAndMoveToNewRoute = async (formData: FormValues, newRoute: string) => {
     deleteFieldArrayIds(formData?.kayttoOikeudet);

--- a/src/pages/yllapito/perusta/index.tsx
+++ b/src/pages/yllapito/perusta/index.tsx
@@ -3,7 +3,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as Yup from "yup";
 import { SchemaOf } from "yup";
 
-import { api, VelhoHakuTulos } from "@services/api";
+import { VelhoHakuTulos } from "@services/api";
 import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/router";
 import TextInput from "@components/form/TextInput";
@@ -16,6 +16,7 @@ import { useHassuTable } from "src/hooks/useHassuTable";
 import { Column } from "react-table";
 import useTranslation from "next-translate/useTranslation";
 import HassuTable from "@components/HassuTable";
+import useApi from "src/hooks/useApi";
 
 interface SearchInput {
   name: string;
@@ -62,6 +63,8 @@ export default function Perusta(props: Props) {
     reset,
   } = useForm<SearchInput>(formOptions);
 
+  const api = useApi();
+
   const onSubmit = useCallback(
     async (data: SearchInput) => {
       if (router.query[PROJEKTI_NIMI_PARAM] !== data.name) {
@@ -85,7 +88,7 @@ export default function Perusta(props: Props) {
       }
       setIsLoading(false);
     },
-    [router]
+    [api, router]
   );
 
   useEffect(() => {

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -10,7 +10,6 @@ import Notification, { NotificationType } from "@components/notification/Notific
 import {
   AloitusKuulutusInput,
   KuulutusJulkaisuTila,
-  api,
   AsiakirjaTyyppi,
   Kieli,
   Kielitiedot,
@@ -50,6 +49,7 @@ import { kuntametadata } from "../../../../../common/kuntametadata";
 import UudelleenkuulutaButton from "@components/projekti/UudelleenkuulutaButton";
 import { getDefaultValuesForLokalisoituText, getDefaultValuesForUudelleenKuulutus } from "src/util/getDefaultValuesForLokalisoituText";
 import SelitteetUudelleenkuulutukselle from "@components/projekti/SelitteetUudelleenkuulutukselle";
+import useApi from "src/hooks/useApi";
 
 type ProjektiFields = Pick<TallennaProjektiInput, "oid">;
 type RequiredProjektiFields = Required<{
@@ -186,6 +186,8 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
     formState: { errors: errors2 },
   } = useForm<PalautusValues>({ defaultValues: { syy: "" } });
 
+  const api = useApi();
+
   const saveAloituskuulutus = useCallback(
     async (formData: FormValues) => {
       deleteFieldArrayIds(formData?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysTiedot);
@@ -197,7 +199,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
       await reloadProjekti();
       reset(formData);
     },
-    [reset, reloadProjekti]
+    [api, reloadProjekti, reset]
   );
 
   const { showSuccessMessage, showErrorMessage } = useSnackbars();
@@ -234,7 +236,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
       setIsFormSubmitting(false);
       setOpen(false);
     },
-    [setIsFormSubmitting, reloadProjekti, showSuccessMessage, showErrorMessage, setOpen, projekti]
+    [projekti, api, reloadProjekti, showSuccessMessage, showErrorMessage]
   );
 
   const lahetaHyvaksyttavaksi = useCallback(
@@ -308,7 +310,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
         log.error("Päättymispäivän laskennassa virhe", error);
       }
     },
-    [setValue, showErrorMessage]
+    [api, setValue, showErrorMessage]
   );
 
   const kielitiedot: Kielitiedot | null | undefined = projekti?.kielitiedot;

--- a/src/pages/yllapito/projekti/[oid]/arkistoi.tsx
+++ b/src/pages/yllapito/projekti/[oid]/arkistoi.tsx
@@ -1,11 +1,13 @@
 import { useRouter } from "next/router";
 import React, { ReactElement, useEffect, useState } from "react";
-import { api } from "@services/api";
+import useApi from "src/hooks/useApi";
 
 export default function Arkistoi(): ReactElement {
   const [result, setResult] = useState<string>("");
   const router = useRouter();
   const oid = typeof router.query.oid === "string" ? router.query.oid : undefined;
+
+  const api = useApi();
 
   useEffect(() => {
     if (oid) {
@@ -18,6 +20,6 @@ export default function Arkistoi(): ReactElement {
           setResult("Arkistoinnin tulos: " + e.message);
         });
     }
-  }, [oid]);
+  }, [api, oid]);
   return <p id="result">{result}</p>;
 }

--- a/src/pages/yllapito/projekti/[oid]/henkilot.tsx
+++ b/src/pages/yllapito/projekti/[oid]/henkilot.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback, useEffect, useMemo } from "react";
 import { ProjektiLisatiedolla, useProjekti } from "src/hooks/useProjekti";
 import KayttoOikeusHallinta from "@components/projekti/KayttoOikeusHallinta";
-import { api, TallennaProjektiInput, ProjektiKayttajaInput } from "@services/api";
+import { TallennaProjektiInput, ProjektiKayttajaInput } from "@services/api";
 import * as Yup from "yup";
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
@@ -23,6 +23,7 @@ import { KeyedMutator } from "swr";
 import HenkilotLukutila from "@components/projekti/lukutila/HenkilotLukutila";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
 import PaivitaVelhoTiedotButton from "@components/projekti/PaivitaVelhoTiedotButton";
+import useApi from "src/hooks/useApi";
 
 // Extend TallennaProjektiInput by making fields other than muistiinpano nonnullable and required
 type RequiredFields = Pick<TallennaProjektiInput, "oid" | "kayttoOikeudet">;
@@ -117,6 +118,8 @@ function Henkilot({ projekti, projektiLoadError, reloadProjekti }: HenkilotFormP
   useLeaveConfirm(isDirty);
 
   const { showSuccessMessage, showErrorMessage } = useSnackbars();
+
+  const api = useApi();
 
   const onSubmit = async (formData: FormValues) => {
     deleteFieldArrayIds(formData?.kayttoOikeudet);

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useCallback, useMemo } from "react";
 import log from "loglevel";
 import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
 import { ProjektiLisatiedolla, useProjekti } from "src/hooks/useProjekti";
-import { api, Status, TallennaProjektiInput } from "@services/api";
+import { Status, TallennaProjektiInput } from "@services/api";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Controller, FormProvider, useForm, UseFormProps } from "react-hook-form";
 import Button from "@components/button/Button";
@@ -31,6 +31,7 @@ import { KeyedMutator } from "swr";
 import ProjektinTiedotLukutila from "@components/projekti/lukutila/ProjektinTiedotLukutila";
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
 import PaivitaVelhoTiedotButton from "@components/projekti/PaivitaVelhoTiedotButton";
+import useApi from "src/hooks/useApi";
 
 type TransientFormValues = {
   suunnittelusopimusprojekti: "true" | "false" | null;
@@ -145,16 +146,21 @@ function ProjektiSivuLomake({ projekti, projektiLoadError, reloadProjekti }: Pro
 
   useLeaveConfirm(isDirty);
 
-  const talletaLogo = useCallback(async (logoTiedosto: File) => {
-    const contentType = (logoTiedosto as Blob).type || "application/octet-stream";
-    const response = await api.valmisteleTiedostonLataus(logoTiedosto.name, contentType);
-    await axios.put(response.latausLinkki, logoTiedosto, {
-      headers: {
-        "Content-Type": contentType,
-      },
-    });
-    return response.tiedostoPolku;
-  }, []);
+  const api = useApi();
+
+  const talletaLogo = useCallback(
+    async (logoTiedosto: File) => {
+      const contentType = (logoTiedosto as Blob).type || "application/octet-stream";
+      const response = await api.valmisteleTiedostonLataus(logoTiedosto.name, contentType);
+      await axios.put(response.latausLinkki, logoTiedosto, {
+        headers: {
+          "Content-Type": contentType,
+        },
+      });
+      return response.tiedostoPolku;
+    },
+    [api]
+  );
 
   const onSubmit = useCallback(
     async (data: FormValues) => {
@@ -182,7 +188,7 @@ function ProjektiSivuLomake({ projekti, projektiLoadError, reloadProjekti }: Pro
       }
       setFormIsSubmitting(false);
     },
-    [reset, projekti?.status, reloadProjekti, showSuccessMessage, talletaLogo, showErrorMessage]
+    [projekti?.status, api, reloadProjekti, reset, showSuccessMessage, talletaLogo, showErrorMessage]
   );
 
   useEffect(() => {

--- a/src/pages/yllapito/projekti/[oid]/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/index.tsx
@@ -32,6 +32,8 @@ import ProjektinTiedotLukutila from "@components/projekti/lukutila/ProjektinTied
 import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
 import PaivitaVelhoTiedotButton from "@components/projekti/PaivitaVelhoTiedotButton";
 import useApi from "src/hooks/useApi";
+import { isApolloError } from "apollo-client/errors/ApolloError";
+import { concatCorrelationIdToErrorMessage } from "@components/ApiProvider";
 
 type TransientFormValues = {
   suunnittelusopimusprojekti: "true" | "false" | null;
@@ -184,7 +186,11 @@ function ProjektiSivuLomake({ projekti, projektiLoadError, reloadProjekti }: Pro
         showSuccessMessage("Tallennus onnistui!");
       } catch (e) {
         log.log("OnSubmit Error", e);
-        showErrorMessage("Tallennuksessa tapahtui virhe!");
+        let errorMessage = "Tallennuksessa tapahtui virhe!";
+        if (e instanceof Error && isApolloError(e)) {
+          errorMessage = concatCorrelationIdToErrorMessage(errorMessage, e.graphQLErrors);
+        }
+        showErrorMessage(errorMessage);
       }
       setFormIsSubmitting(false);
     },

--- a/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useCallback, useState, useMemo, useEffect } from "react";
-import { api, HyvaksymispaatosInput, Status, TallennaProjektiInput } from "@services/api";
+import { HyvaksymispaatosInput, Status, TallennaProjektiInput } from "@services/api";
 import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
 import Section from "@components/layout/Section";
 import { Controller, useForm, UseFormProps } from "react-hook-form";
@@ -30,6 +30,7 @@ import Select from "@components/form/Select";
 import { suunnitelmanTilat } from "common/generated/kasittelynTila";
 import CheckBox from "@components/form/CheckBox";
 import Textarea from "@components/form/Textarea";
+import useApi from "src/hooks/useApi";
 
 type FormValues = Pick<TallennaProjektiInput, "oid" | "kasittelynTila">;
 
@@ -151,6 +152,8 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
 
   useLeaveConfirm(isDirty);
 
+  const api = useApi();
+
   const onSubmit = useCallback(
     async (data: FormValues) => {
       setIsFormSubmitting(true);
@@ -181,7 +184,7 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
       }
       setIsFormSubmitting(false);
     },
-    [isValituksia, reloadProjekti, reset, showErrorMessage, showSuccessMessage]
+    [api, isValituksia, reloadProjekti, reset, showErrorMessage, showSuccessMessage]
   );
 
   const avaaJatkopaatos = useCallback(

--- a/src/services/api/permanentApi.ts
+++ b/src/services/api/permanentApi.ts
@@ -1,10 +1,10 @@
 import awsExports from "../../aws-exports";
 import { createAuthLink } from "aws-appsync-auth-link";
 import { createHttpLink } from "apollo-link-http";
-import { onError } from "apollo-link-error";
+import { ErrorResponse, onError } from "apollo-link-error";
 import { API, ERROR_MESSAGE_NOT_AUTHENTICATED } from "@services/api/commonApi";
 import { FetchResult } from "apollo-link/lib/types";
-import { Observable } from "apollo-link";
+import { ApolloLink, Observable } from "apollo-link";
 import { ServerError } from "apollo-link-http-common";
 import { GraphQLError } from "graphql/error/GraphQLError";
 
@@ -16,18 +16,28 @@ AWS.config.update({
 const graphQLAPI = awsExports.aws_appsync_graphqlEndpoint;
 const yllapitoGraphQLAPI = graphQLAPI.replace("/graphql", "/yllapito/graphql");
 
-const publicLinks = [
+type GenerateLinkArray = (errorHandler?: (errorResponse: ErrorResponse) => void) => ApolloLink[];
+
+const getPublicLinks: GenerateLinkArray = (errorHandler) => [
   createAuthLink({
     url: graphQLAPI,
     region: awsExports.aws_appsync_region,
     auth: { type: "API_KEY", apiKey: awsExports.aws_appsync_apiKey || "" },
+  }),
+  onError((errorResponse) => {
+    if (errorResponse.response?.errors) {
+      const isActualErrorPresent = errorResponse?.response?.errors?.some((error) => error.message !== "HASSU_INFO");
+      if (isActualErrorPresent) {
+        errorHandler?.(errorResponse);
+      }
+    }
   }),
   createHttpLink({
     uri: graphQLAPI,
   }),
 ];
 
-const authenticatedLinks = [
+const getAuthenticatedLinks: GenerateLinkArray = (errorHandler) => [
   createAuthLink({
     url: yllapitoGraphQLAPI,
     region: awsExports.aws_appsync_region,
@@ -36,6 +46,10 @@ const authenticatedLinks = [
   onError((errorResponse) => {
     let networkError = errorResponse.networkError as ServerError;
     let response: Response = networkError?.response as unknown as Response;
+    const isActualErrorPresent = errorResponse?.response?.errors?.some((error) => error.message !== "HASSU_INFO");
+    if (isActualErrorPresent) {
+      errorHandler?.(errorResponse);
+    }
     if (response?.type === "opaqueredirect") {
       let fetchResult: FetchResult = { errors: [new GraphQLError(ERROR_MESSAGE_NOT_AUTHENTICATED)] };
       return Observable.of(fetchResult);
@@ -46,4 +60,8 @@ const authenticatedLinks = [
     fetchOptions: { redirect: "manual" },
   }),
 ];
-export const api = new API(publicLinks, authenticatedLinks);
+export const api = new API(getPublicLinks(), getAuthenticatedLinks());
+
+export function createApiWithAdditionalErrorHandling(errorHandler?: (errorResponse: ErrorResponse) => void) {
+  return new API(getPublicLinks(errorHandler), getAuthenticatedLinks(errorHandler));
+}

--- a/src/services/api/permanentApi.ts
+++ b/src/services/api/permanentApi.ts
@@ -16,7 +16,8 @@ AWS.config.update({
 const graphQLAPI = awsExports.aws_appsync_graphqlEndpoint;
 const yllapitoGraphQLAPI = graphQLAPI.replace("/graphql", "/yllapito/graphql");
 
-type GenerateLinkArray = (errorHandler?: (errorResponse: ErrorResponse) => void) => ApolloLink[];
+export type ErrorResponseHandler = (errorResponse: ErrorResponse) => void;
+type GenerateLinkArray = (errorHandler?: ErrorResponseHandler) => ApolloLink[];
 
 const getPublicLinks: GenerateLinkArray = (errorHandler) => [
   createAuthLink({


### PR DESCRIPTION
- Luotu ApiProvider -konteksti, ja useApi-koukku, api-luokan käyttämiseen frontendissa.
- Poistettu React-komponenteista api-importit, api-luokka haetaan nyt useApi-hookilla. UseApi-koukun kautta tulevalla api-instansseilla tulee käyttöliittymälle virheviestit välipalabaarin (snackbar) välityksellä. 
- Projektin tiedot -sivun tallennuksessa on tyypattu kustomoitua virheviestiä, jossa on kuitenkin korrelointitunnus mukana. 