### PR TITLE
feat: Hassu 1292 uudelleenkuulutus peruu vanhan julkaisun

### DIFF
--- a/backend/src/handler/tila/KuulutusTilaManager.ts
+++ b/backend/src/handler/tila/KuulutusTilaManager.ts
@@ -53,6 +53,10 @@ export abstract class KuulutusTilaManager<
     await fileService.copyYllapitoFolder(sourceFolder, targetFolder);
     auditLog.info("Kuulutusvaiheen uudelleenkuulutus onnistui", { sourceFolder, targetFolder });
     await this.saveVaihe(projekti, uusiKuulutus);
+    // Jo edellistä julkaisua ei ole julkaistu vielä, perutaan julkaisu
+    if (!isDateTimeInThePast(hyvaksyttyJulkaisu.kuulutusPaiva ?? undefined, "start-of-day")) {
+      this.updateJulkaisu(projekti, { ...hyvaksyttyJulkaisu, tila: KuulutusJulkaisuTila.PERUUTETTU });
+    }
     auditLog.info("Tallenna uudelleenkuulutustiedolla varustettu kuulutusvaihe", {
       projektiEnnenTallennusta: projekti,
       tallennettavaKuulutus: uusiKuulutus,
@@ -148,6 +152,9 @@ export abstract class KuulutusTilaManager<
     if (!julkaisuWaitingForApproval) {
       throw new Error("Ei kuulutusta odottamassa hyväksyntää");
     }
+    // Kaikki aiemmat hyväksytyt julkaisut laitetaan peruutetuiksi,
+    // paitsi nyt hyväksyttävän julkaisun julkaisupäivä on tulevaisuudessa,
+    // jolloin jätetään viimeisin julki oleva julkaisu näkyville.
     assert(julkaisuWaitingForApproval.kuulutusPaiva, "kuulutusPaiva on oltava tässä kohtaa");
     const isJulkaisuWaitingForApprovalInPast = isDateTimeInThePast(julkaisuWaitingForApproval.kuulutusPaiva, "start-of-day");
 

--- a/backend/test/fixture/projektiFixture.ts
+++ b/backend/test/fixture/projektiFixture.ts
@@ -1154,7 +1154,7 @@ export class ProjektiFixture {
             "Nähtävilläolovaiheen tavoitteena on nykyisen ja tulevan maankäytön liittäminen luontevasti Hämeenlinnanväylään, huomioida alueen melunsuojaus, parantaa henkilöautoliikenteen ja joukkoliikenteen sujuvuutta ja turvallisuutta sekä tehdä jalankulun ja pyöräilyn yhteydet sujuviksi ja turvallisiksi. Raskaan liikenteen sujuvuuden ja matka-ajan ennustettavuuden parantaminen on myös yksi tavoitteista.",
         },
         hyvaksyja: "A123",
-        id: 2,
+        id: 1,
         ilmoituksenVastaanottajat: {
           kunnat: [
             {
@@ -1214,9 +1214,9 @@ export class ProjektiFixture {
         },
         nahtavillaoloPDFt: {
           SUOMI: {
-            nahtavillaoloIlmoitusPDFPath: "/nahtavillaolo/2/1.pdf",
-            nahtavillaoloPDFPath: "/nahtavillaolo/2/2.pdf",
-            nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath: "/nahtavillaolo/2/3.pdf",
+            nahtavillaoloIlmoitusPDFPath: "/nahtavillaolo/1/1.pdf",
+            nahtavillaoloPDFPath: "/nahtavillaolo/1/2.pdf",
+            nahtavillaoloIlmoitusKiinteistonOmistajallePDFPath: "/nahtavillaolo/1/3.pdf",
           },
         },
       },

--- a/backend/test/handler/tila/nahtavillaoloTilaManagerUudelleenkuuluta.test.ts
+++ b/backend/test/handler/tila/nahtavillaoloTilaManagerUudelleenkuuluta.test.ts
@@ -87,7 +87,7 @@ describe("nahtavillaoloTilaManager", () => {
     // Old julkaisut should not be updated and new one should be inserted with ODOTTAA_HYVAKSYNTAA.
     // If this is true, there should be only one JULKAISTU.
     expect(nahtavillaoloJulkaisuUpdateStub.callCount).to.eql(0);
-    //expect(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1].id).to.eql(3); //First julkaisu has id 2, so this should have id 3
+    expect(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1].id).to.eql(2);
     expect(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1].tila).to.eql(KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA);
     expect(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1].uudelleenKuulutus).to.eql(
       saveProjektiStub.getCall(0).args[0]?.nahtavillaoloVaihe?.uudelleenKuulutus
@@ -106,9 +106,9 @@ describe("nahtavillaoloTilaManager", () => {
     // The new julkaisu should have the same date as the original (we did not change it),
     // so it is published right away.
     // Therefore, we should set the old julkaisu status to PERUUTETTU.
-    //expect(nahtavillaoloJulkaisuUpdateStub.getCall(0).args[1].id).to.eql(2); //The first julkaisu has id 2
+    expect(nahtavillaoloJulkaisuUpdateStub.getCall(0).args[1].id).to.eql(1); //The first julkaisu has id 1
     expect(nahtavillaoloJulkaisuUpdateStub.getCall(0).args[1].tila).to.eql(KuulutusJulkaisuTila.PERUUTETTU);
-    //expect(nahtavillaoloJulkaisuUpdateStub.getCall(1).args[1].id).to.eql(3); //The second julkaisu should have id 3
+    expect(nahtavillaoloJulkaisuUpdateStub.getCall(1).args[1].id).to.eql(2); //The second julkaisu should have id 2
     expect(nahtavillaoloJulkaisuUpdateStub.getCall(1).args[1].tila).to.eql(KuulutusJulkaisuTila.HYVAKSYTTY);
     expect(nahtavillaoloJulkaisuUpdateStub.getCall(1).args[1].kuulutusPaiva).to.eql(originalKuulutusPaiva);
   });

--- a/backend/test/handler/tila/nahtavillaoloTilaManagerUudelleenkuuluta.test.ts
+++ b/backend/test/handler/tila/nahtavillaoloTilaManagerUudelleenkuuluta.test.ts
@@ -3,13 +3,18 @@
 import sinon from "sinon";
 import { ProjektiFixture } from "../../fixture/projektiFixture";
 //import { projektiDatabase } from "../../../src/database/projektiDatabase";
-import { KuulutusJulkaisuTila } from "../../../../common/graphql/apiModel";
+import { KuulutusJulkaisuTila, Projekti } from "../../../../common/graphql/apiModel";
 import { UserFixture } from "../../fixture/userFixture";
 import { userService } from "../../../src/user";
 import { nahtavillaoloTilaManager } from "../../../src/handler/tila/nahtavillaoloTilaManager";
 import MockDate from "mockdate";
-import { DBProjekti, NahtavillaoloVaiheJulkaisu } from "../../../src/database/model";
+import { DBProjekti, NahtavillaoloVaihe, NahtavillaoloVaiheJulkaisu } from "../../../src/database/model";
 import { projektiDatabase } from "../../../src/database/projektiDatabase";
+import { parameters } from "../../../src/aws/parameters";
+import { pdfGeneratorClient } from "../../../src/asiakirja/lambda/pdfGeneratorClient";
+import { fileService } from "../../../src/files/fileService";
+import { KuulutusTilaManager } from "../../../src/handler/tila/KuulutusTilaManager";
+import { TilaManager } from "../../../src/handler/tila/TilaManager";
 
 const { expect } = require("chai");
 
@@ -33,6 +38,7 @@ describe("nahtavillaoloTilaManager", () => {
 
   afterEach(() => {
     sinon.reset();
+    sinon.restore();
     userFixture.logout();
   });
 
@@ -57,5 +63,53 @@ describe("nahtavillaoloTilaManager", () => {
     sinon.stub(projektiDatabase, "saveProjekti");
     await nahtavillaoloTilaManager.uudelleenkuuluta(projekti);
     expect(nahtavillaoloJulkaisuUpdateStub.callCount).to.eql(0);
+  });
+
+  it("should leave one published kuulutus when making uudelleenkuulutus", async function () {
+    const originalKuulutusPaiva = projekti.nahtavillaoloVaihe?.kuulutusPaiva;
+    projekti = { ...projekti, nahtavillaoloVaihe: { ...(projekti.nahtavillaoloVaihe as NahtavillaoloVaihe), aineistoNahtavilla: [] } };
+    MockDate.set("2023-01-01");
+    sinon.stub(parameters, "isAsianhallintaIntegrationEnabled").returns(Promise.resolve(false));
+    sinon
+      .stub(pdfGeneratorClient, "createNahtavillaoloKuulutusPdf")
+      .returns(Promise.resolve({ __typename: "PDF", nimi: "", sisalto: "", textContent: "" }));
+    sinon.stub(fileService, "createFileToProjekti");
+    const nahtavillaoloJulkaisuUpdateStub = sinon.stub(projektiDatabase.nahtavillaoloVaiheJulkaisut, "update");
+    const nahtavillaoloJulkaisuInsertStub = sinon.stub(projektiDatabase.nahtavillaoloVaiheJulkaisut, "insert");
+    const saveProjektiStub = sinon.stub(projektiDatabase, "saveProjekti");
+    // Uudelleenkuuluta
+    await nahtavillaoloTilaManager.uudelleenkuuluta(projekti);
+    projekti = { ...projekti, ...saveProjektiStub.getCall(0).args[0] };
+    // Old should julkaisut has not been updated so there is one HYVAKSYTTY left
+    expect(nahtavillaoloJulkaisuUpdateStub.callCount).to.eql(0);
+    // Send for approval
+    await nahtavillaoloTilaManager.sendForApproval(projekti, UserFixture.hassuAdmin);
+    // Old julkaisut should not be updated and new one should be inserted with ODOTTAA_HYVAKSYNTAA.
+    // If this is true, there should be only one JULKAISTU.
+    expect(nahtavillaoloJulkaisuUpdateStub.callCount).to.eql(0);
+    //expect(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1].id).to.eql(3); //First julkaisu has id 2, so this should have id 3
+    expect(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1].tila).to.eql(KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA);
+    expect(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1].uudelleenKuulutus).to.eql(
+      saveProjektiStub.getCall(0).args[0]?.nahtavillaoloVaihe?.uudelleenKuulutus
+    );
+    projekti = {
+      ...projekti,
+      nahtavillaoloVaiheJulkaisut: projekti.nahtavillaoloVaiheJulkaisut?.concat(nahtavillaoloJulkaisuInsertStub.getCall(0).args[1]),
+    };
+
+    sinon.stub(nahtavillaoloTilaManager, "cleanupKuulutusLuonnosAfterApproval");
+    sinon.stub(nahtavillaoloTilaManager, "synchronizeProjektiFiles");
+    sinon.stub(nahtavillaoloTilaManager, "sendApprovalMailsAndAttachments");
+    sinon.stub(nahtavillaoloTilaManager, "handleAsianhallintaSynkronointi" as any);
+    sinon.stub(nahtavillaoloTilaManager, "reloadProjekti").returns(Promise.resolve(projekti));
+    await nahtavillaoloTilaManager.approve(projekti, UserFixture.hassuAdmin);
+    // The new julkaisu should have the same date as the original (we did not change it),
+    // so it is published right away.
+    // Therefore, we should set the old julkaisu status to PERUUTETTU.
+    //expect(nahtavillaoloJulkaisuUpdateStub.getCall(0).args[1].id).to.eql(2); //The first julkaisu has id 2
+    expect(nahtavillaoloJulkaisuUpdateStub.getCall(0).args[1].tila).to.eql(KuulutusJulkaisuTila.PERUUTETTU);
+    //expect(nahtavillaoloJulkaisuUpdateStub.getCall(1).args[1].id).to.eql(3); //The second julkaisu should have id 3
+    expect(nahtavillaoloJulkaisuUpdateStub.getCall(1).args[1].tila).to.eql(KuulutusJulkaisuTila.HYVAKSYTTY);
+    expect(nahtavillaoloJulkaisuUpdateStub.getCall(1).args[1].kuulutusPaiva).to.eql(originalKuulutusPaiva);
   });
 });

--- a/backend/test/handler/tila/nahtavillaoloTilaManagerUudelleenkuuluta.test.ts
+++ b/backend/test/handler/tila/nahtavillaoloTilaManagerUudelleenkuuluta.test.ts
@@ -1,0 +1,61 @@
+/* tslint:disable:only-arrow-functions */
+
+import sinon from "sinon";
+import { ProjektiFixture } from "../../fixture/projektiFixture";
+//import { projektiDatabase } from "../../../src/database/projektiDatabase";
+import { KuulutusJulkaisuTila } from "../../../../common/graphql/apiModel";
+import { UserFixture } from "../../fixture/userFixture";
+import { userService } from "../../../src/user";
+import { nahtavillaoloTilaManager } from "../../../src/handler/tila/nahtavillaoloTilaManager";
+import MockDate from "mockdate";
+import { DBProjekti, NahtavillaoloVaiheJulkaisu } from "../../../src/database/model";
+import { projektiDatabase } from "../../../src/database/projektiDatabase";
+
+const { expect } = require("chai");
+
+describe("nahtavillaoloTilaManager", () => {
+  let projekti: DBProjekti;
+  const userFixture = new UserFixture(userService);
+
+  afterEach(() => {
+    userFixture.logout();
+    sinon.reset();
+  });
+
+  after(() => {
+    sinon.restore();
+  });
+
+  beforeEach(() => {
+    projekti = new ProjektiFixture().nahtavillaoloVaihe();
+    userFixture.loginAs(UserFixture.hassuAdmin);
+  });
+
+  afterEach(() => {
+    sinon.reset();
+    userFixture.logout();
+  });
+
+  after(() => {
+    sinon.restore();
+  });
+
+  it("should set old julkaisu tila to PERUUTETTU when making uudelleenkuuluta, if old julkaisu's kuulutusPaiva has not passed", async function () {
+    MockDate.set("2020-01-01");
+    const nahtavillaoloJulkaisuUpdateStub = sinon.stub(projektiDatabase.nahtavillaoloVaiheJulkaisut, "update");
+    sinon.stub(projektiDatabase, "saveProjekti");
+    await nahtavillaoloTilaManager.uudelleenkuuluta(projekti);
+    expect(nahtavillaoloJulkaisuUpdateStub.getCall(0).args[1]).to.eql({
+      ...(projekti.nahtavillaoloVaiheJulkaisut as NahtavillaoloVaiheJulkaisu[])[0],
+      tila: KuulutusJulkaisuTila.PERUUTETTU,
+    });
+  });
+
+  it("should not set old julkaisu tila to PERUUTETTU when making uudelleenkuuluta, if old julkaisu's kuulutusPaiva has passed", async function () {
+    MockDate.set("2023-01-01");
+    const nahtavillaoloJulkaisuUpdateStub = sinon.stub(projektiDatabase.nahtavillaoloVaiheJulkaisut, "update");
+    sinon.stub(projektiDatabase, "saveProjekti");
+    await nahtavillaoloTilaManager.uudelleenkuuluta(projekti);
+    expect(nahtavillaoloJulkaisuUpdateStub.callCount).to.eql(0);
+  });
+});


### PR DESCRIPTION
Tässä PR:ssä tehdyt ominaisuudet:
* Jos avaa uudelleenkuulutuksen ja vanha kuulutus ei ole vielä tullut julkiseksi, sen julkiseksi tuleminen perutaan.
* Kuitenkin jos jokin kuulutus/uudelleenkuulutus on tullut julkiseksi kansalaiselle, sitä ei koskaan piiloteta.
* Jos hyväksytään uudelleenkuulutus, joka tulee heti julki, aiemmin julki oleva kuulutus laitetaan piiloon. (Tämä oli toteutettu jo aiemmin.)
* BE-testit näihin liittyen.

On tarkoitus, että virkamies laittaa "käsin" sähköpostin kunnille/viranomaisille, kun uudelleenkuulutus avataan, että "hei, älkää muuten julkaiskokaan sitä aiempaa kuulutusta". Tämän vuoksi s.postin lähetyshommiin ei ole mitään muutosta tässä. Automaattinen s.postiviesti kyseisessä tilanteessa on jatkokehitystiketti (ei luotu vielä).