### PR TITLE
feat: hassu 1161, kunnan edustajan poiston esto

### DIFF
--- a/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
@@ -64,9 +64,7 @@ Object {
       "kuulutusVaihePaattyyPaiva": "2100-01-01",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
-        "yhteysHenkilot": Array [
-          "A000111",
-        ],
+        "yhteysHenkilot": Array [],
         "yhteysTiedot": Array [
           Object {
             "__typename": "Yhteystieto",
@@ -191,9 +189,7 @@ Object {
       "kuulutusVaihePaattyyPaiva": "2100-01-01",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
-        "yhteysHenkilot": Array [
-          "A000111",
-        ],
+        "yhteysHenkilot": Array [],
         "yhteysTiedot": Array [
           Object {
             "__typename": "Yhteystieto",
@@ -512,9 +508,7 @@ Object {
       "kuulutusVaihePaattyyPaiva": "2100-01-01",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
-        "yhteysHenkilot": Array [
-          "A000111",
-        ],
+        "yhteysHenkilot": Array [],
         "yhteysTiedot": Array [
           Object {
             "__typename": "Yhteystieto",
@@ -643,9 +637,7 @@ Object {
       "kuulutusVaihePaattyyPaiva": "2100-01-01",
       "kuulutusYhteystiedot": Object {
         "__typename": "StandardiYhteystiedot",
-        "yhteysHenkilot": Array [
-          "A000111",
-        ],
+        "yhteysHenkilot": Array [],
         "yhteysTiedot": Array [
           Object {
             "__typename": "Yhteystieto",

--- a/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
+++ b/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
@@ -1198,9 +1198,7 @@ Object {
     "arvioSeuraavanVaiheenAlkamisesta": "huomenna",
     "esitettavatYhteystiedot": Object {
       "__typename": "StandardiYhteystiedot",
-      "yhteysHenkilot": Array [
-        "A123456",
-      ],
+      "yhteysHenkilot": Array [],
       "yhteysTiedot": Array [
         Object {
           "__typename": "Yhteystieto",
@@ -1295,9 +1293,7 @@ Object {
         "alkamisAika": "10:00",
         "esitettavatYhteystiedot": Object {
           "__typename": "StandardiYhteystiedot",
-          "yhteysHenkilot": Array [
-            "A123456",
-          ],
+          "yhteysHenkilot": Array [],
           "yhteysTiedot": Array [
             Object {
               "__typename": "Yhteystieto",

--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -1,4 +1,4 @@
-import { AloitusKuulutus, AloitusKuulutusJulkaisu, RequiredLocalizedMap, UudelleenKuulutus } from "../../../database/model";
+import { AloitusKuulutus, AloitusKuulutusJulkaisu, DBVaylaUser, RequiredLocalizedMap, UudelleenKuulutus } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 import { KuulutusJulkaisuTila, LokalisoituTeksti, MuokkausTila } from "../../../../../common/graphql/apiModel";
 import {
@@ -15,6 +15,7 @@ import { adaptMuokkausTila, findJulkaisuWithTila } from "../../projektiUtil";
 import { ProjektiPaths } from "../../../files/ProjektiPath";
 
 export function adaptAloitusKuulutus(
+  kayttoOikeudet: DBVaylaUser[],
   kuulutus?: AloitusKuulutus | null,
   aloitusKuulutusJulkaisut?: AloitusKuulutusJulkaisu[] | null
 ): API.AloitusKuulutus | undefined {
@@ -28,7 +29,7 @@ export function adaptAloitusKuulutus(
       ...otherKuulutusFields,
       ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(kuulutus.ilmoituksenVastaanottajat),
       hankkeenKuvaus: adaptHankkeenKuvaus(kuulutus.hankkeenKuvaus),
-      kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kuulutusYhteystiedot),
+      kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kayttoOikeudet, kuulutusYhteystiedot),
       uudelleenKuulutus: adaptUudelleenKuulutus(uudelleenKuulutus),
       muokkausTila: adaptMuokkausTila(kuulutus, aloitusKuulutusJulkaisut),
     };

--- a/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
@@ -1,4 +1,5 @@
 import {
+  DBVaylaUser,
   Hyvaksymispaatos,
   HyvaksymisPaatosVaihe,
   HyvaksymisPaatosVaiheJulkaisu,
@@ -21,6 +22,7 @@ import { adaptMuokkausTila, findJulkaisuWithTila } from "../../projektiUtil";
 import { adaptUudelleenKuulutus } from "./adaptAloitusKuulutus";
 
 export function adaptHyvaksymisPaatosVaihe(
+  kayttoOikeudet: DBVaylaUser[],
   hyvaksymisPaatosVaihe: HyvaksymisPaatosVaihe | null | undefined,
   hyvaksymisPaatos: Hyvaksymispaatos | null | undefined,
   paths: PathTuple,
@@ -43,7 +45,7 @@ export function adaptHyvaksymisPaatosVaihe(
     ...rest,
     aineistoNahtavilla: adaptAineistot(aineistoNahtavilla, paths),
     hyvaksymisPaatos: adaptAineistot(hyvaksymisPaatosAineisto, paths),
-    kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kuulutusYhteystiedot),
+    kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kayttoOikeudet, kuulutusYhteystiedot),
     ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(ilmoituksenVastaanottajat),
     hyvaksymisPaatoksenPvm: hyvaksymisPaatos?.paatoksenPvm || undefined,
     hyvaksymisPaatoksenAsianumero: hyvaksymisPaatos?.asianumero || undefined,

--- a/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
@@ -41,7 +41,7 @@ export function adaptNahtavillaoloVaihe(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       lisaAineistoParametrit: lisaAineistoService.generateListingParams(dbProjekti.oid, nahtavillaoloVaihe.id, dbProjekti.salt),
-      kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kuulutusYhteystiedot),
+      kuulutusYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(dbProjekti.kayttoOikeudet, kuulutusYhteystiedot),
       ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(ilmoituksenVastaanottajat),
       hankkeenKuvaus: adaptHankkeenKuvaus(hankkeenKuvaus || undefined),
       muokkausTila: adaptMuokkausTila(nahtavillaoloVaihe, nahtavillaoloVaiheJulkaisut),

--- a/backend/src/projekti/adapter/adaptToAPI/adaptVuorovaikutusKierros.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptVuorovaikutusKierros.ts
@@ -1,4 +1,5 @@
 import {
+  DBVaylaUser,
   StandardiYhteystiedot,
   VuorovaikutusKierros,
   VuorovaikutusKierrosJulkaisu,
@@ -22,6 +23,7 @@ import { cloneDeep } from "lodash";
 import { ProjektiPaths } from "../../../files/ProjektiPath";
 
 export function adaptVuorovaikutusKierros(
+  kayttoOikeudet: DBVaylaUser[],
   oid: string,
   vuorovaikutusKierros: VuorovaikutusKierros | null | undefined
 ): API.VuorovaikutusKierros | undefined {
@@ -37,8 +39,8 @@ export function adaptVuorovaikutusKierros(
       __typename: "VuorovaikutusKierros",
       ...(vuorovaikutusKierros as Omit<VuorovaikutusKierros, "vuorovaikutusPDFt">),
       ilmoituksenVastaanottajat: adaptIlmoituksenVastaanottajat(vuorovaikutusKierros.ilmoituksenVastaanottajat),
-      esitettavatYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(vuorovaikutusKierros.esitettavatYhteystiedot),
-      vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(vuorovaikutusKierros.vuorovaikutusTilaisuudet),
+      esitettavatYhteystiedot: adaptStandardiYhteystiedotByAddingTypename(kayttoOikeudet, vuorovaikutusKierros.esitettavatYhteystiedot),
+      vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(kayttoOikeudet, vuorovaikutusKierros.vuorovaikutusTilaisuudet),
       suunnittelumateriaali: adaptLinkkiByAddingTypename(vuorovaikutusKierros.suunnittelumateriaali),
       videot: adaptLinkkiListByAddingTypename(vuorovaikutusKierros.videot),
       esittelyaineistot: adaptAineistot(vuorovaikutusKierros.esittelyaineistot, paths),
@@ -121,6 +123,7 @@ export function adaptVuorovaikutusKierrosJulkaisut(
 }
 
 function adaptVuorovaikutusTilaisuudet(
+  kayttoOikeudet: DBVaylaUser[],
   vuorovaikutusTilaisuudet: Array<VuorovaikutusTilaisuus> | null | undefined
 ): API.VuorovaikutusTilaisuus[] | undefined {
   if (vuorovaikutusTilaisuudet) {
@@ -133,7 +136,7 @@ function adaptVuorovaikutusTilaisuudet(
         __typename: "VuorovaikutusTilaisuus",
       };
       if (tilaisuus.tyyppi === API.VuorovaikutusTilaisuusTyyppi.SOITTOAIKA) {
-        tilaisuus.esitettavatYhteystiedot = adaptStandardiYhteystiedotByAddingTypename(esitettavatYhteystiedot);
+        tilaisuus.esitettavatYhteystiedot = adaptStandardiYhteystiedotByAddingTypename(kayttoOikeudet, esitettavatYhteystiedot);
       }
       return tilaisuus;
     });

--- a/backend/src/projekti/adapter/common/lisaaTypename.ts
+++ b/backend/src/projekti/adapter/common/lisaaTypename.ts
@@ -1,4 +1,4 @@
-import { Kielitiedot, Linkki, StandardiYhteystiedot, Suunnitelma, Velho, Yhteystieto } from "../../../database/model";
+import { DBVaylaUser, Kielitiedot, Linkki, StandardiYhteystiedot, Suunnitelma, Velho, Yhteystieto } from "../../../database/model";
 import * as API from "../../../../../common/graphql/apiModel";
 import { IllegalArgumentError } from "../../../error/IllegalArgumentError";
 import { kuntametadata } from "../../../../../common/kuntametadata";
@@ -75,6 +75,7 @@ export function adaptMandatoryYhteystiedotByAddingTypename(yhteystiedot: Yhteyst
 }
 
 export function adaptStandardiYhteystiedotByAddingTypename(
+  kayttoOikeudet: DBVaylaUser[],
   kuulutusYhteystiedot: StandardiYhteystiedot | undefined
 ): API.StandardiYhteystiedot | undefined {
   if (!kuulutusYhteystiedot) {
@@ -82,7 +83,7 @@ export function adaptStandardiYhteystiedotByAddingTypename(
   }
   return {
     __typename: "StandardiYhteystiedot",
-    yhteysHenkilot: kuulutusYhteystiedot.yhteysHenkilot,
+    yhteysHenkilot: kuulutusYhteystiedot.yhteysHenkilot?.filter((user) => kayttoOikeudet.find((oikeus) => oikeus.kayttajatunnus === user)),
     yhteysTiedot: adaptYhteystiedotByAddingTypename(kuulutusYhteystiedot.yhteysTiedot),
   };
 }

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -61,17 +61,18 @@ export class ProjektiAdapter {
       tallennettu: !!dbProjekti.tallennettu,
       kayttoOikeudet: KayttoOikeudetManager.adaptAPIKayttoOikeudet(kayttoOikeudet),
       tyyppi: velho?.tyyppi || dbProjekti.tyyppi, // remove usage of projekti.tyyppi after all data has been migrated to new format
-      aloitusKuulutus: adaptAloitusKuulutus(aloitusKuulutus, aloitusKuulutusJulkaisut),
+      aloitusKuulutus: adaptAloitusKuulutus(kayttoOikeudet, aloitusKuulutus, aloitusKuulutusJulkaisut),
       aloitusKuulutusJulkaisu: adaptAloitusKuulutusJulkaisu(dbProjekti.oid, aloitusKuulutusJulkaisut),
       suunnitteluSopimus: adaptSuunnitteluSopimus(dbProjekti.oid, suunnitteluSopimus),
       liittyvatSuunnitelmat: adaptLiittyvatSuunnitelmatByAddingTypename(liittyvatSuunnitelmat),
       velho: adaptVelho(velho),
       kielitiedot: adaptKielitiedotByAddingTypename(kielitiedot, true),
-      vuorovaikutusKierros: adaptVuorovaikutusKierros(dbProjekti.oid, vuorovaikutusKierros),
+      vuorovaikutusKierros: adaptVuorovaikutusKierros(kayttoOikeudet, dbProjekti.oid, vuorovaikutusKierros),
       vuorovaikutusKierrosJulkaisut: adaptVuorovaikutusKierrosJulkaisut(dbProjekti.oid, vuorovaikutusKierrosJulkaisut),
       nahtavillaoloVaihe: adaptNahtavillaoloVaihe(dbProjekti, nahtavillaoloVaihe, nahtavillaoloVaiheJulkaisut),
       nahtavillaoloVaiheJulkaisu: adaptNahtavillaoloVaiheJulkaisu(dbProjekti, nahtavillaoloVaiheJulkaisut),
       hyvaksymisPaatosVaihe: adaptHyvaksymisPaatosVaihe(
+        kayttoOikeudet,
         hyvaksymisPaatosVaihe,
         dbProjekti.kasittelynTila?.hyvaksymispaatos,
         projektiPath.hyvaksymisPaatosVaihe(hyvaksymisPaatosVaihe),
@@ -83,6 +84,7 @@ export class ProjektiAdapter {
         (julkaisu) => new ProjektiPaths(dbProjekti.oid).hyvaksymisPaatosVaihe(julkaisu)
       ),
       jatkoPaatos1Vaihe: adaptHyvaksymisPaatosVaihe(
+        kayttoOikeudet,
         jatkoPaatos1Vaihe,
         dbProjekti.kasittelynTila?.ensimmainenJatkopaatos,
         projektiPath.jatkoPaatos1Vaihe(jatkoPaatos1Vaihe),
@@ -94,6 +96,7 @@ export class ProjektiAdapter {
         (julkaisu) => new ProjektiPaths(dbProjekti.oid).jatkoPaatos1Vaihe(julkaisu)
       ),
       jatkoPaatos2Vaihe: adaptHyvaksymisPaatosVaihe(
+        kayttoOikeudet,
         jatkoPaatos2Vaihe,
         dbProjekti.kasittelynTila?.toinenJatkopaatos,
         projektiPath.jatkoPaatos2Vaihe(jatkoPaatos2Vaihe),

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -140,7 +140,11 @@ export class ProjektiAdapter {
       jatkoPaatos2Vaihe,
     } = changes;
     const projektiAdaptationResult: ProjektiAdaptationResult = new ProjektiAdaptationResult(projekti);
-    const kayttoOikeudetManager = new KayttoOikeudetManager(projekti.kayttoOikeudet, await personSearch.getKayttajas());
+    const kayttoOikeudetManager = new KayttoOikeudetManager(
+      projekti.kayttoOikeudet,
+      await personSearch.getKayttajas(),
+      projekti.suunnitteluSopimus?.yhteysHenkilo
+    );
     kayttoOikeudetManager.applyChanges(kayttoOikeudet);
     const aloitusKuulutusToSave = adaptAloitusKuulutusToSave(projekti.aloitusKuulutus, aloitusKuulutus);
 

--- a/backend/src/projekti/projektiHandler.ts
+++ b/backend/src/projekti/projektiHandler.ts
@@ -289,7 +289,11 @@ export async function synchronizeUpdatesFromVelho(oid: string, reset = false): P
       // Poista kaikki muut paitsi tuleva projektipäällikkö ja vastuuhenkilö
       remove(kayttoOikeudet, (user) => user.email !== vastuuhenkilonEmail && user.email !== varahenkilonEmail);
     }
-    const kayttoOikeudetManager = new KayttoOikeudetManager(kayttoOikeudet, await personSearch.getKayttajas());
+    const kayttoOikeudetManager = new KayttoOikeudetManager(
+      kayttoOikeudet,
+      await personSearch.getKayttajas(),
+      projektiFromDB.suunnitteluSopimus?.yhteysHenkilo
+    );
     kayttoOikeudetManager.addProjektiPaallikkoFromEmail(vastuuhenkilonEmail);
     kayttoOikeudetManager.addVarahenkiloFromEmail(varahenkilonEmail);
     const kayttoOikeudetNew = kayttoOikeudetManager.getKayttoOikeudet();

--- a/backend/test/projekti/kayttoOikeudetManager.test.ts
+++ b/backend/test/projekti/kayttoOikeudetManager.test.ts
@@ -16,8 +16,42 @@ describe("KayttoOikeudetManager", () => {
   const kayttajaA3 = personSearchFixture.createKayttaja("A3");
   const kayttajaA4 = personSearchFixture.createKayttaja("A4");
 
+  let users: DBVaylaUser[];
+
   beforeEach(() => {
     kayttajas = Kayttajas.fromKayttajaList([kayttajaA1, kayttajaA2, kayttajaA3, kayttajaA4]);
+    users = [
+      {
+        tyyppi: KayttajaTyyppi.PROJEKTIPAALLIKKO,
+        kayttajatunnus: kayttajaA1.uid as string,
+        email: kayttajaA1.email as string,
+        etunimi: kayttajaA1.etunimi as string,
+        sukunimi: kayttajaA1.sukunimi as string,
+        organisaatio: kayttajaA1.organisaatio as string,
+        puhelinnumero: kayttajaA1.puhelinnumero as string,
+        muokattavissa: false,
+      },
+      {
+        tyyppi: KayttajaTyyppi.VARAHENKILO,
+        kayttajatunnus: kayttajaA2.uid as string,
+        email: kayttajaA2.email as string,
+        etunimi: kayttajaA2.etunimi as string,
+        sukunimi: kayttajaA2.sukunimi as string,
+        organisaatio: kayttajaA2.organisaatio as string,
+        puhelinnumero: kayttajaA2.puhelinnumero as string,
+        muokattavissa: false,
+      },
+      {
+        tyyppi: null,
+        kayttajatunnus: kayttajaA3.uid as string,
+        email: kayttajaA3.email as string,
+        etunimi: kayttajaA3.etunimi as string,
+        sukunimi: kayttajaA3.sukunimi as string,
+        organisaatio: kayttajaA3.organisaatio as string,
+        puhelinnumero: kayttajaA3.puhelinnumero as string,
+        muokattavissa: true,
+      },
+    ];
   });
 
   function expectProjektiPaallikko(manager: KayttoOikeudetManager, uid: string) {
@@ -204,5 +238,35 @@ describe("KayttoOikeudetManager", () => {
       etunimi: "EtunimiA3",
       sukunimi: "SukunimiA3",
     });
+  });
+
+  it("should not allow kunnanEdustaja to be removed when applying changes", async () => {
+    const manager = new KayttoOikeudetManager(users, kayttajas, kayttajaA3.uid || undefined);
+    manager.applyChanges([
+      {
+        kayttajatunnus: kayttajaA1.uid as string,
+        puhelinnumero: kayttajaA1.puhelinnumero as string,
+      },
+      {
+        kayttajatunnus: kayttajaA2.uid as string,
+        puhelinnumero: kayttajaA2.puhelinnumero as string,
+      },
+    ]);
+    const kayttoOikeudet = manager.getKayttoOikeudet();
+    expect(kayttoOikeudet.length).eql(3);
+  });
+
+  it("should not allow kunnanEdustaja to be removed when doing addProjektiPaallikkoFromEmail", async () => {
+    const manager = new KayttoOikeudetManager(users, kayttajas, kayttajaA1.uid || undefined);
+    manager.addProjektiPaallikkoFromEmail(kayttajaA4.email);
+    const kayttoOikeudet = manager.getKayttoOikeudet();
+    expect(kayttoOikeudet.length).eql(4);
+  });
+
+  it("should not allow kunnanEdustaja to be removed when doing addVarahenkiloFromEmail", async () => {
+    const manager = new KayttoOikeudetManager(users, kayttajas, kayttajaA2.uid || undefined);
+    manager.addVarahenkiloFromEmail(kayttajaA4.email);
+    const kayttoOikeudet = manager.getKayttoOikeudet();
+    expect(kayttoOikeudet.length).eql(4);
   });
 });

--- a/backend/test/projekti/projektiAPIAdapter.test.ts
+++ b/backend/test/projekti/projektiAPIAdapter.test.ts
@@ -1,0 +1,126 @@
+import { describe, it } from "mocha";
+import { ProjektiFixture } from "../fixture/projektiFixture";
+import * as sinon from "sinon";
+import { projektiDatabase } from "../../src/database/projektiDatabase";
+import { UserFixture } from "../fixture/userFixture";
+import { AloitusKuulutus, DBProjekti, HyvaksymisPaatosVaihe, NahtavillaoloVaihe, VuorovaikutusKierros } from "../../src/database/model";
+import { loadProjekti } from "../../src/projekti/projektiHandler";
+import { userService } from "../../src/user";
+import { Projekti, VuorovaikutusTilaisuusTyyppi } from "../../../common/graphql/apiModel";
+
+const { expect } = require("chai");
+
+describe("projektiHandler", () => {
+  let fixture: ProjektiFixture;
+  let userFixture: UserFixture;
+  let loadProjektiByOid: sinon.SinonStub;
+  let projekti: DBProjekti;
+  beforeEach(() => {
+    fixture = new ProjektiFixture();
+    userFixture = new UserFixture(userService);
+    loadProjektiByOid = sinon.stub(projektiDatabase, "loadProjektiByOid");
+  });
+
+  afterEach(() => {
+    userFixture.logout();
+    sinon.restore();
+  });
+
+  it("loadProjekti should filter out references to removed users from aloituskuulutus", async () => {
+    projekti = fixture.dbProjekti1();
+    projekti = {
+      ...projekti,
+      aloitusKuulutus: {
+        ...projekti.aloitusKuulutus,
+        kuulutusYhteystiedot: {
+          yhteysTiedot: projekti.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysTiedot,
+          yhteysHenkilot: ["ABC1233"], // lisätään olematon yhteyshenkilö - kuvitteellisesti tämä on ollut kunnan edustaja, joka on vaihdettu toiseen ja poistettu
+        },
+      } as AloitusKuulutus,
+    };
+    loadProjektiByOid.resolves(projekti);
+    userFixture.loginAs(UserFixture.mattiMeikalainen);
+    const adaptoituProjekti: Projekti = (await loadProjekti(projekti.oid)) as Projekti;
+    expect(adaptoituProjekti.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysHenkilot?.length).to.eql(0);
+  });
+
+  it("loadProjekti should filter out references to removed users from vuorovaikutusKierros's esitettavatYhteystiedot", async () => {
+    projekti = fixture.dbProjekti4();
+    projekti = {
+      ...projekti,
+      vuorovaikutusKierros: {
+        ...projekti.vuorovaikutusKierros,
+        esitettavatYhteystiedot: {
+          yhteysTiedot: projekti.vuorovaikutusKierros?.esitettavatYhteystiedot?.yhteysTiedot,
+          yhteysHenkilot: [...(projekti.vuorovaikutusKierros?.esitettavatYhteystiedot?.yhteysHenkilot as string[]), "ABC1233"], // lisätään olematon yhteyshenkilö - kuvitteellisesti tämä on ollut kunnan edustaja, joka on vaihdettu toiseen ja poistettu
+        }, // yhteyshenkilöitä on yksi validi
+      } as VuorovaikutusKierros,
+    };
+    loadProjektiByOid.resolves(projekti);
+    userFixture.loginAs(UserFixture.mattiMeikalainen);
+    const adaptoituProjekti: Projekti = (await loadProjekti(projekti.oid)) as Projekti;
+    expect(adaptoituProjekti.vuorovaikutusKierros?.esitettavatYhteystiedot?.yhteysHenkilot?.length).to.eql(1);
+  });
+
+  it("loadProjekti should filter out references to removed users from vuorovaikutusKierros's vuorovaikutusTilaisuudet", async () => {
+    projekti = fixture.dbProjekti4();
+    projekti = {
+      ...projekti,
+      vuorovaikutusKierros: {
+        ...projekti.vuorovaikutusKierros,
+        vuorovaikutusTilaisuudet: [
+          {
+            tyyppi: VuorovaikutusTilaisuusTyyppi.SOITTOAIKA,
+            nimi: "Lorem ipsum",
+            paivamaara: "2022-03-04",
+            alkamisAika: "15:00",
+            paattymisAika: "16:00",
+            esitettavatYhteystiedot: {
+              yhteysHenkilot: [projekti.kayttoOikeudet[0].kayttajatunnus, "ABC1233"], // lisätään olematon yhteyshenkilö - kuvitteellisesti tämä on ollut kunnan edustaja, joka on vaihdettu toiseen ja poistettu
+            },
+          },
+        ],
+      } as VuorovaikutusKierros,
+    };
+    loadProjektiByOid.resolves(projekti);
+    userFixture.loginAs(UserFixture.mattiMeikalainen);
+    const adaptoituProjekti: Projekti = (await loadProjekti(projekti.oid)) as Projekti;
+    expect(adaptoituProjekti.vuorovaikutusKierros?.vuorovaikutusTilaisuudet?.[0].esitettavatYhteystiedot?.yhteysHenkilot?.length).to.eql(1);
+  });
+
+  it("loadProjekti should filter out references to removed users from nähtävilläolovaihe", async () => {
+    projekti = fixture.dbProjekti4();
+    projekti = {
+      ...projekti,
+      nahtavillaoloVaihe: {
+        ...projekti.nahtavillaoloVaihe,
+        kuulutusYhteystiedot: {
+          yhteysTiedot: projekti.nahtavillaoloVaihe?.kuulutusYhteystiedot?.yhteysTiedot,
+          yhteysHenkilot: [...(projekti.nahtavillaoloVaihe?.kuulutusYhteystiedot?.yhteysHenkilot as string[]), "ABC1233"], // lisätään olematon yhteyshenkilö - kuvitteellisesti tämä on ollut kunnan edustaja, joka on vaihdettu toiseen ja poistettu
+        }, // kaksi validia yhteyshenkilöä
+      } as NahtavillaoloVaihe,
+    };
+    loadProjektiByOid.resolves(projekti);
+    userFixture.loginAs(UserFixture.mattiMeikalainen);
+    const adaptoituProjekti: Projekti = (await loadProjekti(projekti.oid)) as Projekti;
+    expect(adaptoituProjekti.nahtavillaoloVaihe?.kuulutusYhteystiedot?.yhteysHenkilot?.length).to.eql(2);
+  });
+
+  it("loadProjekti should filter out references to removed users from hyvaäksymispäätösVaihe", async () => {
+    projekti = fixture.dbProjekti2();
+    projekti = {
+      ...projekti,
+      hyvaksymisPaatosVaihe: {
+        ...projekti.hyvaksymisPaatosVaihe,
+        kuulutusYhteystiedot: {
+          yhteysTiedot: projekti.hyvaksymisPaatosVaihe?.kuulutusYhteystiedot?.yhteysTiedot,
+          yhteysHenkilot: [...(projekti.hyvaksymisPaatosVaihe?.kuulutusYhteystiedot?.yhteysHenkilot as string[]), "ABC1233"], // lisätään olematon yhteyshenkilö - kuvitteellisesti tämä on ollut kunnan edustaja, joka on vaihdettu toiseen ja poistettu
+        }, // kaksi validia yhteyshenkilöä
+      } as HyvaksymisPaatosVaihe,
+    };
+    loadProjektiByOid.resolves(projekti);
+    userFixture.loginAs(UserFixture.mattiMeikalainen);
+    const adaptoituProjekti: Projekti = (await loadProjekti(projekti.oid)) as Projekti;
+    expect(adaptoituProjekti.hyvaksymisPaatosVaihe?.kuulutusYhteystiedot?.yhteysHenkilot?.length).to.eql(2);
+  });
+});

--- a/backend/test/projekti/projektiAdapter.test.ts
+++ b/backend/test/projekti/projektiAdapter.test.ts
@@ -119,7 +119,7 @@ describe("projektiAdapter", () => {
     });
   });
 
-  it("should precent suunnittelusopimus from being removed if latest aloituskuulutusjulkaisu is waiting for approval", async () => {
+  it("should precent suunnittelusopimus from being added if latest aloituskuulutusjulkaisu is waiting for approval", async () => {
     const projekti = fixture.dbProjekti2();
     delete projekti.suunnitteluSopimus;
     projekti.aloitusKuulutusJulkaisut?.push({
@@ -127,7 +127,7 @@ describe("projektiAdapter", () => {
       tila: KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA,
     });
 
-    // Validate that there is an error if trying to publish suunnitteluvaihe before there is a published aloituskuulutusjulkaisu
+    // Validate that there is an error if trying to add suunnittelusopimus before there is a published aloituskuulutusjulkaisu
     expect(
       projektiAdapter.adaptProjektiToSave(projekti, {
         oid: projekti.oid,

--- a/backend/test/projekti/projektiHandler.test.ts
+++ b/backend/test/projekti/projektiHandler.test.ts
@@ -10,6 +10,8 @@ import { userService } from "../../src/user";
 import { personSearch } from "../../src/personSearch/personSearchClient";
 import { PersonSearchFixture } from "../personSearch/lambda/personSearchFixture";
 import { Kayttajas } from "../../src/personSearch/kayttajas";
+import { KayttajaTyyppi } from "../../../common/graphql/apiModel";
+import { DBProjekti } from "../../src/database/model";
 
 const { expect } = require("chai");
 
@@ -18,7 +20,7 @@ describe("projektiHandler", () => {
   let saveProjektiStub: sinon.SinonStub;
   let loadVelhoProjektiByOidStub: sinon.SinonStub;
   let userFixture: UserFixture;
-
+  let loadProjektiByOid: sinon.SinonStub;
   beforeEach(() => {
     saveProjektiStub = sinon.stub(projektiDatabase, "saveProjektiWithoutLocking");
     loadVelhoProjektiByOidStub = sinon.stub(velho, "loadProjekti");
@@ -30,7 +32,9 @@ describe("projektiHandler", () => {
 
     userFixture = new UserFixture(userService);
     fixture = new ProjektiFixture();
-    sinon.stub(projektiDatabase, "loadProjektiByOid").resolves(fixture.dbProjekti1());
+
+    loadProjektiByOid = sinon.stub(projektiDatabase, "loadProjektiByOid");
+    loadProjektiByOid.resolves(fixture.dbProjekti1());
     const updatedProjekti = fixture.dbProjekti1();
     const velhoData = updatedProjekti.velho;
     velhoData.nimi = "Uusi nimi";
@@ -58,5 +62,21 @@ describe("projektiHandler", () => {
     await synchronizeUpdatesFromVelho("1");
     expect(saveProjektiStub.calledOnce);
     expect(saveProjektiStub.getCall(0).firstArg).toMatchSnapshot();
+  });
+
+  it("should not allow kunnanEdustaja from being removed, when doing synchronizeUpdatesFromVelho", async () => {
+    userFixture.loginAs(UserFixture.mattiMeikalainen);
+    const projariKunnanEdustajana: DBProjekti = { ...fixture.dbProjekti1() };
+    const projari = projariKunnanEdustajana.kayttoOikeudet.find((user) => user.tyyppi === KayttajaTyyppi.PROJEKTIPAALLIKKO);
+    projariKunnanEdustajana.suunnitteluSopimus = {
+      yhteysHenkilo: projari?.kayttajatunnus,
+      kunta: 1,
+      logo: "logo.gif",
+    };
+    loadProjektiByOid.reset();
+    loadProjektiByOid.resolves(projariKunnanEdustajana);
+    await synchronizeUpdatesFromVelho("1");
+    expect(saveProjektiStub.calledOnce);
+    expect(saveProjektiStub.getCall(0).firstArg.kayttoOikeudet.length).eql(5);
   });
 });

--- a/src/components/projekti/KayttoOikeusHallinta.tsx
+++ b/src/components/projekti/KayttoOikeusHallinta.tsx
@@ -312,7 +312,7 @@ const UserFields = ({
               inputProps={{ maxLength: maxPhoneLength }}
               disabled={disableFields}
             />
-            {muokattavissa && (
+            {muokattavissa && !isSuunnitteluSopimusYhteysHenkilo && (
               <div>
                 <IconButton
                   data-testid={`poista.kayttoOikeudet.${index}`}
@@ -366,6 +366,12 @@ const UserFields = ({
       {!muokattavissa && !isProjektiPaallikko && (
         <p>Tämän henkilön tiedot on haettu Projektivelhosta. Jos haluat poistaa tämän henkilön, muutos pitää tehdä Projektivelhoon.</p>
       )}
+      {isSuunnitteluSopimusYhteysHenkilo && muokattavissa && (
+        <p>
+          Kunnan edustajaksi liitettyä henkilöä ei voi poistaa Projektin henkilöt -sivulta, ennen kuin suunnittelusopimukseen on liitetty
+          toinen henkilö.
+        </p>
+      )}
       <Controller<RequiredInputValues>
         name={`kayttoOikeudet.${index}.yleinenYhteystieto`}
         shouldUnregister
@@ -386,7 +392,7 @@ const UserFields = ({
           />
         )}
       />
-      {!!muokattavissa && isMobile && (
+      {!!muokattavissa && isMobile && !isSuunnitteluSopimusYhteysHenkilo && (
         <Button
           onClick={(event) => {
             event.preventDefault();

--- a/src/pages/yllapito/projekti/[oid]/henkilot.tsx
+++ b/src/pages/yllapito/projekti/[oid]/henkilot.tsx
@@ -141,6 +141,7 @@ function Henkilot({ projekti, projektiLoadError, reloadProjekti }: HenkilotFormP
     },
     [setFormContext]
   );
+
   return (
     <>
       <FormProvider {...useFormReturn}>


### PR DESCRIPTION
Toteutettu bäkkäriin ja fronttiin esto kunnan edustajan poistamiselle. Jos projektin henkilö on kunnan edustaja, sille ei pitäisi näkyä UI:ssa poistonappulaa. Lisäksi BE estää kunnan edustajan poistamisen.

Velho-synkronoinnin yhteydessä kunnan edustaja ei poistu, vaikka kunnan edustaja olisi ollut velhosta alun perin tullut projektin projektipäällikkö tai varahenkilö. Jos velhosta tulee synkronoinnin yhteydessä uusi projektipäällikkö tai varahenkilö, kunnan edustaja muutetaan tavalliseksi, muokattavissa olevaksi projektin henkilöksi synkronoinnin yhteydessä.

Kunnan edustaja on mahdollista vaihtaa, minkä jälkeen vanhan kunnan edustajan voi poistaa. Aloituskuulutuksessa, VuorovaikutusKierroksessa, NahtavillaoloVaiheessa, HyvaksymisPaatosVaiheessa ja JatkoPaatosVaiheissa voi olla tämän jälkeen yhä referenssejä vanhaan kunnan edustajaan. Tämä ratkaistaan sillä, että virkamiespuolen adapterit filtteröivät rikkinäiset referenssit pois. Ei ole mahdollista tulla tilannetta, jossa UI:ssa näkyy rikkinäinen refenressi. Sen sijaan kaikkiin julkaistuihin materiaaleihin on muutettu referenssi yhteystiedoksi.

Testausvaiheessa on hyvä testata mm. se, että luo projektin, jolla on velhosta tulevien henkilöiden lisäksi joku kunnan edustaja. Sitten luo vuorovaikutuskierroksen soittoajalla, jonka yhteystieto on kunnan edustaja (ei muita). Sitten vaihtaa kunnan edustajan toiseksi, poistaa alkuperäisen kunnan edustajan ja menee muokkaamaan soittoajan yhteystietoja. Muokkaustilaan pitäisi päästä, mutta siinä ei pitäisi näkyä yhtään valittua yhteystietoa. Ennen tallennusta on annettava jokin uusi yhteystieto.