### PR TITLE
feat: hassuyp 68 ei-julkisen projektin kansalaisnäkymä

### DIFF
--- a/backend/integrationtest/api/testUtil/util.ts
+++ b/backend/integrationtest/api/testUtil/util.ts
@@ -1,6 +1,6 @@
 import { cleanupGeneratedIds } from "./cleanUpFunctions";
 import { fileService } from "../../../src/files/fileService";
-import { AineistoInput, IlmoitettavaViranomainen, Kieli, KirjaamoOsoite, VelhoAineisto } from "../../../../common/graphql/apiModel";
+import { AineistoInput, IlmoitettavaViranomainen, Kieli, KirjaamoOsoite, Status, VelhoAineisto } from "../../../../common/graphql/apiModel";
 import { loadProjektiJulkinenFromDatabase } from "./tests";
 import { UserFixture } from "../../../test/fixture/userFixture";
 import * as sinon from "sinon";
@@ -92,6 +92,23 @@ export function adaptAineistoToInput(aineistot: VelhoAineisto[]): AineistoInput[
 export async function expectJulkinenNotFound(oid: string, userFixture: UserFixture): Promise<void> {
   userFixture.logout();
   await expect(loadProjektiJulkinenFromDatabase(oid)).to.eventually.be.rejectedWith(NotFoundError);
+  userFixture.loginAs(UserFixture.mattiMeikalainen);
+}
+
+export async function expectStatusEiJulkaistu(oid: string, userFixture: UserFixture): Promise<void> {
+  userFixture.logout();
+  const value = await loadProjektiJulkinenFromDatabase(oid);
+  expect(Object.keys(value).length).to.eql(4);
+  expect(value.__typename).to.eql("ProjektiJulkinen");
+  expect(value.status).to.eql(Status.EI_JULKAISTU);
+  expect(value.oid).to.eql(oid);
+  expect(Object.keys(value.velho || {}).length).to.eql(1);
+  // ({
+  //   __typename: "ProjektiJulkinen",
+  //   oid,
+  //   velho: { __typename: "VelhoJulkinen" },
+  //   status: Status.EI_JULKAISTU,
+  // });
   userFixture.loginAs(UserFixture.mattiMeikalainen);
 }
 

--- a/backend/integrationtest/migraatio/migration.test.ts
+++ b/backend/integrationtest/migraatio/migration.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "mocha";
 import * as sinon from "sinon";
 import { UserFixture } from "../../test/fixture/userFixture";
 import { useProjektiTestFixture } from "../api/testFixtureRecorder";
-import { defaultMocks, expectJulkinenNotFound, mockSaveProjektiToVelho } from "../api/testUtil/util";
+import { defaultMocks, expectJulkinenNotFound, expectStatusEiJulkaistu, mockSaveProjektiToVelho } from "../api/testUtil/util";
 import {
   asetaAika,
   julkaiseSuunnitteluvaihe,
@@ -66,13 +66,13 @@ describe("Migraatio", () => {
       this.skip();
     }
     const oid = await useProjektiTestFixture("migraatio_SUUNNITTELU");
-    await expectJulkinenNotFound(oid, userFixture);
+    await expectStatusEiJulkaistu(oid, userFixture);
     const projekti = await loadProjektiFromDatabase(oid, Status.EI_JULKAISTU_PROJEKTIN_HENKILOT);
     // Ylläpitäjä täyttää puuttuvat puhelinnumerot käyttöliittymän kautta
     userFixture.loginAs(UserFixture.hassuAdmin);
     await tallennaPuhelinnumerot(projekti);
     await loadProjektiFromDatabase(oid, Status.SUUNNITTELU);
-    await expectJulkinenNotFound(oid, userFixture);
+    await expectStatusEiJulkaistu(oid, userFixture);
 
     userFixture.loginAs(UserFixture.hassuAdmin);
     let p = await testSuunnitteluvaihePerustiedot(oid, 1, "Asetetaan suunnitteluvaiheen perusteidot migraation jälkeen", userFixture);
@@ -101,7 +101,7 @@ describe("Migraatio", () => {
       this.skip();
     }
     const oid = await useProjektiTestFixture("migraatio_NAHTAVILLAOLO");
-    await expectJulkinenNotFound(oid, userFixture);
+    await expectStatusEiJulkaistu(oid, userFixture);
     userFixture.loginAs(UserFixture.hassuAdmin);
     const initialProjekti = await loadProjektiFromDatabase(oid, Status.EI_JULKAISTU_PROJEKTIN_HENKILOT);
     await tallennaPuhelinnumerot(initialProjekti);

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -73,7 +73,12 @@ class ProjektiAdapterJulkinen {
     const aloitusKuulutusJulkaisu = await this.adaptAloitusKuulutusJulkaisu(dbProjekti, dbProjekti.aloitusKuulutusJulkaisut, kieli);
 
     if (!aloitusKuulutusJulkaisu) {
-      return undefined;
+      return {
+        __typename: "ProjektiJulkinen",
+        oid: dbProjekti.oid,
+        velho: { __typename: "VelhoJulkinen" },
+        status: Status.EI_JULKAISTU,
+      };
     }
 
     const projektiHenkilot: API.ProjektiKayttajaJulkinen[] = adaptProjektiHenkilot(

--- a/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
+++ b/backend/src/projekti/adapter/projektiAdapterJulkinen.ts
@@ -131,6 +131,13 @@ class ProjektiAdapterJulkinen {
     applyProjektiJulkinenStatus(projektiJulkinen);
     if (!projektiJulkinen.status || this.isStatusPublic(projektiJulkinen.status)) {
       return projektiJulkinen;
+    } else if (projektiJulkinen.status === Status.EI_JULKAISTU) {
+      return {
+        __typename: "ProjektiJulkinen",
+        oid: dbProjekti.oid,
+        velho: { __typename: "VelhoJulkinen" },
+        status: projektiJulkinen.status,
+      };
     }
   }
 

--- a/backend/src/projekti/projektiHandlerJulkinen.ts
+++ b/backend/src/projekti/projektiHandlerJulkinen.ts
@@ -1,7 +1,6 @@
 import { projektiDatabase } from "../database/projektiDatabase";
 import * as API from "../../../common/graphql/apiModel";
 import { LataaProjektiJulkinenQueryVariables } from "../../../common/graphql/apiModel";
-import { log } from "../logger";
 import { NotFoundError } from "../error/NotFoundError";
 import { projektiAdapterJulkinen } from "./adapter/projektiAdapterJulkinen";
 import assert from "assert";
@@ -18,8 +17,6 @@ export async function loadProjektiJulkinen(params: LataaProjektiJulkinenQueryVar
     if (adaptedProjekti) {
       return adaptedProjekti;
     }
-    log.info("Projektilla ei ole julkista sisältöä", { oid });
-    throw new NotFoundError("Projektilla ei ole julkista sisältöä: " + oid);
   }
   throw new NotFoundError("Projektia ei löydy: " + oid);
 }

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -128,7 +128,7 @@ Array [
   "Loaded projekti having both projektipaallikko and omistaja",
   Object {
     "__typename": "Projekti",
-    "julkinenStatus": undefined,
+    "julkinenStatus": "EI_JULKAISTU",
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",
@@ -224,7 +224,7 @@ Array [
   "Loaded projekti having only projektipaallikko",
   Object {
     "__typename": "Projekti",
-    "julkinenStatus": undefined,
+    "julkinenStatus": "EI_JULKAISTU",
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",
@@ -319,7 +319,7 @@ Array [
   "Loaded projekti having while adding other user back. There should be projektipaallikko and one user in the projekti now. Projektipaallikko cannot be removed, so it always stays there.",
   Object {
     "__typename": "Projekti",
-    "julkinenStatus": undefined,
+    "julkinenStatus": "EI_JULKAISTU",
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",
@@ -556,7 +556,7 @@ Array [
       "uudelleenKuulutus": undefined,
     },
     "euRahoitus": false,
-    "julkinenStatus": undefined,
+    "julkinenStatus": "EI_JULKAISTU",
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",

--- a/src/components/kansalainen/EiJulkaistuSivu.tsx
+++ b/src/components/kansalainen/EiJulkaistuSivu.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import useTranslation from "next-translate/useTranslation";
+
+function EiJulkaistuSivu() {
+  const { t } = useTranslation("common");
+
+  return (
+    <>
+      <h1>{t("projekti:ui-otsikot.ei-julkaistu")}</h1>
+      <p>{t("projekti:ei-julkaistu-selitys")}</p>
+    </>
+  );
+}
+
+export default EiJulkaistuSivu;

--- a/src/locales/fi/projekti.json
+++ b/src/locales/fi/projekti.json
@@ -100,8 +100,10 @@
       "muistutuksen_jattaminen": "Muistutuksen jättäminen",
       "yhteystiedot": "Yhteystiedot"
     },
-    "paatos_nahtavilla_oleva_aineisto": "Päätöksen liitteenä olevat aineistot"
+    "paatos_nahtavilla_oleva_aineisto": "Päätöksen liitteenä olevat aineistot",
+    "ei-julkaistu": "Sivua ei ole vielä julkaistu"
   },
+  "ei-julkaistu-selitys": "Sivua ei ole vielä julkaistu, sillä linkki palvelun julkiselle puolelle muodostetaan julkaisupäivänä.",
   "vastaava-viranomainen": {
     "ETELA_POHJANMAAN_ELY": "Etelä-Pohjanmaan ELY-keskus",
     "UUDENMAAN_ELY": "Uudenmaan ELY-keskus",

--- a/src/locales/sv/projekti.json
+++ b/src/locales/sv/projekti.json
@@ -100,8 +100,10 @@
       "muistutuksen_jattaminen": "Inlämnande av anmärkning",
       "yhteystiedot": "Kontaktuppgifter"
     },
-    "paatos_nahtavilla_oleva_aineisto": "Materialet bifogat beslutet"
+    "paatos_nahtavilla_oleva_aineisto": "Materialet bifogat beslutet",
+    "ei-julkaistu": "Sidan har ännu inte publicerats"
   },
+  "ei-julkaistu-selitys": "Sidan har ännu inte publicerats, eftersom en länk till tjänstens offentliga sida skapas på publiceringsdagen.",
   "vastaava-viranomainen": {
     "ETELA_POHJANMAAN_ELY": "NTM-centralen i Södra Österbotten",
     "UUDENMAAN_ELY": "NTM-centralen i Nyland",

--- a/src/pages/suunnitelma/[oid]/[...all].tsx
+++ b/src/pages/suunnitelma/[oid]/[...all].tsx
@@ -4,6 +4,7 @@ import log from "loglevel";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
 import { useRouter } from "next/router";
 import { getSivuTilanPerusteella } from "@components/kansalaisenEtusivu/Hakutulokset";
+import { Status } from "@services/api";
 
 function ProjektiPage() {
   const { t } = useTranslation("common");
@@ -11,6 +12,7 @@ function ProjektiPage() {
   const router = useRouter();
 
   useEffect(() => {
+    if (projekti && projekti.status === Status.EI_JULKAISTU) router.push(`/suunnitelma/${projekti?.oid}`);
     if (projekti) router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
   }, [projekti, router]);
 

--- a/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
+++ b/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import { useProjektiJulkinen } from "../../../hooks/useProjektiJulkinen";
 import useTranslation from "next-translate/useTranslation";
 import { Kieli, KuulutusJulkaisuTila, Status } from "../../../../common/graphql/apiModel";
@@ -18,7 +18,7 @@ import HassuLink from "@components/HassuLink";
 import { H3 } from "@components/Headings";
 import { TiedostoLinkkiLista } from "@components/projekti/kansalaisnakyma/TiedostoLinkkiLista";
 import { PreWrapParagraph } from "@components/PreWrapParagraph";
-import EiJulkaistuSivu from "@components/kansalainen/EiJulkaistuSivu";
+import { useRouter } from "next/router";
 
 export default function AloituskuulutusJulkinen(): ReactElement {
   const { t, lang } = useTranslation("projekti");
@@ -40,9 +40,11 @@ export default function AloituskuulutusJulkinen(): ReactElement {
     ),
   };
 
-  if (projekti?.status === Status.EI_JULKAISTU) {
-    return <EiJulkaistuSivu />;
-  }
+  const router = useRouter();
+
+  useEffect(() => {
+    if (projekti && projekti.status === Status.EI_JULKAISTU) router.push(`/suunnitelma/${projekti?.oid}`);
+  }, [projekti, router]);
 
   if (!projekti || !velho || !kuulutus || error) {
     return <>{t("common:projektin_lataamisessa_virhe")}</>;

--- a/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
+++ b/src/pages/suunnitelma/[oid]/aloituskuulutus.tsx
@@ -18,10 +18,11 @@ import HassuLink from "@components/HassuLink";
 import { H3 } from "@components/Headings";
 import { TiedostoLinkkiLista } from "@components/projekti/kansalaisnakyma/TiedostoLinkkiLista";
 import { PreWrapParagraph } from "@components/PreWrapParagraph";
+import EiJulkaistuSivu from "@components/kansalainen/EiJulkaistuSivu";
 
 export default function AloituskuulutusJulkinen(): ReactElement {
   const { t, lang } = useTranslation("projekti");
-  const { data: projekti } = useProjektiJulkinen();
+  const { data: projekti, error } = useProjektiJulkinen();
   const kuulutus = projekti?.aloitusKuulutusJulkaisu;
   const velho = kuulutus?.velho;
   const kieli = useKansalaiskieli();
@@ -39,8 +40,12 @@ export default function AloituskuulutusJulkinen(): ReactElement {
     ),
   };
 
-  if (!projekti || !velho || !kuulutus) {
-    return <></>;
+  if (projekti?.status === Status.EI_JULKAISTU) {
+    return <EiJulkaistuSivu />;
+  }
+
+  if (!projekti || !velho || !kuulutus || error) {
+    return <>{t("common:projektin_lataamisessa_virhe")}</>;
   }
 
   let sijainti = "";

--- a/src/pages/suunnitelma/[oid]/hyvaksymismenettelyssa.tsx
+++ b/src/pages/suunnitelma/[oid]/hyvaksymismenettelyssa.tsx
@@ -1,15 +1,34 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import ProjektiJulkinenPageLayout from "@components/projekti/kansalaisnakyma/ProjektiJulkinenPageLayout";
 import useTranslation from "next-translate/useTranslation";
 import EuLogo from "@components/projekti/common/EuLogo";
 import { useProjektiJulkinen } from "../../../hooks/useProjektiJulkinen";
 import useKansalaiskieli from "src/hooks/useKansalaiskieli";
 import { Kieli, Status } from "@services/api";
+import { useRouter } from "next/router";
+import { getSivuTilanPerusteella } from "@components/kansalaisenEtusivu/Hakutulokset";
 
 export default function Hyvaksymismenettelyssa(): ReactElement {
   const { t } = useTranslation("hyvaksymismenettelyssa");
-  const { data: projekti } = useProjektiJulkinen();
+  const { data: projekti, error } = useProjektiJulkinen();
   const kieli = useKansalaiskieli();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (projekti && projekti.status === Status.EI_JULKAISTU) router.push(`/suunnitelma/${projekti?.oid}`);
+    if (
+      projekti &&
+      projekti.status &&
+      Object.keys(Status).indexOf(projekti.status) < Object.keys(Status).indexOf(Status.HYVAKSYMISMENETTELYSSA_AINEISTOT)
+    ) {
+      router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti.status)}`);
+    }
+  }, [projekti, router]);
+
+  if (error || !projekti) {
+    return <>{t("common:projektin_lataamisessa_virhe")}</>;
+  }
+
   return (
     <ProjektiJulkinenPageLayout
       selectedStep={Status.HYVAKSYMISMENETTELYSSA}

--- a/src/pages/suunnitelma/[oid]/hyvaksymispaatos.tsx
+++ b/src/pages/suunnitelma/[oid]/hyvaksymispaatos.tsx
@@ -1,13 +1,16 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
 import HyvaksymispaatosTiedot from "@components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot";
 import PaatosPageLayout from "@components/projekti/kansalaisnakyma/PaatosPageLayout";
 import useTranslation from "next-translate/useTranslation";
 import SaameContent from "@components/projekti/kansalaisnakyma/SaameContent";
+import { Status } from "@services/api";
+import { useRouter } from "next/router";
+import { getSivuTilanPerusteella } from "@components/kansalaisenEtusivu/Hakutulokset";
 
 export default function Hyvaksymispaatos(): ReactElement {
   const { t } = useTranslation("projekti");
-  const { data: projekti } = useProjektiJulkinen();
+  const { data: projekti, error } = useProjektiJulkinen();
   const kuulutus = projekti?.hyvaksymisPaatosVaihe;
   const SAAME_CONTENT_TEXTS = {
     otsikko: "Gulahus plánema dohkkeheamis",
@@ -15,8 +18,17 @@ export default function Hyvaksymispaatos(): ReactElement {
       "Mearrádussii sáhttá ohcat váidimiin nuppástusa Lappi hálddahusrievttis 30 beaivvi siste mearrádusa diehtunoažžumis. Nuppástusohcama dárkilut rávvagat leat mearrádusa mildosis lean váidinčujuhusas.",
   };
 
-  if (!projekti || !kuulutus) {
-    return <></>;
+  const router = useRouter();
+
+  useEffect(() => {
+    if (projekti && projekti.status === Status.EI_JULKAISTU) router.push(`/suunnitelma/${projekti?.oid}`);
+    if (projekti && !projekti.hyvaksymisPaatosVaihe) {
+      router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
+    }
+  }, [projekti, router]);
+
+  if (!projekti || !kuulutus || error) {
+    return <>{t("common:projektin_lataamisessa_virhe")}</>;
   }
 
   return (

--- a/src/pages/suunnitelma/[oid]/index.tsx
+++ b/src/pages/suunnitelma/[oid]/index.tsx
@@ -5,6 +5,7 @@ import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
 import { useRouter } from "next/router";
 import { getSivuTilanPerusteella } from "@components/kansalaisenEtusivu/Hakutulokset";
 import { Status } from "@services/api";
+import EiJulkaistuSivu from "@components/kansalainen/EiJulkaistuSivu";
 
 function ProjektiPage() {
   const { t } = useTranslation("common");
@@ -30,12 +31,7 @@ function ProjektiPage() {
   }
 
   if (projekti.status === Status.EI_JULKAISTU) {
-    return (
-      <>
-        <h1>Sivua ei ole vielä julkaistu</h1>
-        <p>Sivua ei ole vielä julkaistu, sillä linkki palvelun julkiselle puolelle muodostetaan julkaisupäivänä.</p>
-      </>
-    );
+    return <EiJulkaistuSivu />;
   }
 
   return (

--- a/src/pages/suunnitelma/[oid]/index.tsx
+++ b/src/pages/suunnitelma/[oid]/index.tsx
@@ -4,6 +4,7 @@ import log from "loglevel";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
 import { useRouter } from "next/router";
 import { getSivuTilanPerusteella } from "@components/kansalaisenEtusivu/Hakutulokset";
+import { Status } from "@services/api";
 
 function ProjektiPage() {
   const { t } = useTranslation("common");
@@ -11,7 +12,8 @@ function ProjektiPage() {
   const router = useRouter();
 
   useEffect(() => {
-    if (projekti) router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
+    if (projekti && projekti.status !== Status.EI_JULKAISTU)
+      router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
   }, [projekti, router]);
 
   if (error) {
@@ -23,6 +25,15 @@ function ProjektiPage() {
     return (
       <>
         <p>{t("siirrytaan-aktiiviseen-vaiheeseen")}</p>
+      </>
+    );
+  }
+
+  if (projekti.status === Status.EI_JULKAISTU) {
+    return (
+      <>
+        <h1>Sivua ei ole vielä julkaistu</h1>
+        <p>Sivua ei ole vielä julkaistu, sillä linkki palvelun julkiselle puolelle muodostetaan julkaisupäivänä.</p>
       </>
     );
   }

--- a/src/pages/suunnitelma/[oid]/jatkopaatos1.tsx
+++ b/src/pages/suunnitelma/[oid]/jatkopaatos1.tsx
@@ -1,13 +1,16 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect } from "react";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
 import HyvaksymispaatosTiedot from "@components/projekti/kansalaisnakyma/HyvaksymispaatosTiedot";
 import PaatosPageLayout from "@components/projekti/kansalaisnakyma/PaatosPageLayout";
 import useTranslation from "next-translate/useTranslation";
 import SaameContent from "@components/projekti/kansalaisnakyma/SaameContent";
+import { Status } from "@services/api";
+import { useRouter } from "next/router";
+import { getSivuTilanPerusteella } from "@components/kansalaisenEtusivu/Hakutulokset";
 
 export default function Hyvaksymispaatos(): ReactElement {
   const { t } = useTranslation("projekti");
-  const { data: projekti } = useProjektiJulkinen();
+  const { data: projekti, error } = useProjektiJulkinen();
   const kuulutus = projekti?.hyvaksymisPaatosVaihe;
   const SAAME_CONTENT_TEXTS = {
     otsikko: "Gulahus dohkkehanmearrádusa joatkimis",
@@ -15,8 +18,17 @@ export default function Hyvaksymispaatos(): ReactElement {
       "Mearrádussii sáhttá ohcat váidimiin nuppástusa Lappi hálddahusrievttis 30 beaivvi siste mearrádusa diehtunoažžumis. Nuppástusohcama dárkilut rávvagat leat mearrádusa mildosis lean váidinčujuhusas.",
   };
 
-  if (!projekti || !kuulutus) {
-    return <></>;
+  const router = useRouter();
+
+  useEffect(() => {
+    if (projekti && projekti.status === Status.EI_JULKAISTU) router.push(`/suunnitelma/${projekti?.oid}`);
+    if (projekti && !projekti.jatkoPaatos1Vaihe) {
+      router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
+    }
+  }, [projekti, router]);
+
+  if (!projekti || !kuulutus || error) {
+    return <>{t("common:projektin_lataamisessa_virhe")}</>;
   }
 
   return (

--- a/src/pages/suunnitelma/[oid]/nahtavillaolo.tsx
+++ b/src/pages/suunnitelma/[oid]/nahtavillaolo.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 import ProjektiJulkinenPageLayout from "@components/projekti/kansalaisnakyma/ProjektiJulkinenPageLayout";
 import Section from "@components/layout/Section2";
 import KeyValueTable, { KeyValueData } from "@components/KeyValueTable";
@@ -26,13 +26,17 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 export default function Nahtavillaolo(): ReactElement {
   const { t, lang } = useTranslation("projekti");
-  const { data: projekti } = useProjektiJulkinen();
+  const { data: projekti, error } = useProjektiJulkinen();
   const kuulutus = projekti?.nahtavillaoloVaihe;
   const router = useRouter();
 
-  if (projekti && !kuulutus) {
-    router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
-  }
+  useEffect(() => {
+    if (projekti && projekti.status === Status.EI_JULKAISTU) router.push(`/suunnitelma/${projekti?.oid}`);
+    if (projekti && !projekti.nahtavillaoloVaihe) {
+      router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
+    }
+  }, [projekti, router]);
+
   const SAAME_CONTENT_TEXTS = {
     otsikko: "Gulahus plána oaidninláhkai bidjamis",
     kappale1:
@@ -47,6 +51,10 @@ export default function Nahtavillaolo(): ReactElement {
 
   if (!projekti || !kuulutus || !velho) {
     return <></>;
+  }
+
+  if (error || !projekti) {
+    return <>{t("common:projektin_lataamisessa_virhe")}</>;
   }
 
   let sijainti = "";

--- a/src/pages/suunnitelma/[oid]/suunnittelu.tsx
+++ b/src/pages/suunnitelma/[oid]/suunnittelu.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, ReactElement, useCallback, useMemo, useState } from "react";
+import React, { FunctionComponent, ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import ProjektiJulkinenPageLayout from "@components/projekti/kansalaisnakyma/ProjektiJulkinenPageLayout";
 import Section from "@components/layout/Section2";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
@@ -43,10 +43,12 @@ import { H3, H4, H5 } from "@components/Headings";
 import { AineistoLinkkiLista } from "@components/projekti/kansalaisnakyma/AineistoLinkkiLista";
 import { TiedostoLinkkiLista } from "@components/projekti/kansalaisnakyma/TiedostoLinkkiLista";
 import { PreWrapParagraph } from "@components/PreWrapParagraph";
+import { useRouter } from "next/router";
+import { getSivuTilanPerusteella } from "@components/kansalaisenEtusivu/Hakutulokset";
 
 export default function Suunnittelu(): ReactElement {
   const { t } = useTranslation("suunnittelu");
-  const { data: projekti } = useProjektiJulkinen();
+  const { data: projekti, error } = useProjektiJulkinen();
   const SAAME_CONTENT_TEXTS = {
     otsikko: "Bovdehus vuorrováikkuhussii",
     kappale1:
@@ -55,9 +57,17 @@ export default function Suunnittelu(): ReactElement {
 
   const migroitu = projekti?.vuorovaikutukset?.tila == VuorovaikutusKierrosTila.MIGROITU;
   const kieli = useKansalaiskieli();
+  const router = useRouter();
 
-  if (!(projekti?.vuorovaikutukset && projekti.velho)) {
-    return <></>;
+  useEffect(() => {
+    if (projekti && projekti.status === Status.EI_JULKAISTU) router.push(`/suunnitelma/${projekti?.oid}`);
+    if (projekti && !projekti.vuorovaikutukset) {
+      router.push(`/suunnitelma/${projekti?.oid}/${getSivuTilanPerusteella(projekti?.status)}`);
+    }
+  }, [projekti, router]);
+
+  if (!(projekti?.vuorovaikutukset && projekti.velho) || error) {
+    return <>{t("common:projektin_lataamisessa_virhe")}</>;
   }
 
   return (


### PR DESCRIPTION
Tiketin haluttu toiminnallisuus oli, että jos kunnan virkamies (tai joku muu vastaava kansalaistaho) saa jotenkin käsiinsä linkin projektin julkisen puolen sivulle, hän näkee siellä ilmoituksen, että projektin sivua ei ole vielä julkaistu, sen sijaan että näkisi virheviestin. Tällainen tilanne voi sattua, jos projekti on julkaistu, ja pdf:ään on generoitu linkki projektin julkiselle sivulle. Henkilöt, joille kuulutus lähtee s.postilla, pääsevät käsiksi linkkiin ennen kuin sivu on julkinen.
Tilanne voi sattua kaikissa projektin vaiheissa, koska migroitujen projektien tapauksessa projekti tulee näkyville julkiselle puolelle vasta kun ensimmäinen kuulutus/kutsu on julki Hassussa. Toisin sanottuna kaikille julkisen projektin alasivuilla tulee näkyä tilanteen vaatiessa tieto siitä, että projekti ei ole vielä julki.

Toteutin samassa muita parannuksia julkiselle puolelle: jos käyttäjä yrittää navigoida julkisen projektin alasivulle, joka ei ole vielä valmis (projekti ei ole vielä niin pitkällä), tämä uudelleenohjataan projektin aktiivisen vaiheen sivulle.

Otin huomioon myös tilanteet, joissa projekti on epäaktiivinen. Tällöin näytetään UI:ssa virhe ihan niin kuin projektia ei olisi olemassa.

Teknisesti toteutin tämän siten, että jos ei-julkista projektia hakee BE:stä, saa takaisin dummy-projektin, jonka tila on EI_JULKINEN. Tämän olisi voinut tehdä sitenkin, että laitetaan custom-virhe fronttiin, mutta oli yksinkertaisempi näin...