### PR TITLE
fix: korjaa yhteyksien vuoto kun kutsutaan resursseja allkirjoitetusti. Korjaa maakuntavalikon arvot merkkijonoista numeroiksi, jotta kansalaisen etusivun haku toimisi. Poista duplikaatit vuorovaikutuksen viranomaisvastaaottajista. Poista basic authent...

### DIFF
--- a/backend/src/aws/awsRequest.ts
+++ b/backend/src/aws/awsRequest.ts
@@ -5,6 +5,8 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { HttpRequest as IHttpRequest } from "@aws-sdk/types";
 import { NodeHttpHandler } from "@aws-sdk/node-http-handler";
 
+const client = new NodeHttpHandler();
+
 export async function sendSignedRequest(request: HttpRequest, service: string): Promise<{ body: unknown; statusCode: number }> {
   // Sign the request
   if (!AWS.config.credentials) {
@@ -19,7 +21,6 @@ export async function sendSignedRequest(request: HttpRequest, service: string): 
   const signedRequest: IHttpRequest = await signer.sign(request);
 
   // Send the request
-  const client = new NodeHttpHandler();
 
   const { response } = await client.handle(signedRequest as HttpRequest);
   let responseBody = "";

--- a/backend/src/database/schemaUpgrade.ts
+++ b/backend/src/database/schemaUpgrade.ts
@@ -71,8 +71,7 @@ export function migrateFromOldSchema(projekti: DBProjekti): DBProjekti {
       if (Object.keys(value).includes("SUOMI")) {
         return undefined;
       }
-      let arvioSeuraavanVaiheenAlkamisesta: LocalizedMap<string> = value;
-      arvioSeuraavanVaiheenAlkamisesta = {
+      const arvioSeuraavanVaiheenAlkamisesta: LocalizedMap<string> = {
         SUOMI: value,
       };
       if ([projekti.kielitiedot?.ensisijainenKieli, projekti.kielitiedot?.toissijainenKieli].includes(Kieli.RUOTSI)) {
@@ -87,8 +86,7 @@ export function migrateFromOldSchema(projekti: DBProjekti): DBProjekti {
       if (Object.keys(value).includes("SUOMI")) {
         return undefined;
       }
-      let suunnittelunEteneminenJaKesto: LocalizedMap<string> = value;
-      suunnittelunEteneminenJaKesto = {
+      const suunnittelunEteneminenJaKesto: LocalizedMap<string> = {
         SUOMI: value,
       };
       if ([projekti.kielitiedot?.ensisijainenKieli, projekti.kielitiedot?.toissijainenKieli].includes(Kieli.RUOTSI)) {
@@ -100,8 +98,7 @@ export function migrateFromOldSchema(projekti: DBProjekti): DBProjekti {
       return suunnittelunEteneminenJaKesto;
     }
     if ("videot" == key && value) {
-      let videot: LocalizedMap<Linkki>[] = value;
-      videot = value.map((video: Linkki) => {
+      const videot: LocalizedMap<Linkki>[] = value.map((video: Linkki) => {
         if (Object.keys(video).includes("SUOMI")) {
           return video;
         }
@@ -122,8 +119,7 @@ export function migrateFromOldSchema(projekti: DBProjekti): DBProjekti {
       if (Object.keys(value).includes("SUOMI")) {
         return undefined;
       }
-      let suunnittelumateriaali: LocalizedMap<Linkki> = value;
-      suunnittelumateriaali = {
+      const suunnittelumateriaali: LocalizedMap<Linkki> = {
         SUOMI: value as Linkki,
       };
       if ([projekti.kielitiedot?.ensisijainenKieli, projekti.kielitiedot?.toissijainenKieli].includes(Kieli.RUOTSI)) {
@@ -163,6 +159,22 @@ export function migrateFromOldSchema(projekti: DBProjekti): DBProjekti {
         });
       }
       return vuorovaikutusTilaisuudet;
+    }
+    if ("hyvaksymisPaatosVaihePDFt" == key && value) {
+      [Kieli.SUOMI, Kieli.RUOTSI, Kieli.SAAME].forEach((kieli) => {
+        if (value[kieli]) {
+          if (value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath) {
+            value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath =
+              value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath;
+            delete value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath;
+          }
+          if (value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath) {
+            value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaPDFPath =
+              value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath;
+            delete value[kieli].ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath;
+          }
+        }
+      });
     }
     return undefined;
   });

--- a/backend/test/database/__snapshots__/migrateFromOldSchema.test.ts.snap
+++ b/backend/test/database/__snapshots__/migrateFromOldSchema.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`migrateFromOldSchema should tolerate old pdfs in nähtävilläolo 1`] = `
+Object {
+  "hyvaksymisPaatosVaiheJulkaisut": Array [
+    Object {
+      "hyvaksymisPaatosVaihePDFt": Object {
+        "SUOMI": Object {
+          "hyvaksymisIlmoitusLausunnonantajillePDFPath": "/hyvaksymispaatos/1/62R Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+          "hyvaksymisIlmoitusMuistuttajillePDFPath": "/hyvaksymispaatos/1/63R Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+          "hyvaksymisKuulutusPDFPath": "/hyvaksymispaatos/1/60R Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaKunnalleToiselleViranomaisellePDFPath": "/hyvaksymispaatos/1/61R Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+          "ilmoitusHyvaksymispaatoskuulutuksestaPDFPath": "/hyvaksymispaatos/1/12R Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+        },
+      },
+    },
+  ],
+  "versio": 1,
+}
+`;

--- a/backend/test/database/migrateFromOldSchema.test.ts
+++ b/backend/test/database/migrateFromOldSchema.test.ts
@@ -95,50 +95,26 @@ describe("migrateFromOldSchema", () => {
     expect(migratoitu).to.eql(newForm);
   });
 
-  it("should not mess up projekti in new form", async () => {
-    const newForm = {
-      versio: 1,
-      kielitiedot: {
-        ensisijainenKieli: "SUOMI",
-        toissijainenKieli: "SAAME",
-        projektinNimiToisellaKielellä: "Projektin nimi",
-      },
-      vuorovaikutusKierros: {
-        vuorovaikutusNumero: 0,
-        arvioSeuraavanVaiheenAlkamisesta: { SUOMI: "arvio", SAAME: "arvio" },
-        suunnittelunEteneminenJaKesto: { SUOMI: "kesto", SAAME: "kesto" },
-        vuorovaikutusJulkaisuPaiva: "2023-01-01",
-        videot: [
+  it("should tolerate old pdfs in nähtävilläolo", async () => {
+    expect(
+      migrateFromOldSchema({
+        hyvaksymisPaatosVaiheJulkaisut: [
           {
-            SUOMI: { nimi: "", url: "http://www.1.fi" },
-            SAAME: { nimi: "", url: "http://www.1.fi" },
-          },
-          {
-            SUOMI: { nimi: "", url: "http://www.2.fi" },
-            SAAME: { nimi: "", url: "http://www.2.fi" },
+            hyvaksymisPaatosVaihePDFt: {
+              SUOMI: {
+                hyvaksymisIlmoitusLausunnonantajillePDFPath:
+                  "/hyvaksymispaatos/1/62R Ilmoitus hyvaksymispaatoksesta lausunnon antajille.pdf",
+                hyvaksymisIlmoitusMuistuttajillePDFPath: "/hyvaksymispaatos/1/63R Ilmoitus hyvaksymispaatoksesta muistuttajille.pdf",
+                hyvaksymisKuulutusPDFPath: "/hyvaksymispaatos/1/60R Kuulutus hyvaksymispaatoksen nahtavillaolo.pdf",
+                ilmoitusHyvaksymispaatoskuulutuksestaKunnillePDFPath:
+                  "/hyvaksymispaatos/1/61R Ilmoitus hyvaksymispaatoksesta kunnalle ja ELYlle.pdf",
+                ilmoitusHyvaksymispaatoskuulutuksestaToiselleViranomaisellePDFPath:
+                  "/hyvaksymispaatos/1/12R Ilmoitus hyvaksymispaatoksen kuulutuksesta.pdf",
+              },
+            },
           },
         ],
-        suunnittelumateriaali: {
-          SUOMI: { nimi: "suunnittelumateriaali", url: "http://www.suunnittelumateriaali.fi" },
-          SAAME: { nimi: "suunnittelumateriaali", url: "http://www.suunnittelumateriaali.fi" },
-        },
-        vuorovaikutusTilaisuudet: [
-          {
-            tyyppi: VuorovaikutusTilaisuusTyyppi.PAIKALLA,
-            nimi: { SUOMI: "Tilaisuuden nimi", SAAME: "Tilaisuuden nimi" },
-            paivamaara: "2023-02-01",
-            alkamisAika: "13:00",
-            paatyymisAika: "14:00",
-            paikka: { SUOMI: "Tilaisuuden paikka", SAAME: "Tilaisuuden paikka" },
-            osoite: { SUOMI: "Osoite 123", SAAME: "Osoite 123" },
-            postinumero: "12345",
-            postitoimipaikka: { SUOMI: "Postitoimipaikka", SAAME: "Postitoimipaikka" },
-            Saapumisohje: { SUOMI: "Saapumisohje", SAAME: "Saapumisohje" },
-          },
-        ],
-      },
-    };
-    const migratoitu = migrateFromOldSchema(newForm as any as DBProjekti);
-    expect(migratoitu).to.eql(newForm);
+      } as any as DBProjekti)
+    ).toMatchSnapshot();
   });
 });

--- a/common/kuntametadata.test.ts
+++ b/common/kuntametadata.test.ts
@@ -40,4 +40,13 @@ describe("Metadata", () => {
     const uud = kuntametadata.elyIdFromKey("UUD");
     expect(uud).to.eq("ely/ely01");
   });
+
+  it.only("should render maakuntaoptions correctly", () => {
+    expect(
+      kuntametadata
+        .maakuntaOptions("fi")
+        .filter((opt) => opt.label.includes("Uusimaa"))
+        .pop()
+    ).to.eql({ label: "Uusimaa", value: "1" });
+  });
 });

--- a/common/kuntametadata.ts
+++ b/common/kuntametadata.ts
@@ -92,11 +92,11 @@ class KuntaMetadata {
     if (lang == "sv") {
       options = maakuntaList
         .filter((maakunta) => !maakunta.lakkautettu)
-        .map((maakunta) => ({ value: String(maakunta.id), label: maakunta.nimi.RUOTSI || maakunta.nimi.SUOMI }));
+        .map((maakunta) => ({ value: String(Number.parseInt(maakunta.koodi)), label: maakunta.nimi.RUOTSI || maakunta.nimi.SUOMI }));
     } else {
       options = maakuntaList
         .filter((maakunta) => !maakunta.lakkautettu)
-        .map((maakunta) => ({ value: String(maakunta.id), label: maakunta.nimi.SUOMI }));
+        .map((maakunta) => ({ value: String(Number.parseInt(maakunta.koodi)), label: maakunta.nimi.SUOMI }));
     }
     if (addEmptyOption) {
       options.push({ label: "", value: "" });

--- a/cypress/integration/2-perusta-projekti/009-hyvaksyntavaihe.spec.js
+++ b/cypress/integration/2-perusta-projekti/009-hyvaksyntavaihe.spec.js
@@ -48,7 +48,9 @@ describe("9 - Projektin hyvaksymispaatosavaiheen kuulutustiedot", () => {
     cy.visit(Cypress.env("host") + "/yllapito/projekti/" + oid + "/hyvaksymispaatos", { timeout: 30000 });
     cy.contains(projektiNimi);
 
-    cy.get("#kuulutuksentiedot_tab").click({ force: true });
+    cy.get("#kuulutuksentiedot_tab")
+      .scrollIntoView({ offset: { top: -250, left: 0 } })
+      .click();
 
     const today = formatDate(dayjs());
     cy.get('[name="paatos.kuulutusPaiva"]').should("be.enabled").type(today, {
@@ -59,7 +61,11 @@ describe("9 - Projektin hyvaksymispaatosavaiheen kuulutustiedot", () => {
     cy.get('[name="paatos.ilmoituksenVastaanottajat.kunnat.0.sahkoposti"]').clear().type("test@vayla.fi");
     cy.get('[name="paatos.ilmoituksenVastaanottajat.kunnat.1.sahkoposti"]').clear().type("test@vayla.fi");
 
-    cy.get("#save_and_send_for_acceptance").should("be.enabled").click({ force: true });
+    cy.get("#save_and_send_for_acceptance")
+      .scrollIntoView({ offset: { top: -250, left: 0 } })
+      .should("be.visible")
+      .should("be.enabled")
+      .click({ force: true });
     cy.contains("Lähetys onnistui", { timeout: 30000 });
     cy.get("#kuulutuksentiedot_tab").click();
     cy.get("#button_open_acceptance_dialog")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -29,7 +29,7 @@ import "cypress-file-upload";
  * Faster typing into input fields
  */
 Cypress.Commands.overwrite("type", (originalFn, subject, text, options = {}) => {
-  options.delay = 3;
+  options.delay = 0;
 
   return originalFn(subject, text, options);
 });

--- a/src/components/projekti/paatos/aineistot/HyvaksymisPaatosVaihePainikkeet.tsx
+++ b/src/components/projekti/paatos/aineistot/HyvaksymisPaatosVaihePainikkeet.tsx
@@ -91,6 +91,7 @@ export default function PaatosPainikkeet({ paatosTyyppi }: { paatosTyyppi: Paato
           </Button>
           <Button
             id="save_and_send_for_acceptance"
+            type="button"
             primary
             disabled={!aineistotPresentAndNoKategorisoimattomat}
             onClick={handleSubmit(saveAndMoveToKuulutusPage)}

--- a/src/components/projekti/paatos/kuulutuksenTiedot/Painikkeet.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/Painikkeet.tsx
@@ -197,6 +197,7 @@ export default function Painikkeet({ projekti, julkaisu, paatosTyyppi, julkaisem
               </Button>
               <Button
                 id="save_and_send_for_acceptance"
+                type="button"
                 primary
                 disabled={!projektiMeetsMinimumStatus(projekti, Status.HYVAKSYTTY) || !isProjektiReadyForTilaChange}
                 onClick={handleSubmit(lahetaHyvaksyttavaksi)}

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -520,7 +520,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
               <Button onClick={handleSubmit(saveDraft)} disabled={disableFormEdit}>
                 Tallenna tiedot
               </Button>
-              <Button id="save_and_send_for_acceptance" primary onClick={handleSubmit(lahetaHyvaksyttavaksi)}>
+              <Button id="save_and_send_for_acceptance" type="button" primary onClick={handleSubmit(lahetaHyvaksyttavaksi)}>
                 Tallenna ja lähetä Hyväksyttäväksi
               </Button>
             </Stack>

--- a/src/util/defaultVastaanottajat.ts
+++ b/src/util/defaultVastaanottajat.ts
@@ -9,6 +9,7 @@ import {
   ViranomaisVastaanottajaInput,
 } from "@services/api";
 import { kuntametadata } from "../../common/kuntametadata";
+import { uniqBy } from "lodash";
 
 export default function defaultVastaanottajat(
   projekti: Projekti | null | undefined,
@@ -51,6 +52,7 @@ export default function defaultVastaanottajat(
             return { nimi: kuntametadata.nameForKuntaId(kuntaId, Kieli.SUOMI), sahkoposti: "" } as ViranomaisVastaanottajaInput;
           }
         }) || [];
+      viranomaiset = uniqBy(viranomaiset, (v) => v.nimi);
     } else {
       viranomaiset = [
         vaylavirastoKirjaamo


### PR DESCRIPTION
...ication kehittäjien ympäristöjen s3-bucketeista. Se ei toiminut. Migroi vanha tietorakenne nähtävilläolon muuttuneiden pdf:ien osalta, jotta koodi ei turhaan hajoaisi virheisiin.