### PR TITLE
feat: hassu 1436 välitä kansalaispuolelle hyväksymispäätöksen kuulutus ja näytä se

### DIFF
--- a/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusUudelleenKuulutus.test.ts.snap
+++ b/backend/integrationtest/aloitusKuulutus/__snapshots__/aloitusKuulutusUudelleenKuulutus.test.ts.snap
@@ -258,14 +258,6 @@ Object {
   "description": "publicProjekti uudelleenkuulutuksen jälkeen",
   "obj": Object {
     "__typename": "AloitusKuulutusJulkaisuJulkinen",
-    "aloituskuulutusPDFt": Object {
-      "SUOMI": Object {
-        "__typename": "AloitusKuulutusPDF",
-        "aloituskuulutusIlmoitusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-        "aloituskuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412 Aloituskuulutus.pdf",
-      },
-      "__typename": "AloitusKuulutusPDFt",
-    },
     "hankkeenKuvaus": Object {
       "RUOTSI": "På Svenska",
       "SAAME": "Saameksi",
@@ -275,6 +267,10 @@ Object {
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
+    },
+    "kuulutusPDF": Object {
+      "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "__typename": "KuulutusPDFJulkinen",
     },
     "kuulutusPaiva": "2000-01-01",
     "kuulutusTekstit": Object {

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -3291,6 +3291,17 @@ Object {
     "hyvaksymisPaatoksenAsianumero": "asianro123",
     "hyvaksymisPaatoksenPvm": "2022-06-09",
     "hyvaksymisPaatos": undefined,
+    "hyvaksymisPaatosVaihePDFt": Object {
+      "SUOMI": Object {
+        "__typename": "HyvaksymisPaatosVaihePDF",
+        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+        "hyvaksymisKuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+      },
+      "__typename": "HyvaksymisPaatosVaihePDFt",
+    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",

--- a/backend/integrationtest/api/__snapshots__/api.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/api.test.ts.snap
@@ -5,14 +5,6 @@ Object {
   "description": "Julkinen aloituskuulutus teksteineen",
   "obj": Object {
     "__typename": "AloitusKuulutusJulkaisuJulkinen",
-    "aloituskuulutusPDFt": Object {
-      "SUOMI": Object {
-        "__typename": "AloitusKuulutusPDF",
-        "aloituskuulutusIlmoitusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-        "aloituskuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412 Aloituskuulutus.pdf",
-      },
-      "__typename": "AloitusKuulutusPDFt",
-    },
     "hankkeenKuvaus": Object {
       "RUOTSI": "På Svenska",
       "SAAME": "Saameksi",
@@ -22,6 +14,10 @@ Object {
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
+    },
+    "kuulutusPDF": Object {
+      "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412 Aloituskuulutus.pdf",
+      "__typename": "KuulutusPDFJulkinen",
     },
     "kuulutusPaiva": "2022-01-02",
     "kuulutusTekstit": Object {
@@ -1297,14 +1293,6 @@ Object {
     "__typename": "ProjektiJulkinen",
     "aloitusKuulutusJulkaisu": Object {
       "__typename": "AloitusKuulutusJulkaisuJulkinen",
-      "aloituskuulutusPDFt": Object {
-        "SUOMI": Object {
-          "__typename": "AloitusKuulutusPDF",
-          "aloituskuulutusIlmoitusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412 Aloituskuulutus.pdf",
-        },
-        "__typename": "AloitusKuulutusPDFt",
-      },
       "hankkeenKuvaus": Object {
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
@@ -1314,6 +1302,10 @@ Object {
       "kielitiedot": Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",
+      },
+      "kuulutusPDF": Object {
+        "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/aloituskuulutus/T412 Aloituskuulutus.pdf",
+        "__typename": "KuulutusPDFJulkinen",
       },
       "kuulutusPaiva": "2022-01-02",
       "kuulutusTekstit": Object {
@@ -2553,6 +2545,10 @@ Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
     },
+    "kuulutusPDF": Object {
+      "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf",
+      "__typename": "KuulutusPDFJulkinen",
+    },
     "kuulutusPaiva": "2022-06-07",
     "kuulutusTekstit": Object {
       "__typename": "KuulutusTekstit",
@@ -3291,20 +3287,13 @@ Object {
     "hyvaksymisPaatoksenAsianumero": "asianro123",
     "hyvaksymisPaatoksenPvm": "2022-06-09",
     "hyvaksymisPaatos": undefined,
-    "hyvaksymisPaatosVaihePDFt": Object {
-      "SUOMI": Object {
-        "__typename": "HyvaksymisPaatosVaihePDF",
-        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-        "hyvaksymisKuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
-      },
-      "__typename": "HyvaksymisPaatosVaihePDFt",
-    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
+    },
+    "kuulutusPDF": Object {
+      "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2978288874.2711575506/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+      "__typename": "KuulutusPDFJulkinen",
     },
     "kuulutusPaiva": "2022-06-09",
     "kuulutusTekstit": Object {

--- a/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
@@ -372,6 +372,17 @@ Object {
         "tuotu": "***unittest***",
       },
     ],
+    "hyvaksymisPaatosVaihePDFt": Object {
+      "SUOMI": Object {
+        "__typename": "HyvaksymisPaatosVaihePDF",
+        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/jatkopaatos1/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/jatkopaatos1/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+        "hyvaksymisKuulutusPDFPath": "/jatkopaatos1/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/jatkopaatos1/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/jatkopaatos1/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+      },
+      "__typename": "HyvaksymisPaatosVaihePDFt",
+    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
@@ -822,6 +833,17 @@ Object {
         "tuotu": "***unittest***",
       },
     ],
+    "hyvaksymisPaatosVaihePDFt": Object {
+      "SUOMI": Object {
+        "__typename": "HyvaksymisPaatosVaihePDF",
+        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/jatkopaatos2/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/jatkopaatos2/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+        "hyvaksymisKuulutusPDFPath": "/jatkopaatos2/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/jatkopaatos2/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/jatkopaatos2/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+      },
+      "__typename": "HyvaksymisPaatosVaihePDFt",
+    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",

--- a/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
+++ b/backend/integrationtest/api/__snapshots__/jatkopaatos.test.ts.snap
@@ -372,20 +372,13 @@ Object {
         "tuotu": "***unittest***",
       },
     ],
-    "hyvaksymisPaatosVaihePDFt": Object {
-      "SUOMI": Object {
-        "__typename": "HyvaksymisPaatosVaihePDF",
-        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/jatkopaatos1/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/jatkopaatos1/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-        "hyvaksymisKuulutusPDFPath": "/jatkopaatos1/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/jatkopaatos1/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/jatkopaatos1/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
-      },
-      "__typename": "HyvaksymisPaatosVaihePDFt",
-    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
+    },
+    "kuulutusPDF": Object {
+      "SUOMI": "/jatkopaatos1/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+      "__typename": "KuulutusPDFJulkinen",
     },
     "kuulutusPaiva": "2022-06-09",
     "kuulutusVaihePaattyyPaiva": "2100-01-01",
@@ -833,20 +826,13 @@ Object {
         "tuotu": "***unittest***",
       },
     ],
-    "hyvaksymisPaatosVaihePDFt": Object {
-      "SUOMI": Object {
-        "__typename": "HyvaksymisPaatosVaihePDF",
-        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/jatkopaatos2/1/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/jatkopaatos2/1/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-        "hyvaksymisKuulutusPDFPath": "/jatkopaatos2/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/jatkopaatos2/1/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/jatkopaatos2/1/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
-      },
-      "__typename": "HyvaksymisPaatosVaihePDFt",
-    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
+    },
+    "kuulutusPDF": Object {
+      "SUOMI": "/jatkopaatos2/1/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+      "__typename": "KuulutusPDFJulkinen",
     },
     "kuulutusPaiva": "2022-06-09",
     "kuulutusVaihePaattyyPaiva": "2100-01-01",

--- a/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
+++ b/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
@@ -354,6 +354,17 @@ Object {
     "hyvaksymisPaatoksenAsianumero": "asianro123",
     "hyvaksymisPaatoksenPvm": "2022-06-09",
     "hyvaksymisPaatos": undefined,
+    "hyvaksymisPaatosVaihePDFt": Object {
+      "SUOMI": Object {
+        "__typename": "HyvaksymisPaatosVaihePDF",
+        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+        "hyvaksymisKuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
+        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+      },
+      "__typename": "HyvaksymisPaatosVaihePDFt",
+    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
@@ -462,6 +473,17 @@ Object {
       "hyvaksymisPaatoksenAsianumero": "asianro123",
       "hyvaksymisPaatoksenPvm": "2022-06-09",
       "hyvaksymisPaatos": undefined,
+      "hyvaksymisPaatosVaihePDFt": Object {
+        "SUOMI": Object {
+          "__typename": "HyvaksymisPaatosVaihePDF",
+          "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+          "hyvaksymisIlmoitusMuistuttajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+          "hyvaksymisKuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+        },
+        "__typename": "HyvaksymisPaatosVaihePDFt",
+      },
       "kielitiedot": Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",

--- a/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
+++ b/backend/integrationtest/migraatio/__snapshots__/migration.test.ts.snap
@@ -354,20 +354,13 @@ Object {
     "hyvaksymisPaatoksenAsianumero": "asianro123",
     "hyvaksymisPaatoksenPvm": "2022-06-09",
     "hyvaksymisPaatos": undefined,
-    "hyvaksymisPaatosVaihePDFt": Object {
-      "SUOMI": Object {
-        "__typename": "HyvaksymisPaatosVaihePDF",
-        "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-        "hyvaksymisIlmoitusMuistuttajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-        "hyvaksymisKuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
-        "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
-      },
-      "__typename": "HyvaksymisPaatosVaihePDFt",
-    },
     "kielitiedot": Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
+    },
+    "kuulutusPDF": Object {
+      "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+      "__typename": "KuulutusPDFJulkinen",
     },
     "kuulutusPaiva": "2022-06-09",
     "kuulutusTekstit": Object {
@@ -473,20 +466,13 @@ Object {
       "hyvaksymisPaatoksenAsianumero": "asianro123",
       "hyvaksymisPaatoksenPvm": "2022-06-09",
       "hyvaksymisPaatos": undefined,
-      "hyvaksymisPaatosVaihePDFt": Object {
-        "SUOMI": Object {
-          "__typename": "HyvaksymisPaatosVaihePDF",
-          "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_3 Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
-          "hyvaksymisIlmoitusMuistuttajillePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_4 Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
-          "hyvaksymisKuulutusPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
-          "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_1 Ilmoitus hyvaksymispaatoksesta kunnalle ja toiselle viranomaiselle.pdf",
-          "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431_2 Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
-        },
-        "__typename": "HyvaksymisPaatosVaihePDFt",
-      },
       "kielitiedot": Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",
+      },
+      "kuulutusPDF": Object {
+        "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2789861876.697619507/hyvaksymispaatos/T431 Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+        "__typename": "KuulutusPDFJulkinen",
       },
       "kuulutusPaiva": "2022-06-09",
       "kuulutusTekstit": Object {
@@ -1085,6 +1071,10 @@ Object {
       "__typename": "Kielitiedot",
       "ensisijainenKieli": "SUOMI",
     },
+    "kuulutusPDF": Object {
+      "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf",
+      "__typename": "KuulutusPDFJulkinen",
+    },
     "kuulutusPaiva": "2022-06-07",
     "kuulutusTekstit": Object {
       "__typename": "KuulutusTekstit",
@@ -1211,6 +1201,10 @@ Object {
       "kielitiedot": Object {
         "__typename": "Kielitiedot",
         "ensisijainenKieli": "SUOMI",
+      },
+      "kuulutusPDF": Object {
+        "SUOMI": "/tiedostot/suunnitelma/1.2.246.578.5.1.2574551391.2902330452/nahtavillaolo/T414 Kuulutus suunnitelman nahtavillaolo.pdf",
+        "__typename": "KuulutusPDFJulkinen",
       },
       "kuulutusPaiva": "2022-06-07",
       "kuulutusTekstit": Object {

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -5,8 +5,8 @@ import {
   DBVaylaUser,
   Hyvaksymispaatos,
   HyvaksymisPaatosVaiheJulkaisu,
-  HyvaksymisPaatosVaihePDF,
   LocalizedMap,
+  NahtavillaoloVaiheJulkaisu,
   UudelleenKuulutus,
   Velho,
   VuorovaikutusKierrosJulkaisu,
@@ -167,7 +167,7 @@ class ProjektiAdapterJulkinen {
       velho: adaptVelho(velho),
       suunnitteluSopimus: adaptSuunnitteluSopimusJulkaisuJulkinen(oid, suunnitteluSopimus),
       kielitiedot: adaptKielitiedotByAddingTypename(kielitiedot),
-      aloituskuulutusPDFt: this.adaptJulkaisuPDFPaths(oid, julkaisu),
+      kuulutusPDF: this.adaptJulkaisuPDFPaths(oid, julkaisu),
       tila,
       uudelleenKuulutus: adaptUudelleenKuulutus(uudelleenKuulutus),
     };
@@ -180,32 +180,31 @@ class ProjektiAdapterJulkinen {
     return julkaisuJulkinen;
   }
 
-  adaptJulkaisuPDFPaths(oid: string, aloitusKuulutus: AloitusKuulutusJulkaisu): API.AloitusKuulutusPDFt | undefined {
-    const aloitusKuulutusPDFS = aloitusKuulutus.aloituskuulutusPDFt;
-    if (!aloitusKuulutusPDFS) {
+  adaptJulkaisuPDFPaths(oid: string, aloitusKuulutus: AloitusKuulutusJulkaisu): API.KuulutusPDFJulkinen | undefined {
+    if (!aloitusKuulutus.aloituskuulutusPDFt) {
       return undefined;
     }
 
-    if (!aloitusKuulutusPDFS[API.Kieli.SUOMI]) {
+    const { SUOMI: suomiPDFS, ...muunKielisetPDFS } = aloitusKuulutus.aloituskuulutusPDFt || {};
+
+    if (!suomiPDFS) {
       throw new Error(`adaptJulkaisuPDFPaths: aloitusKuulutusPDFS.${API.Kieli.SUOMI} määrittelemättä`);
     }
 
-    const result: Partial<API.AloitusKuulutusPDFt> = {};
-    for (const kieli in aloitusKuulutusPDFS) {
-      const pdfs = aloitusKuulutusPDFS[kieli as API.Kieli];
+    const aloituskuulutusPath = new ProjektiPaths(oid).aloituskuulutus(aloitusKuulutus);
+
+    const result: API.KuulutusPDFJulkinen = {
+      __typename: "KuulutusPDFJulkinen",
+      SUOMI: fileService.getPublicPathForProjektiFile(aloituskuulutusPath, suomiPDFS.aloituskuulutusPDFPath),
+    };
+    for (const k in muunKielisetPDFS) {
+      const kieli = k as API.Kieli.SAAME | API.Kieli.RUOTSI;
+      const pdfs = muunKielisetPDFS[kieli];
       if (pdfs) {
-        const aloituskuulutusPath = new ProjektiPaths(oid).aloituskuulutus(aloitusKuulutus);
-        result[kieli as API.Kieli] = {
-          __typename: "AloitusKuulutusPDF",
-          aloituskuulutusPDFPath: fileService.getPublicPathForProjektiFile(aloituskuulutusPath, pdfs.aloituskuulutusPDFPath),
-          aloituskuulutusIlmoitusPDFPath: fileService.getPublicPathForProjektiFile(
-            aloituskuulutusPath,
-            pdfs.aloituskuulutusIlmoitusPDFPath
-          ),
-        };
+        result[kieli] = fileService.getPublicPathForProjektiFile(aloituskuulutusPath, pdfs.aloituskuulutusPDFPath);
       }
     }
-    return { __typename: "AloitusKuulutusPDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.AloitusKuulutusPDF, ...result };
+    return result;
   }
 
   private static async adaptNahtavillaoloVaiheJulkaisu(
@@ -258,6 +257,7 @@ class ProjektiAdapterJulkinen {
       hankkeenKuvaus: adaptLokalisoituTeksti(hankkeenKuvaus),
       kuulutusPaiva,
       kuulutusVaihePaattyyPaiva,
+      kuulutusPDF: adaptNahtavillaoloPDFPaths(dbProjekti.oid, julkaisu),
       muistutusoikeusPaattyyPaiva,
       yhteystiedot: adaptMandatoryYhteystiedotByAddingTypename(yhteystiedot),
       velho: adaptVelho(velho),
@@ -401,7 +401,7 @@ class ProjektiAdapterJulkinen {
       hallintoOikeus,
       tila,
       uudelleenKuulutus: adaptUudelleenKuulutus(uudelleenKuulutus),
-      hyvaksymisPaatosVaihePDFt: adaptHyvaksymispaatosPDFPaths(dbProjekti.oid, julkaisu),
+      kuulutusPDF: adaptHyvaksymispaatosPDFPaths(dbProjekti.oid, julkaisu),
     };
 
     if (kieli) {
@@ -535,47 +535,66 @@ function adaptVuorovaikutusPDFPaths(oid: string, vuorovaikutus: VuorovaikutusKie
   return { __typename: "VuorovaikutusPDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.VuorovaikutusPDF, ...result };
 }
 
-function adaptHyvaksymispaatosPDFPaths(
-  oid: string,
-  hyvaksymispaatos: HyvaksymisPaatosVaiheJulkaisu
-): API.HyvaksymisPaatosVaihePDFt | undefined {
-  const hyvaksymispdfs: LocalizedMap<HyvaksymisPaatosVaihePDF> | undefined = hyvaksymispaatos.hyvaksymisPaatosVaihePDFt;
-  if (!hyvaksymispdfs) {
+function adaptHyvaksymispaatosPDFPaths(oid: string, hyvaksymispaatos: HyvaksymisPaatosVaiheJulkaisu): API.KuulutusPDFJulkinen | undefined {
+  if (!hyvaksymispaatos.hyvaksymisPaatosVaihePDFt) {
     return undefined;
   }
-  const result: Partial<API.HyvaksymisPaatosVaihePDFt> = {};
-  if (hyvaksymispdfs && !hyvaksymispdfs[API.Kieli.SUOMI]) {
+  const { SUOMI: suomiPDFs, ...hyvaksymispdfs } = hyvaksymispaatos.hyvaksymisPaatosVaihePDFt || {};
+
+  if (!suomiPDFs) {
     throw new Error(`adaptHyvaksymispaatosPDFPaths: hyvaksymispaatos.${API.Kieli.SUOMI} määrittelemättä`);
   }
-  for (const kieli in hyvaksymispdfs) {
-    const pdfs = hyvaksymispdfs[kieli as API.Kieli];
+
+  const result: API.KuulutusPDFJulkinen = {
+    __typename: "KuulutusPDFJulkinen",
+    SUOMI: fileService.getPublicPathForProjektiFile(
+      new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
+      suomiPDFs.hyvaksymisKuulutusPDFPath
+    ),
+  };
+
+  for (const k in hyvaksymispdfs) {
+    const kieli = k as API.Kieli.RUOTSI | API.Kieli.SAAME;
+    const pdfs = hyvaksymispdfs[kieli];
     if (pdfs) {
-      result[kieli as API.Kieli] = {
-        __typename: "HyvaksymisPaatosVaihePDF",
-        hyvaksymisKuulutusPDFPath: fileService.getPublicPathForProjektiFile(
-          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
-          pdfs.hyvaksymisKuulutusPDFPath
-        ),
-        ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath: fileService.getPublicPathForProjektiFile(
-          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
-          pdfs.ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath
-        ),
-        ilmoitusHyvaksymispaatoskuulutuksestaPDFPath: fileService.getPublicPathForProjektiFile(
-          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
-          pdfs.ilmoitusHyvaksymispaatoskuulutuksestaPDFPath
-        ),
-        hyvaksymisIlmoitusLausunnonantajillePDFPath: fileService.getPublicPathForProjektiFile(
-          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
-          pdfs.hyvaksymisIlmoitusLausunnonantajillePDFPath
-        ),
-        hyvaksymisIlmoitusMuistuttajillePDFPath: fileService.getPublicPathForProjektiFile(
-          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
-          pdfs.hyvaksymisIlmoitusMuistuttajillePDFPath
-        ),
-      };
+      result[kieli] = fileService.getPublicPathForProjektiFile(
+        new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
+        pdfs.hyvaksymisKuulutusPDFPath
+      );
     }
   }
-  return { __typename: "HyvaksymisPaatosVaihePDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.HyvaksymisPaatosVaihePDF, ...result };
+  return result;
+}
+
+function adaptNahtavillaoloPDFPaths(oid: string, nahtavillaoloVaihe: NahtavillaoloVaiheJulkaisu): API.KuulutusPDFJulkinen | undefined {
+  if (!nahtavillaoloVaihe.nahtavillaoloPDFt) {
+    return undefined;
+  }
+  const { SUOMI: suomiPDFs, ...hyvaksymispdfs } = nahtavillaoloVaihe.nahtavillaoloPDFt || {};
+
+  if (!suomiPDFs) {
+    throw new Error(`adaptNahtavillaoloPDFPaths: nahtavillaoloVaihe.${API.Kieli.SUOMI} määrittelemättä`);
+  }
+
+  const result: API.KuulutusPDFJulkinen = {
+    __typename: "KuulutusPDFJulkinen",
+    SUOMI: fileService.getPublicPathForProjektiFile(
+      new ProjektiPaths(oid).nahtavillaoloVaihe(nahtavillaoloVaihe),
+      suomiPDFs.nahtavillaoloPDFPath
+    ),
+  };
+
+  for (const k in hyvaksymispdfs) {
+    const kieli = k as API.Kieli.RUOTSI | API.Kieli.SAAME;
+    const pdfs = hyvaksymispdfs[kieli];
+    if (pdfs) {
+      result[kieli] = fileService.getPublicPathForProjektiFile(
+        new ProjektiPaths(oid).nahtavillaoloVaihe(nahtavillaoloVaihe),
+        pdfs.nahtavillaoloPDFPath
+      );
+    }
+  }
+  return result;
 }
 
 function removeUndefinedFields(object: API.ProjektiJulkinen): API.ProjektiJulkinen {

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -5,6 +5,7 @@ import {
   DBVaylaUser,
   Hyvaksymispaatos,
   HyvaksymisPaatosVaiheJulkaisu,
+  HyvaksymisPaatosVaihePDF,
   LocalizedMap,
   UudelleenKuulutus,
   Velho,
@@ -400,6 +401,7 @@ class ProjektiAdapterJulkinen {
       hallintoOikeus,
       tila,
       uudelleenKuulutus: adaptUudelleenKuulutus(uudelleenKuulutus),
+      hyvaksymisPaatosVaihePDFt: adaptHyvaksymispaatosPDFPaths(dbProjekti.oid, julkaisu),
     };
 
     if (kieli) {
@@ -531,6 +533,49 @@ function adaptVuorovaikutusPDFPaths(oid: string, vuorovaikutus: VuorovaikutusKie
     }
   }
   return { __typename: "VuorovaikutusPDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.VuorovaikutusPDF, ...result };
+}
+
+function adaptHyvaksymispaatosPDFPaths(
+  oid: string,
+  hyvaksymispaatos: HyvaksymisPaatosVaiheJulkaisu
+): API.HyvaksymisPaatosVaihePDFt | undefined {
+  const hyvaksymispdfs: LocalizedMap<HyvaksymisPaatosVaihePDF> | undefined = hyvaksymispaatos.hyvaksymisPaatosVaihePDFt;
+  if (!hyvaksymispdfs) {
+    return undefined;
+  }
+  const result: Partial<API.HyvaksymisPaatosVaihePDFt> = {};
+  if (hyvaksymispdfs && !hyvaksymispdfs[API.Kieli.SUOMI]) {
+    throw new Error(`adaptHyvaksymispaatosPDFPaths: hyvaksymispaatos.${API.Kieli.SUOMI} määrittelemättä`);
+  }
+  for (const kieli in hyvaksymispdfs) {
+    const pdfs = hyvaksymispdfs[kieli as API.Kieli];
+    if (pdfs) {
+      result[kieli as API.Kieli] = {
+        __typename: "HyvaksymisPaatosVaihePDF",
+        hyvaksymisKuulutusPDFPath: fileService.getPublicPathForProjektiFile(
+          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
+          pdfs.hyvaksymisKuulutusPDFPath
+        ),
+        ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath: fileService.getPublicPathForProjektiFile(
+          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
+          pdfs.ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath
+        ),
+        ilmoitusHyvaksymispaatoskuulutuksestaPDFPath: fileService.getPublicPathForProjektiFile(
+          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
+          pdfs.ilmoitusHyvaksymispaatoskuulutuksestaPDFPath
+        ),
+        hyvaksymisIlmoitusLausunnonantajillePDFPath: fileService.getPublicPathForProjektiFile(
+          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
+          pdfs.hyvaksymisIlmoitusLausunnonantajillePDFPath
+        ),
+        hyvaksymisIlmoitusMuistuttajillePDFPath: fileService.getPublicPathForProjektiFile(
+          new ProjektiPaths(oid).hyvaksymisPaatosVaihe(hyvaksymispaatos),
+          pdfs.hyvaksymisIlmoitusMuistuttajillePDFPath
+        ),
+      };
+    }
+  }
+  return { __typename: "HyvaksymisPaatosVaihePDFt", [API.Kieli.SUOMI]: result[API.Kieli.SUOMI] as API.HyvaksymisPaatosVaihePDF, ...result };
 }
 
 function removeUndefinedFields(object: API.ProjektiJulkinen): API.ProjektiJulkinen {

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -1027,14 +1027,6 @@ Object {
     "__typename": "ProjektiJulkinen",
     "aloitusKuulutusJulkaisu": Object {
       "__typename": "AloitusKuulutusJulkaisuJulkinen",
-      "aloituskuulutusPDFt": Object {
-        "SUOMI": Object {
-          "__typename": "AloitusKuulutusPDF",
-          "aloituskuulutusIlmoitusPDFPath": "/tiedostot/suunnitelma/1/aloituskuulutus/T412_1 Ilmoitus aloituskuulutuksesta.pdf",
-          "aloituskuulutusPDFPath": "/tiedostot/suunnitelma/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
-        },
-        "__typename": "AloitusKuulutusPDFt",
-      },
       "hankkeenKuvaus": Object {
         "RUOTSI": "På Svenska",
         "SAAME": "Saameksi",
@@ -1046,6 +1038,10 @@ Object {
         "ensisijainenKieli": "SUOMI",
         "projektinNimiVieraskielella": "Projektin nimi saameksi",
         "toissijainenKieli": "SAAME",
+      },
+      "kuulutusPDF": Object {
+        "SUOMI": "/tiedostot/suunnitelma/1/aloituskuulutus/T412 Aloituskuulutus.pdf",
+        "__typename": "KuulutusPDFJulkinen",
       },
       "kuulutusPaiva": "2022-01-02",
       "kuulutusTekstit": Object {

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -327,7 +327,7 @@ type NahtavillaoloVaiheJulkaisuJulkinen {
   velho: VelhoJulkinen!
   kielitiedot: Kielitiedot
   yhteystiedot: [Yhteystieto!]!
-  nahtavillaoloPDFt: NahtavillaoloPDFt
+  kuulutusPDF: KuulutusPDFJulkinen
   tila: KuulutusJulkaisuTila
   uudelleenKuulutus: UudelleenKuulutus
   kuulutusTekstit: KuulutusTekstit
@@ -344,7 +344,7 @@ type HyvaksymisPaatosVaiheJulkaisuJulkinen {
   kielitiedot: Kielitiedot
   hallintoOikeus: HallintoOikeus
   yhteystiedot: [Yhteystieto!]
-  hyvaksymisPaatosVaihePDFt: HyvaksymisPaatosVaihePDFt
+  kuulutusPDF: KuulutusPDFJulkinen
   tila: KuulutusJulkaisuTila
   viimeinenVoimassaolovuosi: String
   uudelleenKuulutus: UudelleenKuulutus
@@ -654,6 +654,12 @@ type AloitusKuulutusPDFt {
   SAAME: AloitusKuulutusPDF
 }
 
+type KuulutusPDFJulkinen {
+  SUOMI: String!
+  RUOTSI: String
+  SAAME: String
+}
+
 type AloitusKuulutus {
   kuulutusPaiva: String
   siirtyySuunnitteluVaiheeseen: String
@@ -694,7 +700,7 @@ type AloitusKuulutusJulkaisuJulkinen {
   velho: VelhoJulkinen!
   suunnitteluSopimus: SuunnitteluSopimusJulkaisu
   kielitiedot: Kielitiedot
-  aloituskuulutusPDFt: AloitusKuulutusPDFt
+  kuulutusPDF: KuulutusPDFJulkinen
   tila: KuulutusJulkaisuTila
   uudelleenKuulutus: UudelleenKuulutus
   kuulutusTekstit: KuulutusTekstit

--- a/src/components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot.tsx
+++ b/src/components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot.tsx
@@ -8,7 +8,7 @@ import { Stack } from "@mui/material";
 import ExtLink from "@components/ExtLink";
 import Notification, { NotificationType } from "../../notification/Notification";
 import KansalaisenAineistoNakyma from "../common/KansalaisenAineistoNakyma";
-import { HyvaksymisPaatosVaiheJulkaisuJulkinen, Kieli } from "@services/api";
+import { HyvaksymisPaatosVaiheJulkaisuJulkinen } from "@services/api";
 import { yhteystietoKansalaiselleTekstiksi } from "src/util/kayttajaTransformationUtil";
 import useKansalaiskieli from "src/hooks/useKansalaiskieli";
 import FormatDate from "@components/FormatDate";
@@ -27,7 +27,7 @@ export default function HyvaksymispaatosTiedot({ kuulutus }: Props): ReactElemen
   const velho = kuulutus?.velho;
   const kieli = useKansalaiskieli();
 
-  const hyvaksymisKuulutusPDFPath = kuulutus?.hyvaksymisPaatosVaihePDFt?.[kieli || Kieli.SUOMI]?.hyvaksymisKuulutusPDFPath;
+  const hyvaksymisKuulutusPDFPath = kuulutus?.kuulutusPDF?.[kieli] || undefined;
   const kutsuPdfPath = splitFilePath(hyvaksymisKuulutusPDFPath);
 
   if (!projekti || !kuulutus || !velho) {

--- a/src/components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot.tsx
+++ b/src/components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot.tsx
@@ -121,7 +121,6 @@ export default function HyvaksymispaatosTiedot({ kuulutus }: Props): ReactElemen
       <Section noDivider>
         <h5 className="vayla-smallest-title">{t("projekti:ui-otsikot.ladattava_kuulutus")}</h5>
         <SectionContent className="flex gap-4">
-          {!hyvaksymisKuulutusPDFPath && "TODO palauta hyvaksymisPaatosVaihePDFt backendistä"}
           <ExtLink className="file_download" href={kutsuPdfPath.path}>
             {kutsuPdfPath.fileName}
           </ExtLink>{" "}

--- a/src/components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot.tsx
+++ b/src/components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot.tsx
@@ -5,7 +5,7 @@ import useTranslation from "next-translate/useTranslation";
 import KeyValueTable, { KeyValueData } from "../../KeyValueTable";
 import Section from "../../layout/Section";
 import { Stack } from "@mui/material";
-import ExtLink from "../../ExtLink";
+import ExtLink from "@components/ExtLink";
 import Notification, { NotificationType } from "../../notification/Notification";
 import KansalaisenAineistoNakyma from "../common/KansalaisenAineistoNakyma";
 import { HyvaksymisPaatosVaiheJulkaisuJulkinen, Kieli } from "@services/api";
@@ -27,11 +27,8 @@ export default function HyvaksymispaatosTiedot({ kuulutus }: Props): ReactElemen
   const velho = kuulutus?.velho;
   const kieli = useKansalaiskieli();
 
-  const hyvaksymisKuulutusPDFPath =
-    kuulutus?.hyvaksymisPaatosVaihePDFt?.[kuulutus.kielitiedot?.ensisijainenKieli || Kieli.SUOMI]?.hyvaksymisKuulutusPDFPath;
-  const hyvaksymisKuulutusPDFUrl = hyvaksymisKuulutusPDFPath ? "/" + hyvaksymisKuulutusPDFPath : "";
-  const hyvaksymisKuulutusPDFFilename = hyvaksymisKuulutusPDFPath ? splitFilePath(hyvaksymisKuulutusPDFPath).fileName : "";
-  const hyvaksymisKuulutusPDFFileExtension = hyvaksymisKuulutusPDFPath ? splitFilePath(hyvaksymisKuulutusPDFPath).fileExt : "";
+  const hyvaksymisKuulutusPDFPath = kuulutus?.hyvaksymisPaatosVaihePDFt?.[kieli || Kieli.SUOMI]?.hyvaksymisKuulutusPDFPath;
+  const kutsuPdfPath = splitFilePath(hyvaksymisKuulutusPDFPath);
 
   if (!projekti || !kuulutus || !velho) {
     return <div />;
@@ -125,10 +122,10 @@ export default function HyvaksymispaatosTiedot({ kuulutus }: Props): ReactElemen
         <h5 className="vayla-smallest-title">{t("projekti:ui-otsikot.ladattava_kuulutus")}</h5>
         <SectionContent className="flex gap-4">
           {!hyvaksymisKuulutusPDFPath && "TODO palauta hyvaksymisPaatosVaihePDFt backendistä"}
-          <ExtLink className="file_download" href={hyvaksymisKuulutusPDFUrl}>
-            {hyvaksymisKuulutusPDFFilename}
+          <ExtLink className="file_download" href={kutsuPdfPath.path}>
+            {kutsuPdfPath.fileName}
           </ExtLink>{" "}
-          ({hyvaksymisKuulutusPDFFileExtension}) (
+          ({kutsuPdfPath.fileExt}) (
           <FormatDate date={kuulutus.kuulutusPaiva} />)
         </SectionContent>
       </Section>

--- a/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
+++ b/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
@@ -44,7 +44,7 @@ export default function AloituskuulutusJulkinen(): ReactElement {
     { header: t(`ui-otsikot.suunnitelman_tyyppi`), data: velho?.tyyppi && t(`projekti-tyyppi.${velho?.tyyppi}`) },
   ];
 
-  const aloituskuulutusPDFPath = splitFilePath(kuulutus.aloituskuulutusPDFt?.[kieli]?.aloituskuulutusPDFPath);
+  const aloituskuulutusPDFPath = splitFilePath(kuulutus.kuulutusPDF?.[kieli] || undefined);
 
   if (kuulutus.tila == KuulutusJulkaisuTila.MIGROITU) {
     return (

--- a/src/pages/suunnitelma/[oid]/nahtavillaolo.tsx
+++ b/src/pages/suunnitelma/[oid]/nahtavillaolo.tsx
@@ -15,6 +15,9 @@ import useKansalaiskieli from "src/hooks/useKansalaiskieli";
 import { kuntametadata } from "../../../../common/kuntametadata";
 import { yhteystietoKansalaiselleTekstiksi } from "src/util/kayttajaTransformationUtil";
 import { renderTextAsHTML } from "../../../util/renderTextAsHTML";
+import { splitFilePath } from "src/util/fileUtil";
+import ExtLink from "@components/ExtLink";
+import FormatDate from "@components/FormatDate";
 
 export default function Nahtavillaolo(): ReactElement {
   const { t, lang } = useTranslation("projekti");
@@ -53,6 +56,8 @@ export default function Nahtavillaolo(): ReactElement {
 
   const kuulutusTekstit = projekti.nahtavillaoloVaihe?.kuulutusTekstit;
   let pKey = 1;
+
+  const nahtavillaoloKuulutusPDFPath = splitFilePath(kuulutus.kuulutusPDF?.[kieli] || undefined);
 
   return migroitu ? (
     <ProjektiJulkinenPageLayout selectedStep={2} title="Kuulutus suunnitelman nähtäville asettamisesta">
@@ -119,11 +124,19 @@ export default function Nahtavillaolo(): ReactElement {
             })}
           </p>
           {kuulutus.yhteystiedot.map((yhteystieto, index) => (
-            <p key={index}>
-              <p key={index}>{yhteystietoKansalaiselleTekstiksi(lang, yhteystieto, t)}</p>
-            </p>
+            <p key={index}>{yhteystietoKansalaiselleTekstiksi(lang, yhteystieto, t)}</p>
           ))}
         </SectionContent>
+        <Section noDivider>
+          <h5 className="vayla-smallest-title">{t("projekti:ui-otsikot.ladattava_kuulutus")}</h5>
+          <SectionContent className="flex gap-4">
+            <ExtLink className="file_download" href={nahtavillaoloKuulutusPDFPath.path}>
+              {nahtavillaoloKuulutusPDFPath.fileName}
+            </ExtLink>{" "}
+            ({nahtavillaoloKuulutusPDFPath.fileExt}) (
+            <FormatDate date={kuulutus.kuulutusPaiva} />)
+          </SectionContent>
+        </Section>
       </Section>
     </ProjektiJulkinenPageLayout>
   );

--- a/src/pages/suunnitelma/[oid]/suunnittelu.tsx
+++ b/src/pages/suunnitelma/[oid]/suunnittelu.tsx
@@ -336,7 +336,14 @@ function TilaisuusContent({ tilaisuus }: { tilaisuus: VuorovaikutusTilaisuusJulk
         <div>
           <p>{t("tilaisuudet.verkossa.yleisotilaisuus_jarjestetaan_verkkotapahtumana")}</p>
           <p>{t("tilaisuudet.verkossa.tilaisuus_toteutetaan_teamsin")}</p>
-          <p>{t("tilaisuudet.verkossa.liity_tilaisuuteen")}{tilaisuus.linkki?  (<ExtLink href={tilaisuus.linkki}>{tilaisuus.linkki}</ExtLink>) : t("tilaisuudet.verkossa.liittymislinkki_julkaistaan")}</p>
+          <p>
+            {t("tilaisuudet.verkossa.liity_tilaisuuteen")}
+            {tilaisuus.linkki ? (
+              <ExtLink href={tilaisuus.linkki}>{tilaisuus.linkki}</ExtLink>
+            ) : (
+              t("tilaisuudet.verkossa.liittymislinkki_julkaistaan")
+            )}
+          </p>
         </div>
       )}
     </>

--- a/src/services/api/fragmentTypes.json
+++ b/src/services/api/fragmentTypes.json
@@ -309,6 +309,12 @@
       },
       {
         "kind": "OBJECT",
+        "name": "KuulutusPDFJulkinen",
+        "possibleTypes": null,
+        "__typename": "__Type"
+      },
+      {
+        "kind": "OBJECT",
         "name": "KuulutusTekstit",
         "possibleTypes": null,
         "__typename": "__Type"


### PR DESCRIPTION
Hox! jos halutaan, että kansalaispuolelle ei välitetä esim. kuulutus muistutuksen antajille jne, niin sanokaa, niin teen erillisen tietotyypin HyvakysmisPaatosVaihePDFtJulkinen tms., jossa ei vaadita niitä muita pdf:iä kuin se yksi, mikä näytetään.
Tämä on nopeasti tehty toteutus, mutta pitäisi toimia.