### PR TITLE
feat: HASSU-1510 yleinen saavutettavuus (kansalaispuoli)

### DIFF
--- a/src/components/button/JataPalautettaNappi.tsx
+++ b/src/components/button/JataPalautettaNappi.tsx
@@ -26,7 +26,7 @@ const JataPalautettaNappi = (
       <LeijuvaNappi
         id="feedback_button_hovering"
         {...props}
-        className="btn btn-primary fixed bottom-6 right-6 bg-primary text-white rounded p-4"
+        className="btn btn-primary fixed bottom-6 right-6 bg-primary text-white rounded p-4 hoverbutton"
         onClick={onClick}
         style={{ borderRadius: "50%", display: "absolute", right: "1em", bottom: "5em" }}
       >

--- a/src/components/form/FormGroup.tsx
+++ b/src/components/form/FormGroup.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
 import React, { ReactElement, ReactNode } from "react";
-import { styled, experimental_sx as sx } from "@mui/material";
+import { styled, experimental_sx as sx, capitalize } from "@mui/material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import HassuStack from "@components/layout/HassuStack";
 
@@ -13,6 +13,7 @@ interface Props {
   bottomInfo?: ReactNode;
   flexDirection?: "row" | "col";
   inlineFlex?: boolean;
+  controlName?: string;
 }
 
 export default function FormGroup({
@@ -22,11 +23,12 @@ export default function FormGroup({
   bottomInfo,
   flexDirection = "col",
   inlineFlex,
+  controlName,
   ...props
 }: Props & React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>): ReactElement {
   return (
     <div {...props}>
-      {label && <Label>{label}</Label>}
+      {label && <Label htmlFor={controlName}>{capitalize(label)}</Label>}
       <div className={classNames(inlineFlex ? "inline-flex" : "flex", flexDirection === "row" ? "flex-row" : "flex-col")}>{children}</div>
       {(bottomInfo || errorMessage) && (
         <div className="flex">

--- a/src/components/form/HassuMuiSelect.tsx
+++ b/src/components/form/HassuMuiSelect.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from "react";
-import { FormControl, InputBase, InputLabel, MenuItem, Select, styled } from "@mui/material";
+import { capitalize, FormControl, InputBase, InputLabel, MenuItem, Select, styled } from "@mui/material";
 import { Controller } from "react-hook-form";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
@@ -35,7 +35,7 @@ const HassuMuiSelect = ({ name, label, control, defaultValue, children, ...props
   const labelId = `${name}-label`;
   return (
     <FormControl sx={{ paddingTop: "3px" }} {...props}>
-      <InputLabel id={labelId}>{label}</InputLabel>
+      <InputLabel id={labelId} htmlFor={name}>{capitalize(label)}</InputLabel>
       <Controller
         render={({ field: { onChange, onBlur, value, ref } }) => (
           <>

--- a/src/components/form/Select.tsx
+++ b/src/components/form/Select.tsx
@@ -31,10 +31,10 @@ const Select = (
   ref: React.ForwardedRef<HTMLSelectElement>
 ) => {
   return (
-    <FormGroup label={label} className={className} errorMessage={hideErrorMessage ? undefined : error?.message}>
+    <FormGroup label={label} controlName={props.name} className={className} errorMessage={hideErrorMessage ? undefined : error?.message}>
       <div className="select-wrapper">
         <select className={classNames("hassu-input", error && "error")} {...props} ref={ref}>
-          {addEmptyOption && <option value=""/>}
+          {addEmptyOption && <option value="" />}
           {options.map((option) => (
             <option key={option.value} value={option.value} disabled={option.disabled}>
               {option.label}

--- a/src/components/form/TextInput.tsx
+++ b/src/components/form/TextInput.tsx
@@ -28,6 +28,7 @@ const TextInput = (
   return (
     <FormGroup
       label={label}
+      controlName={props.name}
       errorMessage={hideErrorMessage ? undefined : error?.message}
       className={className}
       style={style}

--- a/src/components/form/Textarea.tsx
+++ b/src/components/form/Textarea.tsx
@@ -31,6 +31,7 @@ const Textarea = (
   return (
     <FormGroup
       label={label}
+      controlName={props.name}
       errorMessage={hideErrorMessage ? undefined : error?.message}
       className={className}
       bottomInfo={

--- a/src/components/kansalaisenEtusivu/TyylitellytKomponentit.tsx
+++ b/src/components/kansalaisenEtusivu/TyylitellytKomponentit.tsx
@@ -160,13 +160,7 @@ export const NavigointiNappi = styled(Link)(
 
 export const NavigointiNappiDisabled = styled("div")(
   sx({
-    border: "1px solid rgb(216, 216, 216)",
-    boxSizing: "border-box",
-    textAlign: "center",
-    borderRadius: "15px",
-    marginLeft: "0.3em",
-    display: "inline-block",
-    cursor: "not-allowed",
+    display: "none",
   })
 );
 

--- a/src/components/layout/ScrollToTopButton.tsx
+++ b/src/components/layout/ScrollToTopButton.tsx
@@ -22,7 +22,7 @@ const ScrollToTopButton: FunctionComponent = () => {
       onClick={() => {
         window.scrollTo(0, 0);
       }}
-      className={`fixed bottom-6 right-6 bg-primary text-white rounded p-4 ${!toTopEnabled ? "hidden" : ""}`}
+      className={`to-top fixed bottom-6 right-6 bg-primary text-white rounded p-4 ${!toTopEnabled ? "hidden" : ""}`}
     >
       To Top
     </button>

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -15,23 +15,23 @@ type SocialMediaLinkProps = {
 } & HassuLinkProps;
 
 const vaylaSocialMedia: SocialMediaLinkProps[] = [
-  { icon: { iconName: "facebook-square", prefix: "fab" }, title: "Facebook", href: "https://www.facebook.com/vaylafi/" },
-  { icon: { iconName: "twitter", prefix: "fab" }, title: "Twitter", href: "https://www.twitter.com/vaylafi" },
-  { icon: { iconName: "instagram", prefix: "fab" }, title: "Instagram", href: "https://www.instagram.com/vaylafi" },
-  { icon: { iconName: "linkedin", prefix: "fab" }, title: "LinkedIn", href: "https://www.linkedin.com/company/vaylafi" },
-  { icon: { iconName: "flickr", prefix: "fab" }, title: "Flickr", href: "https://www.flickr.com/vaylafi" },
-  { icon: { iconName: "youtube", prefix: "fab" }, title: "Youtube", href: "https://www.youtube.com/c/vaylafi" },
+  { icon: { iconName: "facebook-square", prefix: "fab" }, title: "Väylävirasto Facebook", href: "https://www.facebook.com/vaylafi/" },
+  { icon: { iconName: "twitter", prefix: "fab" }, title: "Väylävirasto Twitter", href: "https://www.twitter.com/vaylafi" },
+  { icon: { iconName: "instagram", prefix: "fab" }, title: "Väylävirasto Instagram", href: "https://www.instagram.com/vaylafi" },
+  { icon: { iconName: "linkedin", prefix: "fab" }, title: "Väylävirasto LinkedIn", href: "https://www.linkedin.com/company/vaylafi" },
+  { icon: { iconName: "flickr", prefix: "fab" }, title: "Väylävirasto Flickr", href: "https://www.flickr.com/vaylafi" },
+  { icon: { iconName: "youtube", prefix: "fab" }, title: "Väylävirasto Youtube", href: "https://www.youtube.com/c/vaylafi" },
 ];
 
 const elySocialMedia: SocialMediaLinkProps[] = [
-  { icon: { iconName: "facebook-square", prefix: "fab" }, title: "Facebook", href: "https://www.facebook.com/ELYkeskus" },
-  { icon: { iconName: "twitter", prefix: "fab" }, title: "Twitter", href: "https://www.twitter.com/ELYkeskus" },
+  { icon: { iconName: "facebook-square", prefix: "fab" }, title: "ELY Facebook", href: "https://www.facebook.com/ELYkeskus" },
+  { icon: { iconName: "twitter", prefix: "fab" }, title: "ELY Twitter", href: "https://www.twitter.com/ELYkeskus" },
   {
     icon: { iconName: "linkedin", prefix: "fab" },
-    title: "LinkedIn",
+    title: "ELY LinkedIn",
     href: "https://www.linkedin.com/company/centre-for-economic-development-transport-and-the-environment/",
   },
-  { icon: { iconName: "youtube", prefix: "fab" }, title: "Youtube", href: "https://www.youtube.com/channel/UChlaFxyANJa7Qs8-NlPx-wg" },
+  { icon: { iconName: "youtube", prefix: "fab" }, title: "ELY Youtube", href: "https://www.youtube.com/channel/UChlaFxyANJa7Qs8-NlPx-wg" },
 ];
 
 export const Footer = () => {
@@ -119,9 +119,9 @@ const SocialMediaLinkList = styled("div")(({ theme }) => ({
   gap: theme.spacing(3),
 }));
 
-const SocialMediaLink = styled(({ icon, ref, ...props }: SocialMediaLinkProps) => (
+const SocialMediaLink = styled(({ icon, ref, title, ...props }: SocialMediaLinkProps) => (
   <HassuLink useNextLink={false} target="_blank" {...props}>
-    <FontAwesomeIcon icon={icon} />
+    <FontAwesomeIcon icon={icon} title={title} />
   </HassuLink>
 ))(({ theme }) => ({
   color: "white",

--- a/src/pages/tietoa-palvelusta/yhteystiedot-ja-palaute.tsx
+++ b/src/pages/tietoa-palvelusta/yhteystiedot-ja-palaute.tsx
@@ -35,7 +35,7 @@ export default function TietoaPalvelustaSivu() {
           />
         </ContentSpacer>
         <ContentSpacer gap={4}>
-          <h3 className="vayla-subtitle">{t("palvelun-yhteystiedot.otsikko")}</h3>
+          <h2 className="vayla-subtitle">{t("palvelun-yhteystiedot.otsikko")}</h2>
           <Trans
             i18nKey="tietoa-palvelusta/yhteystiedot-ja-palaute:palvelun-yhteystiedot.kappale1"
             components={{
@@ -46,15 +46,15 @@ export default function TietoaPalvelustaSivu() {
           />
         </ContentSpacer>
         <ContentSpacer gap={4}>
-          <h3 className="vayla-subtitle">{t("palautetta-palvelusta.otsikko")}</h3>
+          <h2 className="vayla-subtitle">{t("palautetta-palvelusta.otsikko")}</h2>
           <p>{t("palautetta-palvelusta.kappale1")}</p>
           <p>{t("palautetta-palvelusta.kappale2")}</p>
         </ContentSpacer>
         <JataPalautettaNappi onClick={openDialog} teksti={t("palautetta-palvelusta.avaa-dialogi-painike")} />
         {isPalateDialogOpen && <AnnaPalvelustaPalautettaDialog open={isPalateDialogOpen} onClose={closeDialog} />}
-        <h3 className="vayla-subtitle">{t("haluat-antaa-muuta-palautetta.otsikko")}</h3>
+        <h2 className="vayla-subtitle">{t("haluat-antaa-muuta-palautetta.otsikko")}</h2>
         <ContentSpacer gap={4}>
-          <h4 className="vayla-small-title">{t("haluat-antaa-muuta-palautetta.palautetta-suunnitelmista.otsikko")}</h4>
+          <h3 className="vayla-small-title">{t("haluat-antaa-muuta-palautetta.palautetta-suunnitelmista.otsikko")}</h3>
           <Trans
             i18nKey="tietoa-palvelusta/yhteystiedot-ja-palaute:haluat-antaa-muuta-palautetta.palautetta-suunnitelmista.kappale1"
             components={{
@@ -64,9 +64,9 @@ export default function TietoaPalvelustaSivu() {
           />
         </ContentSpacer>
         <ContentSpacer gap={4}>
-          <h4 className="vayla-small-title">
+          <h3 className="vayla-small-title">
             {t("haluat-antaa-muuta-palautetta.palautetta-valtion-teista-rautateistä-ja-vesivaylista.otsikko")}
-          </h4>
+          </h3>
           <Trans
             i18nKey="tietoa-palvelusta/yhteystiedot-ja-palaute:haluat-antaa-muuta-palautetta.palautetta-valtion-teista-rautateistä-ja-vesivaylista.kappale1"
             components={{

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,11 +22,12 @@
   body :is(input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea, select):-webkit-autofill {
     -webkit-box-shadow: 0 0 0px 1000px white inset;
   }
-  body :is(input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea, select):-internal-autofill-selected {
+  body
+    :is(input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea, select):-internal-autofill-selected {
     -webkit-box-shadow: 0 0 0px 1000px white inset !important;
     box-shadow: 0 0 0px 1000px white inset !important;
   }
- 
+
   body :is(input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea, select):active.hassu-input {
     box-shadow: inset rgb(0 0 0 / 10%) 0px 0px 2px 0px, inset rgb(0 0 0 / 10%) 0px 2px 4px 0px;
   }
@@ -40,7 +41,8 @@
   body :is(input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea, select).error.hassu-input {
     @apply border-red;
   }
-  body :is(input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea, select):focus:not(.error).hassu-input {
+  body
+    :is(input[type="text"], input[type="password"], input[type="number"], input[type="date"], textarea, select):focus:not(.error).hassu-input {
     @apply border-primary;
     @apply ring-1;
   }
@@ -384,5 +386,8 @@
   }
   .ingress {
     @apply mb-8;
+  }
+  button.to-top {
+    background-color: #0064af;
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -390,4 +390,7 @@
   button.to-top {
     background-color: #0064af;
   }
+  button.hoverbutton {
+    background-color: #0064af;
+  }
 }


### PR DESCRIPTION
Korjaukset dokumentin Muistiinpanot_saavutettavuus.pdf perusteella

**Yleiset**
1. ok
2. ok - vanha versio
3. kts alla
4. nextjs placeholder sisällön liikkumisen estämiseksi latausten valmistuessa, ei ongelma ruudunlukijat osaavat huomioida tyhjät altit, minkä lisäksi elementillä on aria-hidden joka myöskin varmistaa ruudunlukijoiden toimvuuden
5. kts yllä
6. noscript elementit ovat logojen esittämisen tarkoitettuja nextjs:n automaattisesti luomia vaihtoehtoisia kuvien lataustapoja
7. - 
8. ok
9. kansalaisen murupolulla oma tiketti
10. ei toistettavissa, kielivalikkoon pääsee tabulaattorilla

**Etusivu**
1. ok
2. ok
3. oma tiketti
4. oma tiketti
5. korjattu painikkeiden piilotus, kun ensimmaisellä tai viimeisellä sivulla, vierekkäisiä linkkejä (sivunumerovalikko ja edellinen/seuraava) ei nähty ongelmaksi

**Yhteystiedot ja palaute**
1. ok
2. Kansalaisen headerin navigointipalkki muutetaan siten, että "Tietoa palvelusta" on pudotusvalikko -> Vaatii designin ([Huhtamäki Jade CGI Suomi Oy]) ja toteutuksen omalla tiketillä