### PR TITLE
fix: Älä oleta että tuorein-versio -avain on olemassa

### DIFF
--- a/backend/src/aineisto/PartiallyMandatory.ts
+++ b/backend/src/aineisto/PartiallyMandatory.ts
@@ -1,0 +1,4 @@
+export type PartiallyMandatory<T, K extends keyof T> = Omit<T, K> &
+  Required<{
+    [P in K]: NonNullable<T[P]>;
+  }>;

--- a/backend/src/aineisto/PartiallyRequiredAndNonNullable.ts
+++ b/backend/src/aineisto/PartiallyRequiredAndNonNullable.ts
@@ -1,4 +1,0 @@
-export type PartiallyRequiredAndNonNullable<T, K extends keyof T> = Omit<T, K> &
-  Required<{
-    [P in K]: NonNullable<T[P]>;
-  }>;

--- a/backend/src/aineisto/PartiallyRequiredAndNonNullable.ts
+++ b/backend/src/aineisto/PartiallyRequiredAndNonNullable.ts
@@ -1,0 +1,4 @@
+export type PartiallyRequiredAndNonNullable<T, K extends keyof T> = Omit<T, K> &
+  Required<{
+    [P in K]: NonNullable<T[P]>;
+  }>;

--- a/backend/src/velho/velhoClient.ts
+++ b/backend/src/velho/velhoClient.ts
@@ -14,7 +14,7 @@ import dayjs from "dayjs";
 import { getAxios } from "../aws/monitoring";
 import { assertIsDefined } from "../util/assertions";
 import { IllegalArgumentError } from "../error/IllegalArgumentError";
-import { PartiallyRequiredAndNonNullable } from "../aineisto/PartiallyRequiredAndNonNullable";
+import { PartiallyMandatory } from "../aineisto/PartiallyMandatory";
 
 const NodeCache = require("node-cache");
 const accessTokenCache = new NodeCache({
@@ -140,8 +140,7 @@ export class VelhoClient {
 
           const aineistot: VelhoAineisto[] = aineistoArray
             .filter(
-              (aineisto): aineisto is PartiallyRequiredAndNonNullable<AineistoPalvelu.AineistoAineisto, "tuorein-versio"> =>
-                !!aineisto["tuorein-versio"]
+              (aineisto): aineisto is PartiallyMandatory<AineistoPalvelu.AineistoAineisto, "tuorein-versio"> => !!aineisto["tuorein-versio"]
             )
             .map((aineisto) => {
               const { dokumenttiTyyppi } = adaptDokumenttiTyyppi(`${aineisto.metatiedot.dokumenttityyppi}`);

--- a/backend/src/velho/velhoClient.ts
+++ b/backend/src/velho/velhoClient.ts
@@ -139,20 +139,16 @@ export class VelhoClient {
 
           const aineistot: VelhoAineisto[] = aineistoArray.map((aineisto) => {
             const { dokumenttiTyyppi } = adaptDokumenttiTyyppi(`${aineisto.metatiedot.dokumenttityyppi}`);
-            const tiedostoNimi = aineisto["tuorein-versio"]?.nimi;
-            if (!tiedostoNimi) {
-              throw new Error("loadProjektiAineistot: aineisto['tuorein-versio']?.nimi puuttuu");
-            }
-            if (!aineisto["tuorein-versio"]?.muokattu) {
-              throw new Error("loadProjektiAineistot: aineisto['tuorein-versio']?.muokattu puuttuu");
-            }
+            const tiedostoNimi = aineisto["tuorein-versio"]?.nimi || aineisto.versiot?.[aineisto.versiot.length - 1]?.nimi || aineisto.oid;
+            const muokattu =
+              aineisto["tuorein-versio"]?.muokattu || aineisto.versiot?.[aineisto.versiot.length - 1]?.muokattu || aineisto.muokattu;
             return {
               __typename: "VelhoAineisto",
               oid: aineisto.oid,
               tiedosto: tiedostoNimi,
               kuvaus: aineisto.metatiedot.kuvaus || "",
               dokumenttiTyyppi,
-              muokattu: dayjs(aineisto["tuorein-versio"].muokattu).format(),
+              muokattu: dayjs(muokattu).format(),
             };
           });
           return { __typename: "VelhoToimeksianto", nimi, aineistot, oid: toimeksianto.oid };


### PR DESCRIPTION
Käytä backupina versiot-arrayn vikaa objektia, ja sen jälkeen päätason objektin tietoja