### PR TITLE
fix: Korjaa huoltokatkosivulla näytettävät ikonit

### DIFF
--- a/under-maintenance/pages/_app.tsx
+++ b/under-maintenance/pages/_app.tsx
@@ -6,6 +6,7 @@ import { AppProps } from "next/app";
 import React from "react";
 import HassuMuiThemeProvider from "../../src/components/layout/HassuMuiThemeProvider";
 
+import "@fortawesome/fontawesome-svg-core/styles.css";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
 library.add(faExternalLinkAlt);


### PR DESCRIPTION
Ilman muutosta näyttää tältä:
<img width="753" alt="image" src="https://github.com/finnishtransportagency/hassu/assets/77731851/5dcaeb6d-2ea8-4f08-b67e-d6f743ef9113">

Muutoksen kanssa tältä:
<img width="761" alt="image" src="https://github.com/finnishtransportagency/hassu/assets/77731851/d318301b-3c57-4eb0-8531-6ddf3eeb3e78">

Korjausta voi testata itsekin ajamalla
npm run export-under-maintenance
npm run deploy:frontend

ja menemällä kattomaan cloudfrontissa olevasta frontista /huoltokatko.index.html