### PR TITLE
fix: hassu-1775 vähäisen menettelyn projektin aloituskuulutuksen voi uudelleenkuuluttaa

### DIFF
--- a/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
+++ b/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
@@ -55,7 +55,7 @@ async function createAloituskuulutusPDF(
     inline: true,
     contentType: "application/pdf",
     publicationTimestamp: parseDate(julkaisuWaitingForApproval.kuulutusPaiva),
-    asiakirjaTyyppi
+    asiakirjaTyyppi,
   });
 }
 
@@ -124,9 +124,15 @@ class AloitusKuulutusTilaManager extends KuulutusTilaManager<AloitusKuulutus, Al
     if (!hyvaksyttyJulkaisu) {
       throw new IllegalArgumentError("Ei ole olemassa kuulutusta, jota uudelleenkuuluttaa");
     }
-    // Aloituskuulutuksen uudelleenkuul uttaminen on mahdollista vain jos projekti on ylläpidossa suunnitteluvaiheessa
+    // Aloituskuulutuksen uudelleenkuul uttaminen on mahdollista vain jos projekti on ylläpidossa suunnitteluvaiheessa,
+    // tai nähtävilläolovaiheessa, kun kyseessä on vähäinen menettely
     const apiProjekti = await projektiAdapter.adaptProjekti(projekti);
-    if (apiProjekti.status !== Status.SUUNNITTELU) {
+    if (
+      !(
+        (apiProjekti.status === Status.SUUNNITTELU && !apiProjekti.vahainenMenettely) ||
+        (apiProjekti.status === Status.NAHTAVILLAOLO_AINEISTOT && apiProjekti.vahainenMenettely)
+      )
+    ) {
       throw new IllegalArgumentError("Et voi uudelleenkuuluttaa aloistuskuulutusta projektin ollessa tässä tilassa:" + apiProjekti.status);
     }
     assert(kuulutus, "Projektilla pitäisi olla aloituskuulutus, jos se on suunnittelutilassa");

--- a/backend/src/projekti/validator/projektiValidator.ts
+++ b/backend/src/projekti/validator/projektiValidator.ts
@@ -1,4 +1,4 @@
-import { DBProjekti, UudelleenKuulutus } from "../../database/model";
+import { DBProjekti, UudelleenKuulutus, UudelleenkuulutusTila } from "../../database/model";
 import {
   KayttajaTyyppi,
   KuulutusJulkaisuTila,
@@ -179,11 +179,12 @@ function validateVahainenMenettely(dbProjekti: DBProjekti, input: TallennaProjek
   } // Lista voi olla myos olemassa, mutta tyhja, jos kuulutus on esim palautettu muokattavaksi
 
   const latestAloituskuulutusJulkaisuTila = dbProjekti?.aloitusKuulutusJulkaisut?.[dbProjekti.aloitusKuulutusJulkaisut.length - 1].tila;
+  const uudelleenKuulutusPalautettu = dbProjekti?.aloitusKuulutus?.uudelleenKuulutus?.tila == UudelleenkuulutusTila.JULKAISTU_PERUUTETTU;
   const isLatestJulkaisuPendingApprovalOrApproved =
     !!latestAloituskuulutusJulkaisuTila &&
     [KuulutusJulkaisuTila.HYVAKSYTTY, KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA].includes(latestAloituskuulutusJulkaisuTila);
 
-  if (isVahainenMenettelyValueChanged && isLatestJulkaisuPendingApprovalOrApproved) {
+  if (isVahainenMenettelyValueChanged && isLatestJulkaisuPendingApprovalOrApproved && !uudelleenKuulutusPalautettu) {
     throw new IllegalArgumentError(
       "Vähäinen menettely -tietoa ei voi muuttaa, jos aloituskuulutus on jo julkaistu tai se odottaa hyväksyntää!"
     );

--- a/backend/test/handler/tila/aloitusKuulutusTilaManager.test.ts
+++ b/backend/test/handler/tila/aloitusKuulutusTilaManager.test.ts
@@ -77,6 +77,22 @@ describe("aloitusKuulutusTilaManager", () => {
     expect(savedProjekti.aloitusKuulutus?.uudelleenKuulutus).to.eql({ tila: UudelleenkuulutusTila.PERUUTETTU });
   });
 
+  it("should create uudelleenkuulutus succesfully for published kuulutus when project uses vähäinenMenettely", async function () {
+    const projekti = new ProjektiFixture().dbProjekti4();
+    projekti.aloitusKuulutusJulkaisut![0].kuulutusPaiva = dateToString(nyt().add(-1, "day")); // Yesterday
+    delete projekti.vuorovaikutusKierros;
+    delete projekti.vuorovaikutusKierrosJulkaisut;
+    delete projekti.nahtavillaoloVaihe;
+    delete projekti.nahtavillaoloVaiheJulkaisut;
+    delete projekti.hyvaksymisPaatosVaiheJulkaisut;
+    await aloitusKuulutusTilaManager.uudelleenkuuluta(projekti);
+    const savedProjekti: Partial<DBProjekti> = saveProjektiStub.getCall(0).firstArg;
+    expect(savedProjekti.aloitusKuulutus?.uudelleenKuulutus).to.eql({
+      tila: UudelleenkuulutusTila.JULKAISTU_PERUUTETTU,
+      alkuperainenHyvaksymisPaiva: "2022-03-21",
+    });
+  });
+
   it("should create uudelleenkuulutus succesfully for published kuulutus", async function () {
     projekti.aloitusKuulutusJulkaisut![0].kuulutusPaiva = dateToString(nyt().add(-1, "day")); // Yesterday
     await aloitusKuulutusTilaManager.uudelleenkuuluta(projekti);

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -363,7 +363,8 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti }: Al
   const showUudelleenkuulutaButton =
     projekti.aloitusKuulutusJulkaisu?.tila === KuulutusJulkaisuTila.HYVAKSYTTY &&
     projekti.aloitusKuulutus?.muokkausTila === MuokkausTila.LUKU &&
-    projekti.status === Status.SUUNNITTELU &&
+    ((projekti.status === Status.SUUNNITTELU && !projekti.vahainenMenettely) ||
+      (projekti.status === Status.NAHTAVILLAOLO_AINEISTOT && projekti.vahainenMenettely)) &&
     projekti.nykyinenKayttaja.onYllapitaja;
 
   const kunnat = watch("aloitusKuulutus.ilmoituksenVastaanottajat.kunnat");


### PR DESCRIPTION
Huomioitu myös, että jos uudelleenkuulutus on palautettu, pitäisi voida muokata vähäisen menettelyn totuusarvoa.