### PR TITLE
fix: Kuulutuksia ei pääse julkaisemaan, jos kuulutukselle lisätty projektihenkilöiden ulkopuolisia yhteystietoja

### DIFF
--- a/src/components/projekti/nahtavillaolo/kuulutuksentiedot/KuulutuksenTiedot.tsx
+++ b/src/components/projekti/nahtavillaolo/kuulutuksentiedot/KuulutuksenTiedot.tsx
@@ -12,13 +12,13 @@ import KuulutuksessaEsitettavatYhteystiedot from "./KuulutuksessaEsitettavatYhte
 import KuulutusJaJulkaisuPaiva from "./KuulutusJaJulkaisuPaiva";
 import IlmoituksenVastaanottajatKomponentti from "./IlmoituksenVastaanottajat";
 import defaultVastaanottajat from "src/util/defaultVastaanottajat";
-import { removeTypeName } from "src/util/removeTypeName";
 import Lukunakyma from "./Lukunakyma";
 import useKirjaamoOsoitteet from "src/hooks/useKirjaamoOsoitteet";
 import PdfPreviewForm from "@components/projekti/PdfPreviewForm";
 import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import { getDefaultValuesForLokalisoituText, getDefaultValuesForUudelleenKuulutus } from "src/util/getDefaultValuesForLokalisoituText";
 import SelitteetUudelleenkuulutukselle from "@components/projekti/SelitteetUudelleenkuulutukselle";
+import defaultEsitettavatYhteystiedot from "src/util/defaultEsitettavatYhteystiedot";
 
 type PickedTallennaProjektiInput = Pick<TallennaProjektiInput, "oid" | "versio" | "nahtavillaoloVaihe">;
 
@@ -55,10 +55,7 @@ function KuulutuksenTiedotForm({ projekti, kirjaamoOsoitteet }: KuulutuksenTiedo
         kuulutusVaihePaattyyPaiva: projekti?.nahtavillaoloVaihe?.kuulutusVaihePaattyyPaiva || null,
         muistutusoikeusPaattyyPaiva: projekti?.nahtavillaoloVaihe?.muistutusoikeusPaattyyPaiva || null,
         hankkeenKuvaus,
-        kuulutusYhteystiedot: {
-          yhteysTiedot: projekti?.nahtavillaoloVaihe?.kuulutusYhteystiedot?.yhteysTiedot?.map((yt) => removeTypeName(yt)) || [],
-          yhteysHenkilot: projekti?.nahtavillaoloVaihe?.kuulutusYhteystiedot?.yhteysHenkilot || [],
-        },
+        kuulutusYhteystiedot: defaultEsitettavatYhteystiedot(projekti.nahtavillaoloVaihe?.kuulutusYhteystiedot),
         ilmoituksenVastaanottajat: defaultVastaanottajat(
           projekti,
           projekti.nahtavillaoloVaihe?.ilmoituksenVastaanottajat,

--- a/src/components/projekti/paatos/kuulutuksenTiedot/index.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/index.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { HyvaksymisPaatosVaiheInput, KirjaamoOsoite, MuokkausTila, TallennaProjektiInput, YhteystietoInput } from "@services/api";
+import { HyvaksymisPaatosVaiheInput, KirjaamoOsoite, MuokkausTila, TallennaProjektiInput } from "@services/api";
 import Notification, { NotificationType } from "@components/notification/Notification";
 import React, { ReactElement, useEffect, useMemo } from "react";
 import { FormProvider, useForm, UseFormProps } from "react-hook-form";
@@ -13,7 +13,6 @@ import MuutoksenHaku from "./MuutoksenHaku";
 import IlmoituksenVastaanottajatKomponentti from "./IlmoituksenVastaanottajat";
 import Lukunakyma from "./Lukunakyma";
 import defaultVastaanottajat from "src/util/defaultVastaanottajat";
-import { removeTypeName } from "src/util/removeTypeName";
 import useKirjaamoOsoitteet from "src/hooks/useKirjaamoOsoitteet";
 import PdfPreviewForm from "@components/projekti/PdfPreviewForm";
 import useLeaveConfirm from "src/hooks/useLeaveConfirm";
@@ -23,6 +22,7 @@ import { getPaatosSpecificData, paatosIsJatkopaatos, PaatosTyyppi } from "src/ut
 import Voimassaolovuosi from "./Voimassaolovuosi";
 import { getDefaultValuesForUudelleenKuulutus } from "src/util/getDefaultValuesForLokalisoituText";
 import SelitteetUudelleenkuulutukselle from "@components/projekti/SelitteetUudelleenkuulutukselle";
+import defaultEsitettavatYhteystiedot from "src/util/defaultEsitettavatYhteystiedot";
 
 type paatosInputValues = Omit<HyvaksymisPaatosVaiheInput, "hallintoOikeus"> & {
   hallintoOikeus: HyvaksymisPaatosVaiheInput["hallintoOikeus"] | "";
@@ -56,10 +56,6 @@ function KuulutuksenTiedotForm({ kirjaamoOsoitteet, paatosTyyppi, projekti }: Ku
   );
 
   const defaultValues: KuulutuksenTiedotFormValues = useMemo(() => {
-    const yhteysTiedot: YhteystietoInput[] = julkaisematonPaatos?.kuulutusYhteystiedot?.yhteysTiedot?.map((yt) => removeTypeName(yt)) || [];
-
-    const yhteysHenkilot: string[] = julkaisematonPaatos?.kuulutusYhteystiedot?.yhteysHenkilot || [];
-
     const formValues: KuulutuksenTiedotFormValues = {
       oid: projekti.oid,
       versio: projekti.versio,
@@ -67,10 +63,7 @@ function KuulutuksenTiedotForm({ kirjaamoOsoitteet, paatosTyyppi, projekti }: Ku
         kuulutusPaiva: julkaisematonPaatos?.kuulutusPaiva || null,
         kuulutusVaihePaattyyPaiva: julkaisematonPaatos?.kuulutusVaihePaattyyPaiva || null,
         hallintoOikeus: julkaisematonPaatos?.hallintoOikeus || "",
-        kuulutusYhteystiedot: {
-          yhteysTiedot,
-          yhteysHenkilot,
-        },
+        kuulutusYhteystiedot: defaultEsitettavatYhteystiedot(julkaisematonPaatos?.kuulutusYhteystiedot),
         ilmoituksenVastaanottajat: defaultVastaanottajat(projekti, julkaisematonPaatos?.ilmoituksenVastaanottajat, kirjaamoOsoitteet),
       },
     };

--- a/src/components/projekti/suunnitteluvaihe/LuonnoksetJaAineistot/MuokkaustilainenLomake.tsx
+++ b/src/components/projekti/suunnitteluvaihe/LuonnoksetJaAineistot/MuokkaustilainenLomake.tsx
@@ -170,33 +170,27 @@ export default function MuokkaustilainenLomake({ vuorovaikutus, hidden }: Props)
             <TextInput
               style={{ width: "100%" }}
               key={field.id + ensisijainenKieli}
-              {...register(`vuorovaikutusKierros.videot.${index}.${ensisijainenKieli}.url`)}
-              onChange={(e) => {
-                setValue(`vuorovaikutusKierros.videot.${index}.${ensisijainenKieli}.url`, e.target.value);
-                if (toissijainenKieli) {
-                  trigger(`vuorovaikutusKierros.videot.${index}.${toissijainenKieli}`);
-                }
-              }}
+              {...register(`vuorovaikutusKierros.videot.${index}.${ensisijainenKieli}.url`, {
+                onChange: () => {
+                  if (toissijainenKieli) {
+                    trigger(`vuorovaikutusKierros.videot.${index}.${toissijainenKieli}.url`);
+                  }
+                },
+              })}
               label={`Linkki videoon ensisijaisella kielellä ${lowerCase(ensisijainenKieli)}`}
-              error={
-                (formState.errors as any)?.vuorovaikutusKierros?.videot?.[index]?.[ensisijainenKieli]?.url ||
-                (formState.errors as any)?.vuorovaikutusKierros?.videot?.[index]?.[ensisijainenKieli]
-              }
+              error={(formState.errors as any)?.vuorovaikutusKierros?.videot?.[index]?.[ensisijainenKieli]?.url}
             />
             {toissijainenKieli && (
               <TextInput
                 style={{ width: "100%" }}
                 key={field.id + toissijainenKieli}
-                {...register(`vuorovaikutusKierros.videot.${index}.${toissijainenKieli}.url`)}
-                onChange={(e) => {
-                  setValue(`vuorovaikutusKierros.videot.${index}.${toissijainenKieli}.url`, e.target.value);
-                  trigger(`vuorovaikutusKierros.videot.${index}.${ensisijainenKieli}`);
-                }}
+                {...register(`vuorovaikutusKierros.videot.${index}.${toissijainenKieli}.url`, {
+                  onChange: () => {
+                    trigger(`vuorovaikutusKierros.videot.${index}.${ensisijainenKieli}.url`);
+                  },
+                })}
                 label={`Linkki videoon toissijaisella kielellä ${lowerCase(toissijainenKieli)}`}
-                error={
-                  (formState.errors as any)?.vuorovaikutusKierros?.videot?.[index]?.[toissijainenKieli]?.url ||
-                  (formState.errors as any)?.vuorovaikutusKierros?.videot?.[index]?.[toissijainenKieli]
-                }
+                error={(formState.errors as any)?.vuorovaikutusKierros?.videot?.[index]?.[toissijainenKieli]?.url}
               />
             )}
             {!!index && (
@@ -245,31 +239,28 @@ export default function MuokkaustilainenLomake({ vuorovaikutus, hidden }: Props)
           <TextInput
             style={{ width: "100%" }}
             label={`Linkin kuvaus ensisijaisella kielellä (${lowerCase(ensisijainenKieli)})`}
-            {...register(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.nimi`)}
-            onChange={(e) => {
-              setValue(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.nimi`, e.target.value);
-              if (toissijainenKieli) {
+            {...register(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.nimi`, {
+              onChange: () => {
                 trigger(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.url`);
-                trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}`);
-              }
-            }}
+                if (toissijainenKieli) {
+                  trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}`);
+                }
+              },
+            })}
             error={(formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[ensisijainenKieli]?.nimi}
           />
           <TextInput
             style={{ width: "100%" }}
             label={`Linkki muihin esittelyaineistoihin ensisijaisella kielellä (${lowerCase(ensisijainenKieli)})`}
-            {...register(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.url`)}
-            onChange={(e) => {
-              setValue(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.url`, e.target.value);
-              if (toissijainenKieli) {
+            {...register(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.url`, {
+              onChange: () => {
                 trigger(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}.nimi`);
-                trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}`);
-              }
-            }}
-            error={
-              (formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[ensisijainenKieli]?.url ||
-              (formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[ensisijainenKieli]
-            }
+                if (toissijainenKieli) {
+                  trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}`);
+                }
+              },
+            })}
+            error={(formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[ensisijainenKieli]?.url}
           />
         </div>
         {toissijainenKieli && (
@@ -277,27 +268,24 @@ export default function MuokkaustilainenLomake({ vuorovaikutus, hidden }: Props)
             <TextInput
               style={{ width: "100%" }}
               label={`Linkin kuvaus toissijaisella kielellä (${lowerCase(toissijainenKieli)})`}
-              {...register(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.nimi`)}
-              onChange={(e) => {
-                setValue(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.nimi`, e.target.value);
-                trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.url`);
-                trigger(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}`);
-              }}
+              {...register(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.nimi`, {
+                onChange: () => {
+                  trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.url`);
+                  trigger(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}`);
+                },
+              })}
               error={(formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[toissijainenKieli]?.nimi}
             />
             <TextInput
               style={{ width: "100%" }}
               label={`Linkki muihin esittelyaineistoihin toissijaisella kielellä (${lowerCase(toissijainenKieli)})`}
-              {...register(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.url`)}
-              onChange={(e) => {
-                setValue(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.url`, e.target.value);
-                trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.nimi`);
-                trigger(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}`);
-              }}
-              error={
-                (formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[toissijainenKieli]?.url ||
-                (formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[toissijainenKieli]
-              }
+              {...register(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.url`, {
+                onChange: () => {
+                  trigger(`vuorovaikutusKierros.suunnittelumateriaali.${toissijainenKieli}.nimi`);
+                  trigger(`vuorovaikutusKierros.suunnittelumateriaali.${ensisijainenKieli}`);
+                },
+              })}
+              error={(formState.errors as any)?.vuorovaikutusKierros?.suunnittelumateriaali?.[toissijainenKieli]?.url}
             />
           </div>
         )}

--- a/src/components/projekti/suunnitteluvaihe/Perustiedot/SuunnittelunEteneminenJaArvioKestosta.tsx
+++ b/src/components/projekti/suunnitteluvaihe/Perustiedot/SuunnittelunEteneminenJaArvioKestosta.tsx
@@ -18,7 +18,6 @@ export default function SuunnittelunEteneminenJaArvioKestosta({ kielitiedot }: P
     register,
     formState: { errors },
     trigger,
-    setValue,
   } = useFormContext<SuunnittelunPerustiedotFormValues>();
 
   const ensisijainenKieli = kielitiedot?.ensisijainenKieli || Kieli.SUOMI;
@@ -35,13 +34,13 @@ export default function SuunnittelunEteneminenJaArvioKestosta({ kielitiedot }: P
         <Textarea
           label={`Julkisella puolella esitettävä suunnittelun etenemisen kuvaus ensisijaisella kielellä (${lowerCase(ensisijainenKieli)})`}
           maxLength={maxHankkeenkuvausLength}
-          {...register(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${ensisijainenKieli}`)}
-          onChange={(e) => {
-            setValue(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${ensisijainenKieli}`, e.target.value);
-            if (toissijainenKieli) {
-              trigger(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${toissijainenKieli}`);
-            }
-          }}
+          {...register(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${ensisijainenKieli}`, {
+            onChange: () => {
+              if (toissijainenKieli) {
+                trigger(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${toissijainenKieli}`);
+              }
+            },
+          })}
           error={(errors.vuorovaikutusKierros?.suunnittelunEteneminenJaKesto as any)?.[ensisijainenKieli]}
         />
         {toissijainenKieli && (
@@ -50,13 +49,11 @@ export default function SuunnittelunEteneminenJaArvioKestosta({ kielitiedot }: P
               toissijainenKieli
             )})`}
             maxLength={maxHankkeenkuvausLength}
-            {...register(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${toissijainenKieli}`)}
-            onChange={(e) => {
-              setValue(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${toissijainenKieli}`, e.target.value);
-              if (toissijainenKieli) {
+            {...register(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${toissijainenKieli}`, {
+              onChange: () => {
                 trigger(`vuorovaikutusKierros.suunnittelunEteneminenJaKesto.${ensisijainenKieli}`);
-              }
-            }}
+              },
+            })}
             error={(errors.vuorovaikutusKierros?.suunnittelunEteneminenJaKesto as any)?.[toissijainenKieli]}
           />
         )}
@@ -66,34 +63,32 @@ export default function SuunnittelunEteneminenJaArvioKestosta({ kielitiedot }: P
           Anna arvio hallinnollisen käsittelyn seuraavan vaiheen alkamisesta. Seuraava vaihe on nähtävillä olo, jossa kansalaisilla on
           mahdollisuus jättää muistutuksia tehtyihin suunnitelmiin.
         </p>
-
         <p className="mb-8 pb-6">
           {`Arvio esitetään palvelun julkisella puolella. Jos arviota ei pystytä antamaan, kirjoita 'Seuraavan
-        vaiheen alkamisesta ei pystytä vielä antamaan arviota'`}
-          .
+        vaiheen alkamisesta ei pystytä vielä antamaan arviota'.`}
         </p>
         <TextInput
           className="mt-8"
           label={`Arvio seuraavan vaiheen alkamisesta ensisijaisella kielellä (${lowerCase(ensisijainenKieli)})`}
           maxLength={maxHankkeenkuvausLength}
-          {...register(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${ensisijainenKieli}`)}
-          onChange={(e) => {
-            setValue(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${ensisijainenKieli}`, e.target.value);
-            if (toissijainenKieli) {
-              trigger(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${toissijainenKieli}`);
-            }
-          }}
+          {...register(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${ensisijainenKieli}`, {
+            onChange: () => {
+              if (toissijainenKieli) {
+                trigger(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${toissijainenKieli}`);
+              }
+            },
+          })}
           error={(errors.vuorovaikutusKierros?.arvioSeuraavanVaiheenAlkamisesta as any)?.[ensisijainenKieli]}
         />
         {toissijainenKieli && (
           <TextInput
             label={`Arvio seuraavan vaiheen alkamisesta toissijaisella kielellä (${lowerCase(toissijainenKieli)})`}
             maxLength={maxHankkeenkuvausLength}
-            {...register(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${toissijainenKieli}`)}
-            onChange={(e) => {
-              setValue(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${toissijainenKieli}`, e.target.value);
-              trigger(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${ensisijainenKieli}`);
-            }}
+            {...register(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${toissijainenKieli}`, {
+              onChange: () => {
+                trigger(`vuorovaikutusKierros.arvioSeuraavanVaiheenAlkamisesta.${ensisijainenKieli}`);
+              },
+            })}
             error={(errors.vuorovaikutusKierros?.arvioSeuraavanVaiheenAlkamisesta as any)?.[toissijainenKieli]}
           />
         )}

--- a/src/components/projekti/suunnitteluvaihe/VuorovaikutusKierros/index.tsx
+++ b/src/components/projekti/suunnitteluvaihe/VuorovaikutusKierros/index.tsx
@@ -27,7 +27,7 @@ import { Stack } from "@mui/material";
 import HyvaksymisDialogi from "./HyvaksymisDialogi";
 import EsitettavatYhteystiedot from "./EsitettavatYhteystiedot";
 import IlmoituksenVastaanottajat from "./IlmoituksenVastaanottajat";
-import { removeTypeName, removeTypeNamesFromArray } from "src/util/removeTypeName";
+import { removeTypeName } from "src/util/removeTypeName";
 import defaultVastaanottajat from "src/util/defaultVastaanottajat";
 import VuorovaikuttamisenInfo from "./VuorovaikuttamisenInfo";
 import VuorovaikutusMahdollisuudet from "./VuorovaikutusMahdollisuudet";
@@ -42,6 +42,7 @@ import Julkaisupaiva from "./Julkaisupaiva";
 import useProjektiHenkilot from "src/hooks/useProjektiHenkilot";
 import useApi from "src/hooks/useApi";
 import HankkeenSisallonKuvaus from "./HankkeenSisallonKuvaus";
+import defaultEsitettavatYhteystiedot from "src/util/defaultEsitettavatYhteystiedot";
 
 type ProjektiFields = Pick<TallennaProjektiInput, "oid" | "versio">;
 
@@ -136,10 +137,7 @@ function VuorovaikutusKierrosKutsu({
         hankkeenKuvaus: hankkeenKuvaus,
 
         kysymyksetJaPalautteetViimeistaan: vuorovaikutusKierros?.kysymyksetJaPalautteetViimeistaan || null,
-        esitettavatYhteystiedot: {
-          yhteysTiedot: removeTypeNamesFromArray(vuorovaikutusKierros?.esitettavatYhteystiedot?.yhteysTiedot) || [],
-          yhteysHenkilot: vuorovaikutusKierros?.esitettavatYhteystiedot?.yhteysHenkilot || [],
-        },
+        esitettavatYhteystiedot: defaultEsitettavatYhteystiedot(vuorovaikutusKierros.esitettavatYhteystiedot),
         ilmoituksenVastaanottajat: defaultVastaanottajat(projekti, vuorovaikutusKierros?.ilmoituksenVastaanottajat, kirjaamoOsoitteet),
         vuorovaikutusTilaisuudet:
           vuorovaikutusKierros?.vuorovaikutusTilaisuudet?.map((tilaisuus: VuorovaikutusTilaisuus) => {
@@ -152,10 +150,7 @@ function VuorovaikutusKierrosKutsu({
               postitoimipaikka: removeTypeName(postitoimipaikka),
               Saapumisohjeet: removeTypeName(Saapumisohjeet),
               paikka: removeTypeName(paikka),
-              esitettavatYhteystiedot: {
-                yhteysHenkilot: esitettavatYhteystiedot?.yhteysHenkilot || [],
-                yhteysTiedot: removeTypeNamesFromArray(esitettavatYhteystiedot?.yhteysTiedot) || [],
-              },
+              esitettavatYhteystiedot: defaultEsitettavatYhteystiedot(esitettavatYhteystiedot),
             };
             return vuorovaikutusTilaisuusInput;
           }) || [],

--- a/src/components/projekti/suunnitteluvaihe/komponentit/VuorovaikutustilaisuusDialog/index.tsx
+++ b/src/components/projekti/suunnitteluvaihe/komponentit/VuorovaikutustilaisuusDialog/index.tsx
@@ -359,15 +359,13 @@ export default function VuorovaikutusDialog({
                             label={`Paikan nimi ensisijaisella kielellä (${lowerCase(ensisijainenKieli)})`}
                             maxLength={200}
                             style={{ gridColumn: "1 / span 1" }}
-                            {...register(`vuorovaikutusTilaisuudet.${index}.paikka.${ensisijainenKieli}`)}
-                            onChange={(e) => {
-                              setValue(`vuorovaikutusTilaisuudet.${index}.paikka.${ensisijainenKieli}`, e.target.value);
-                              trigger(`vuorovaikutusTilaisuudet.${index}.paikka.${ensisijainenKieli}`);
-                              if (toissijainenKieli) {
-                                trigger(`vuorovaikutusTilaisuudet.${index}.paikka.${toissijainenKieli}`);
-                              }
-                            }}
-                            value={watch(`vuorovaikutusTilaisuudet.${index}.paikka.${ensisijainenKieli}`) || ""}
+                            {...register(`vuorovaikutusTilaisuudet.${index}.paikka.${ensisijainenKieli}`, {
+                              onChange: () => {
+                                if (toissijainenKieli) {
+                                  trigger(`vuorovaikutusTilaisuudet.${index}.paikka.${toissijainenKieli}`);
+                                }
+                              },
+                            })}
                             error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.paikka?.[ensisijainenKieli]}
                             disabled={mostlyDisabled}
                           />
@@ -376,13 +374,11 @@ export default function VuorovaikutusDialog({
                               label={`Paikan nimi toissijaisella kielellä (${lowerCase(toissijainenKieli)})`}
                               maxLength={200}
                               style={{ gridColumn: "2 / span 1" }}
-                              {...register(`vuorovaikutusTilaisuudet.${index}.paikka.${toissijainenKieli}`)}
-                              onChange={(e) => {
-                                setValue(`vuorovaikutusTilaisuudet.${index}.paikka.${toissijainenKieli}`, e.target.value);
-                                trigger(`vuorovaikutusTilaisuudet.${index}.paikka.${ensisijainenKieli}`);
-                                trigger(`vuorovaikutusTilaisuudet.${index}.paikka.${toissijainenKieli}`);
-                              }}
-                              value={watch(`vuorovaikutusTilaisuudet.${index}.paikka.${toissijainenKieli}`) || ""}
+                              {...register(`vuorovaikutusTilaisuudet.${index}.paikka.${toissijainenKieli}`, {
+                                onChange: () => {
+                                  trigger(`vuorovaikutusTilaisuudet.${index}.paikka.${ensisijainenKieli}`);
+                                },
+                              })}
                               error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.paikka?.[toissijainenKieli]}
                               disabled={mostlyDisabled}
                             />
@@ -394,15 +390,13 @@ export default function VuorovaikutusDialog({
                             maxLength={200}
                             disabled={mostlyDisabled}
                             style={{ gridColumn: "1 / span 2" }}
-                            {...register(`vuorovaikutusTilaisuudet.${index}.osoite.${ensisijainenKieli}`)}
-                            onChange={(e) => {
-                              setValue(`vuorovaikutusTilaisuudet.${index}.osoite.${ensisijainenKieli}`, e.target.value);
-                              trigger(`vuorovaikutusTilaisuudet.${index}.osoite.${ensisijainenKieli}`);
-                              if (toissijainenKieli) {
-                                trigger(`vuorovaikutusTilaisuudet.${index}.osoite.${toissijainenKieli}`);
-                              }
-                            }}
-                            value={watch(`vuorovaikutusTilaisuudet.${index}.osoite.${ensisijainenKieli}`) || ""}
+                            {...register(`vuorovaikutusTilaisuudet.${index}.osoite.${ensisijainenKieli}`, {
+                              onChange: () => {
+                                if (toissijainenKieli) {
+                                  trigger(`vuorovaikutusTilaisuudet.${index}.osoite.${toissijainenKieli}`);
+                                }
+                              },
+                            })}
                             error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.osoite?.[ensisijainenKieli]}
                           />
                           <TextInput
@@ -416,15 +410,13 @@ export default function VuorovaikutusDialog({
                             label="Postitoimipaikka"
                             disabled={mostlyDisabled}
                             maxLength={200}
-                            {...register(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${ensisijainenKieli}`)}
-                            onChange={(e) => {
-                              setValue(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${ensisijainenKieli}`, e.target.value);
-                              trigger(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${ensisijainenKieli}`);
-                              if (toissijainenKieli) {
-                                trigger(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${toissijainenKieli}`);
-                              }
-                            }}
-                            value={watch(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${ensisijainenKieli}`) || ""}
+                            {...register(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${ensisijainenKieli}`, {
+                              onChange: () => {
+                                if (toissijainenKieli) {
+                                  trigger(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${toissijainenKieli}`);
+                                }
+                              },
+                            })}
                             error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.postitoimipaikka?.[ensisijainenKieli]}
                           />
                         </HassuGrid>
@@ -435,13 +427,11 @@ export default function VuorovaikutusDialog({
                               maxLength={200}
                               disabled={mostlyDisabled}
                               style={{ gridColumn: "1 / span 2" }}
-                              {...register(`vuorovaikutusTilaisuudet.${index}.osoite.${toissijainenKieli}`)}
-                              onChange={(e) => {
-                                setValue(`vuorovaikutusTilaisuudet.${index}.osoite.${toissijainenKieli}`, e.target.value);
-                                trigger(`vuorovaikutusTilaisuudet.${index}.osoite.${ensisijainenKieli}`);
-                                trigger(`vuorovaikutusTilaisuudet.${index}.osoite.${toissijainenKieli}`);
-                              }}
-                              value={watch(`vuorovaikutusTilaisuudet.${index}.osoite.${toissijainenKieli}`) || ""}
+                              {...register(`vuorovaikutusTilaisuudet.${index}.osoite.${toissijainenKieli}`, {
+                                onChange: () => {
+                                  trigger(`vuorovaikutusTilaisuudet.${index}.osoite.${ensisijainenKieli}`);
+                                },
+                              })}
                               error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.osoite?.[toissijainenKieli]}
                             />
                             <TextInput
@@ -454,13 +444,11 @@ export default function VuorovaikutusDialog({
                               label="Postitoimipaikka"
                               disabled={mostlyDisabled}
                               maxLength={200}
-                              {...register(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${toissijainenKieli}`)}
-                              onChange={(e) => {
-                                setValue(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${toissijainenKieli}`, e.target.value);
-                                trigger(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${ensisijainenKieli}`);
-                                trigger(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${toissijainenKieli}`);
-                              }}
-                              value={watch(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${toissijainenKieli}`) || ""}
+                              {...register(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${toissijainenKieli}`, {
+                                onChange: () => {
+                                  trigger(`vuorovaikutusTilaisuudet.${index}.postitoimipaikka.${ensisijainenKieli}`);
+                                },
+                              })}
                               error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.postitoimipaikka?.[toissijainenKieli]}
                             />
                           </HassuGrid>
@@ -468,15 +456,13 @@ export default function VuorovaikutusDialog({
 
                         <TextInput
                           label={`Saapumisohjeet ensisijaisella kielellä (${lowerCase(ensisijainenKieli)})`}
-                          {...register(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${ensisijainenKieli}`)}
-                          onChange={(e) => {
-                            setValue(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${ensisijainenKieli}`, e.target.value);
-                            trigger(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${ensisijainenKieli}`);
-                            if (toissijainenKieli) {
-                              trigger(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${toissijainenKieli}`);
-                            }
-                          }}
-                          value={watch(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${ensisijainenKieli}`) || ""}
+                          {...register(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${ensisijainenKieli}`, {
+                            onChange: () => {
+                              if (toissijainenKieli) {
+                                trigger(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${toissijainenKieli}`);
+                              }
+                            },
+                          })}
                           error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.Saapumisohjeet?.[ensisijainenKieli]}
                           maxLength={200}
                           disabled={!!peruttu}
@@ -484,13 +470,11 @@ export default function VuorovaikutusDialog({
                         {toissijainenKieli && (
                           <TextInput
                             label={`Saapumisohjeet ensisijaisella kielellä (${lowerCase(toissijainenKieli)})`}
-                            {...register(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${toissijainenKieli}`)}
-                            onChange={(e) => {
-                              setValue(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${toissijainenKieli}`, e.target.value);
-                              trigger(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${ensisijainenKieli}`);
-                              trigger(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${toissijainenKieli}`);
-                            }}
-                            value={watch(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${toissijainenKieli}`) || ""}
+                            {...register(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${toissijainenKieli}`, {
+                              onChange: () => {
+                                trigger(`vuorovaikutusTilaisuudet.${index}.Saapumisohjeet.${ensisijainenKieli}`);
+                              },
+                            })}
                             error={(errors as any)?.vuorovaikutusTilaisuudet?.[index]?.Saapumisohjeet?.[toissijainenKieli]}
                             maxLength={200}
                             disabled={!!peruttu}
@@ -500,8 +484,8 @@ export default function VuorovaikutusDialog({
                           !peruttu && (
                             <Button
                               className="btn-remove-red"
-                              onClick={(event) => {
-                                event.preventDefault();
+                              type="button"
+                              onClick={() => {
                                 setValue(`vuorovaikutusTilaisuudet.${index}.peruttu`, true);
                               }}
                             >
@@ -511,8 +495,8 @@ export default function VuorovaikutusDialog({
                         ) : (
                           <Button
                             className="btn-remove-red"
-                            onClick={(event) => {
-                              event.preventDefault();
+                            type="button"
+                            onClick={() => {
                               remove(index);
                             }}
                           >
@@ -635,9 +619,7 @@ function TilaisuudenNimiJaAika(props: { index: number; mostlyDisabled?: boolean;
   const {
     register,
     formState: { errors },
-    setValue,
     trigger,
-    watch,
   } = useFormContext<VuorovaikutustilaisuusFormValues>();
 
   const { data: projekti } = useProjekti();
@@ -650,15 +632,13 @@ function TilaisuudenNimiJaAika(props: { index: number; mostlyDisabled?: boolean;
       {!!props.peruttu && <div className="text-red">PERUTTU</div>}
       <TextInput
         label={`Tilaisuuden nimi ensisijaisella kielellä (${lowerCase(ensisijainenKieli)})`}
-        {...register(`vuorovaikutusTilaisuudet.${props.index}.nimi.${ensisijainenKieli}`)}
-        onChange={(e) => {
-          setValue(`vuorovaikutusTilaisuudet.${props.index}.nimi.${ensisijainenKieli}`, e.target.value);
-          trigger(`vuorovaikutusTilaisuudet.${props.index}.nimi.${ensisijainenKieli}`);
-          if (toissijainenKieli) {
-            trigger(`vuorovaikutusTilaisuudet.${props.index}.nimi.${toissijainenKieli}`);
-          }
-        }}
-        value={watch(`vuorovaikutusTilaisuudet.${props.index}.nimi.${ensisijainenKieli}`) || ""}
+        {...register(`vuorovaikutusTilaisuudet.${props.index}.nimi.${ensisijainenKieli}`, {
+          onChange: () => {
+            if (toissijainenKieli) {
+              trigger(`vuorovaikutusTilaisuudet.${props.index}.nimi.${toissijainenKieli}`);
+            }
+          },
+        })}
         error={(errors as any)?.vuorovaikutusTilaisuudet?.[props.index]?.nimi?.[ensisijainenKieli]}
         disabled={!!props.peruttu}
         maxLength={200}
@@ -666,13 +646,11 @@ function TilaisuudenNimiJaAika(props: { index: number; mostlyDisabled?: boolean;
       {toissijainenKieli && (
         <TextInput
           label={`Tilaisuuden nimi toissijaisella kielellä (${lowerCase(toissijainenKieli)})`}
-          {...register(`vuorovaikutusTilaisuudet.${props.index}.nimi.${toissijainenKieli}`)}
-          onChange={(e) => {
-            setValue(`vuorovaikutusTilaisuudet.${props.index}.nimi.${toissijainenKieli}`, e.target.value);
-            trigger(`vuorovaikutusTilaisuudet.${props.index}.nimi.${ensisijainenKieli}`);
-            trigger(`vuorovaikutusTilaisuudet.${props.index}.nimi.${toissijainenKieli}`);
-          }}
-          value={watch(`vuorovaikutusTilaisuudet.${props.index}.nimi.${toissijainenKieli}`) || ""}
+          {...register(`vuorovaikutusTilaisuudet.${props.index}.nimi.${toissijainenKieli}`, {
+            onChange: () => {
+              trigger(`vuorovaikutusTilaisuudet.${props.index}.nimi.${ensisijainenKieli}`);
+            },
+          })}
           error={(errors as any)?.vuorovaikutusTilaisuudet?.[props.index]?.nimi?.[toissijainenKieli]}
           disabled={!!props.peruttu}
           maxLength={200}

--- a/src/components/projekti/suunnitteluvaihe/komponentit/VuorovaikutustilaisuusDialog/index.tsx
+++ b/src/components/projekti/suunnitteluvaihe/komponentit/VuorovaikutustilaisuusDialog/index.tsx
@@ -22,7 +22,6 @@ import {
   VuorovaikutusTilaisuusInput,
   VuorovaikutusTilaisuusTyyppi,
   Yhteystieto,
-  YhteystietoInput,
 } from "@services/api";
 import capitalize from "lodash/capitalize";
 import { Controller, FormProvider, useFieldArray, useForm, useFormContext, UseFormProps } from "react-hook-form";
@@ -38,6 +37,7 @@ import { useProjekti } from "src/hooks/useProjekti";
 import { lowerCase } from "lodash";
 import { poistaTypeNameJaTurhatKielet } from "src/util/removeExtraLanguagesAndTypename";
 import useTranslation from "next-translate/useTranslation";
+import defaultEsitettavatYhteystiedot from "src/util/defaultEsitettavatYhteystiedot";
 
 function defaultTilaisuus(
   ensisijainenKieli: Kieli,
@@ -94,15 +94,7 @@ function tilaisuudetInputiksi(
     delete (tilaisuusCopy as Partial<VuorovaikutusTilaisuus>).__typename;
     const palautetaan = {
       ...tilaisuusCopy,
-      esitettavatYhteystiedot: {
-        yhteysHenkilot: tilaisuus.esitettavatYhteystiedot?.yhteysHenkilot || [],
-        yhteysTiedot:
-          tilaisuus.esitettavatYhteystiedot?.yhteysTiedot?.map((yhteystieto) => {
-            const yhteystietoCopy: Partial<YhteystietoInput | Yhteystieto> = { ...yhteystieto };
-            delete (yhteystietoCopy as Partial<Yhteystieto>).__typename;
-            return yhteystietoCopy;
-          }) || [],
-      },
+      esitettavatYhteystiedot: defaultEsitettavatYhteystiedot(tilaisuus.esitettavatYhteystiedot),
     };
     if (palautetaan.nimi) {
       palautetaan.nimi = poistaTypeNameJaTurhatKielet(palautetaan.nimi, kielitiedot);

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -19,7 +19,6 @@ import {
   TallennaProjektiInput,
   TilasiirtymaToiminto,
   TilasiirtymaTyyppi,
-  YhteystietoInput,
 } from "@services/api";
 import log from "loglevel";
 import { getProjektiValidationSchema, ProjektiTestType } from "src/schemas/projekti";
@@ -42,7 +41,6 @@ import HassuSpinner from "@components/HassuSpinner";
 import PdfPreviewForm from "@components/projekti/PdfPreviewForm";
 import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import { KeyedMutator } from "swr";
-import { removeTypeName } from "src/util/removeTypeName";
 import { HassuDatePickerWithController } from "@components/form/HassuDatePicker";
 import { today } from "src/util/dateUtils";
 import { kuntametadata } from "../../../../../common/kuntametadata";
@@ -50,6 +48,7 @@ import UudelleenkuulutaButton from "@components/projekti/UudelleenkuulutaButton"
 import { getDefaultValuesForLokalisoituText, getDefaultValuesForUudelleenKuulutus } from "src/util/getDefaultValuesForLokalisoituText";
 import SelitteetUudelleenkuulutukselle from "@components/projekti/SelitteetUudelleenkuulutukselle";
 import useApi from "src/hooks/useApi";
+import defaultEsitettavatYhteystiedot from "src/util/defaultEsitettavatYhteystiedot";
 
 type ProjektiFields = Pick<TallennaProjektiInput, "oid" | "versio">;
 type RequiredProjektiFields = Required<{
@@ -109,11 +108,6 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
       ]),
     ];
 
-    const yhteysTiedot: YhteystietoInput[] =
-      projekti?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysTiedot?.map((yt) => removeTypeName(yt)) || [];
-
-    const yhteysHenkilot: string[] = projekti?.aloitusKuulutus?.kuulutusYhteystiedot?.yhteysHenkilot || [];
-
     const hankkeenKuvaus = getDefaultValuesForLokalisoituText(projekti.kielitiedot, projekti.aloitusKuulutus?.hankkeenKuvaus);
 
     const tallentamisTiedot: FormValues = {
@@ -134,10 +128,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
         hankkeenKuvaus,
         kuulutusPaiva: projekti?.aloitusKuulutus?.kuulutusPaiva || null,
         siirtyySuunnitteluVaiheeseen: projekti?.aloitusKuulutus?.siirtyySuunnitteluVaiheeseen || null,
-        kuulutusYhteystiedot: {
-          yhteysTiedot,
-          yhteysHenkilot,
-        },
+        kuulutusYhteystiedot: defaultEsitettavatYhteystiedot(projekti.aloitusKuulutus?.kuulutusYhteystiedot),
       },
     };
 

--- a/src/util/defaultEsitettavatYhteystiedot.ts
+++ b/src/util/defaultEsitettavatYhteystiedot.ts
@@ -1,0 +1,23 @@
+import { StandardiYhteystiedot, StandardiYhteystiedotInput, YhteystietoInput } from "@services/api";
+
+export default function defaultEsitettavatYhteystiedot(
+  standardiYhteystiedot: StandardiYhteystiedot | StandardiYhteystiedotInput | null | undefined
+): StandardiYhteystiedotInput {
+  const yhteysTiedot: YhteystietoInput[] =
+    standardiYhteystiedot?.yhteysTiedot?.map<YhteystietoInput>(
+      ({ etunimi, puhelinnumero, sahkoposti, sukunimi, organisaatio, titteli, kunta }) => ({
+        etunimi,
+        puhelinnumero,
+        sahkoposti,
+        sukunimi,
+        organisaatio,
+        titteli,
+        kunta,
+      })
+    ) || [];
+  const yhteysHenkilot: string[] = standardiYhteystiedot?.yhteysHenkilot || [];
+  return {
+    yhteysHenkilot,
+    yhteysTiedot,
+  };
+}


### PR DESCRIPTION
Johtui siitä, että lomakkeiden oletusarvoihin valui ylimääräinen kenttiä (elyOrganisaatio).
Lisäksi muokkasin kutsussa olevien monikielisten kenttien validointeja ja triggeröintiä sellaiseksi, että erroria näytetään, jos tieto on toisella kielellä. Virheilmoitus poistuu näkyvistä kun tieto on täytetty molemmilla kielillä. 