### PR TITLE
fix: Aseta vieraskielinen projektinimi pakotetuksi tiedoksi schemaan

### DIFF
--- a/src/components/projekti/ProjektiKuulutuskielet.tsx
+++ b/src/components/projekti/ProjektiKuulutuskielet.tsx
@@ -20,9 +20,7 @@ export default function ProjektiKuulutuskielet(): ReactElement {
     Object.entries(Kieli).map(([k, v]) => ({ label: lowerCase(k), value: v }))
   );
   const kielioptions = kielioptionsKaikki.filter((kielivalinta) => kielivalinta.value !== Kieli.SAAME);
-  const [kielioptions2, setKielioptions2] = useState(
-    kielioptionsKaikki.filter((kielivalinta) => kielivalinta.value !== Kieli.SUOMI)
-  );
+  const [kielioptions2, setKielioptions2] = useState(kielioptionsKaikki.filter((kielivalinta) => kielivalinta.value !== Kieli.SUOMI));
   const [vieraskieliEnsisijainen, setVieraskieliEnsisijainen] = useState("");
   const kieli1 = watch("kielitiedot.ensisijainenKieli");
   const kieli2 = watch("kielitiedot.toissijainenKieli");
@@ -75,14 +73,12 @@ export default function ProjektiKuulutuskielet(): ReactElement {
       </SectionContent>
       {hasVieraskieli() && (
         <TextInput
-          label={`Projektin nimi ${
-            vieraskieliEnsisijainen ? lowerCase(vieraskieliEnsisijainen) : lowerCase(kieli2)
-          }n kielellä`}
+          label={`Projektin nimi ${vieraskieliEnsisijainen ? lowerCase(vieraskieliEnsisijainen) : lowerCase(kieli2)}n kielellä *`}
           error={errors.kielitiedot?.projektinNimiVieraskielella}
           {...register("kielitiedot.projektinNimiVieraskielella", { shouldUnregister: true })}
         />
       )}
-      <p>Huomaa, että valinta vaikuttaa siihen, mitä kenttiä järjestelmässä näytetään kuulutusten yhteydessä. </p>
+      <p>Huomaa, että valinta vaikuttaa siihen, mitä kenttiä järjestelmässä näytetään kuulutusten yhteydessä.</p>
     </Section>
   );
 }

--- a/src/schemas/perustiedot.ts
+++ b/src/schemas/perustiedot.ts
@@ -16,7 +16,17 @@ export const perustiedotValidationSchema = Yup.object()
       .shape({
         ensisijainenKieli: Yup.string().required("Ensisijainen kieli puuttuu"),
         toissijainenKieli: Yup.string().notRequired().nullable().default(null),
-        projektinNimiVieraskielella: Yup.string().notRequired().nullable().default(null),
+        projektinNimiVieraskielella: Yup.string()
+          .nullable()
+          .default(null)
+          .when("ensisijainenKieli", {
+            is: (value: Kieli) => [Kieli.RUOTSI, Kieli.SAAME].includes(value),
+            then: (schema) => schema.required("Projektin nimi on pakollinen"),
+          })
+          .when("toissijainenKieli", {
+            is: (value: Kieli) => [Kieli.RUOTSI, Kieli.SAAME].includes(value),
+            then: (schema) => schema.required("Projektin nimi on pakollinen"),
+          }),
       })
       .notRequired()
       .nullable()


### PR DESCRIPTION
Laitettu schemaan konditionaalinen vaade vieraskieliselle nimelle riippuen onko vieraskieltä valittu projektille. Kun backendin tekemä perustietojen schemavalidointi epäonnistuu, siirtää se projektin tilan EI_JULKAISTU:ksi, jolloin käyttäjä hennosti pakotetaan laittamaan vieraskielinen nimi tai poistamaan vieraskielivalinnan. 