### PR TITLE
feat: Piilota suunnitteluvaiheen palautteenantonappi

### DIFF
--- a/src/locales/fi/suunnittelu.json
+++ b/src/locales/fi/suunnittelu.json
@@ -9,7 +9,8 @@
     "otsikko": "Osallistumisen ja vaikuttamisen mahdollisuudet ja aikataulut",
     "voit_osallistua_vuorovaikutuksiin": "Voit osallistua vuorovaikutustilaisuuksiin, tutustua suunnittelu- ja esittelyaineistoihin sekä jättää palautteen tai kysyä hankkeesta. Osallistumalla sinulla on mahdollisuus vaikuttaa hankkeen suunnitteluun.",
     "aineistot_ovat_tutustuttavissa": "<p>Suunnitelmaluonnokset ja esittelyaineistot ovat tutustuttavissa alempaa tältä sivulta. <a>Siirry aineistoihin.</a></p>",
-    "kysymykset_ja_palautteet": "<p>Kysymykset ja palautteet toivotaan esitettävän {{paivamaara}} mennessä. <a>Siirry lomakkeelle.</a></p>"
+    "kysymykset_ja_palautteet": "Kysymykset ja palautteet toivotaan esitettävän {{paivamaara}} mennessä.",
+    "siirry_lomakkeelle": "<a>Siirry lomakkeelle.</a>"
   },
   "videoesittely": {
     "otsikko": "Enakkoon kuvattu videoesittely",
@@ -35,7 +36,6 @@
       "osoite": "Osoite: {{paikka}}{{osoite}}, {{postinumero}} {{postitoimipaikka}}",
       "yleisotilaisuus_jarjestetaan": "Yleisötilaisuus järjestetään fyysisenä tilaisuutena ylläolevassa osoitteessa.",
       "saapumisohje": "Saapumisohje: {{saapumisohje}}"
-
     },
     "soittoaika": {
       "voit_soittaa": "Voit soittaa alla esitetyille henkilöille myös soittoajan ulkopuolella, mutta parhaiten tavoitat heidät esitettynä ajankohtana."

--- a/src/locales/sv/suunnittelu.json
+++ b/src/locales/sv/suunnittelu.json
@@ -8,8 +8,9 @@
   "vuorovaikuttaminen": {
     "otsikko": "RUOTSIKSI Osallistumisen ja vaikuttamisen mahdollisuudet ja aikataulut",
     "voit_osallistua_vuorovaikutuksiin": "RUOTSIKSI Voit osallistua vuorovaikutustilaisuuksiin, tutustua suunnittelu- ja esittelyaineistoihin sekä jättää palautteen tai kysyä hankkeesta. Osallistumalla sinulla on mahdollisuus vaikuttaa hankkeen suunnitteluun.",
-    "aineistot_ovat_tutustuttavissa": "RUOTSIKSI <p>Suunnitelmaluonnokset ja esittelyaineistot ovat tutustuttavissa alempaa tältä sivulta. <a>Siirry aineistoihin.</a></p>",
-    "kysymykset_ja_palautteet": "RUOTSIKSI <p>Kysymykset ja palautteet toivotaan esitettävän {{paivamaara}} mennessä. <a>Siirry lomakkeelle.</a></p>"
+    "aineistot_ovat_tutustuttavissa": "<p> RUOTSIKSI Suunnitelmaluonnokset ja esittelyaineistot ovat tutustuttavissa alempaa tältä sivulta. <a>Siirry aineistoihin.</a></p>",
+    "kysymykset_ja_palautteet": "RUOTSIKSI Kysymykset ja palautteet toivotaan esitettävän {{paivamaara}} mennessä.",
+    "siirry_lomakkeelle": "<a>RUOTSIKSI Siirry lomakkeelle.</a>"
   },
   "videoesittely": {
     "otsikko": "RUOTSIKSI Enakkoon kuvattu videoesittely",

--- a/src/pages/suunnitelma/[oid]/suunnittelu.tsx
+++ b/src/pages/suunnitelma/[oid]/suunnittelu.tsx
@@ -11,6 +11,7 @@ import LocationCityIcon from "@mui/icons-material/LocationCity";
 import LocalPhoneIcon from "@mui/icons-material/LocalPhone";
 import {
   ProjektiJulkinen,
+  Status,
   VuorovaikutusKierrosJulkinen,
   VuorovaikutusKierrosTila,
   VuorovaikutusTilaisuusJulkinen,
@@ -91,6 +92,7 @@ const VuorovaikutusTiedot: FunctionComponent<{
   const [palauteLomakeOpen, setPalauteLomakeOpen] = useState(false);
   const { t, lang } = useTranslation("suunnittelu");
   const kieli = useKansalaiskieli();
+  const { data: projekti } = useProjektiJulkinen();
 
   const now = dayjs();
 
@@ -117,11 +119,18 @@ const VuorovaikutusTiedot: FunctionComponent<{
           {vuorovaikutus && (
             <>
               <Trans i18nKey="suunnittelu:vuorovaikuttaminen.aineistot_ovat_tutustuttavissa" components={{ p: <p />, a: <a href="" /> }} />
-              <Trans
-                i18nKey="suunnittelu:vuorovaikuttaminen.kysymykset_ja_palautteet"
-                values={{ paivamaara: formatDate(vuorovaikutus.kysymyksetJaPalautteetViimeistaan) }}
-                components={{ p: <p />, a: <a href="" /> }}
-              />
+              <p>
+                <Trans
+                  i18nKey="suunnittelu:vuorovaikuttaminen.kysymykset_ja_palautteet"
+                  values={{ paivamaara: formatDate(vuorovaikutus.kysymyksetJaPalautteetViimeistaan) }}
+                />{" "}
+                {projekti?.status === Status.SUUNNITTELU && (
+                  <Trans
+                    i18nKey="suunnittelu:vuorovaikuttaminen.siirry_lomakkeelle"
+                    components={{ a: <button onClick={() => setPalauteLomakeOpen(true)} /> }}
+                  />
+                )}
+              </p>
             </>
           )}
         </SectionContent>
@@ -231,13 +240,17 @@ const VuorovaikutusTiedot: FunctionComponent<{
       )}
       {vuorovaikutus && (
         <>
-          <JataPalautettaNappi teksti={t("projekti:palautelomake.jata_palaute")} onClick={() => setPalauteLomakeOpen(true)} />
-          <PalauteLomakeDialogi
-            vuorovaikutus={vuorovaikutus}
-            open={palauteLomakeOpen}
-            onClose={() => setPalauteLomakeOpen(false)}
-            projektiOid={projektiOid}
-          />
+          {projekti?.status === Status.SUUNNITTELU && (
+            <>
+              <JataPalautettaNappi teksti={t("projekti:palautelomake.jata_palaute")} onClick={() => setPalauteLomakeOpen(true)} />
+              <PalauteLomakeDialogi
+                vuorovaikutus={vuorovaikutus}
+                open={palauteLomakeOpen}
+                onClose={() => setPalauteLomakeOpen(false)}
+                projektiOid={projektiOid}
+              />
+            </>
+          )}
           <h4 className="vayla-small-title">{t(`ladattava_kuulutus.otsikko`)}</h4>
           <SectionContent className="flex gap-4">
             <ExtLink className="file_download" href={kutsuPDFPath.path}>


### PR DESCRIPTION
Piilota palautteenantonappi kun nähtävilläolovaihe alkaa. Tätä varten piti vähän muokata käännöksiä, koska tekstissä oli linkki palautteenantoon.