### PR TITLE
fix: Sulje dialogit oikein aloituskuulutussivulla, kun dialogista painetaan hyväksymispainiketta

### DIFF
--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -233,6 +233,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
       }
       setIsFormSubmitting(false);
       setOpen(false);
+      setOpenHyvaksy(false);
     },
     [setIsFormSubmitting, reloadProjekti, showSuccessMessage, showErrorMessage, setOpen, projekti]
   );


### PR DESCRIPTION
Aiemmin hyväksymisdialogi jäi "open"-tilaan ja kun projekti vietiin hyväksyttäväksi, dialogi oli edelleen auki. Uudelleenkuulutus-sykliä toteuttamalla ongelman voi helpoiten havaita. Uudelleenkuuluta -> Tallenna ja lähetä Hyväksyttäväksi -> Hyväksy ja lähetä ->  Uudelleenkuuluta -> Tallenna ja lähetä Hyväksyttäväksi (ongelma havaittavissa)