### PR TITLE
fix: Korjaa varoitukset footerin sosiaalisen median linkeistä

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -119,9 +119,9 @@ const SocialMediaLinkList = styled("div")(({ theme }) => ({
   gap: theme.spacing(3),
 }));
 
-const SocialMediaLink = styled(({ icon, ref, title, ...props }: SocialMediaLinkProps) => (
+const SocialMediaLink = styled(({ icon, ref, ...props }: SocialMediaLinkProps) => (
   <HassuLink useNextLink={false} target="_blank" {...props}>
-    <FontAwesomeIcon icon={icon} title={title} />
+    <FontAwesomeIcon icon={icon} />
   </HassuLink>
 ))(({ theme }) => ({
   color: "white",


### PR DESCRIPTION
Katsoin väylä.fi -sivuston sosiaalisen median ikoneja ja linkkejä. Siellä myös title annettu a-elementille ja lapsielementti-ikonissa ei ole mitään aria-attribuutteja. Meillä sinne tulee sentään aria-hidden="true", mikä ilmaisee, että kyseessä on vain decoratiivinen kuva, jolle ei tarvitse antaa muita aria-attributteja. 

Testattu myös toimivaksi Macin VoiceOver ruudunlukijalla.