### PR TITLE
feat: hätäkorjaus kielilukitukseen

### DIFF
--- a/backend/test/projekti/status/projektiStatusHandler.test.ts
+++ b/backend/test/projekti/status/projektiStatusHandler.test.ts
@@ -19,6 +19,10 @@ describe("applyProjektiStatus", () => {
         __typename: "AloitusKuulutus",
         muokkausTila: API.MuokkausTila.LUKU,
       },
+      kielitiedot: {
+        __typename: "Kielitiedot",
+        ensisijainenKieli: API.Kieli.SUOMI,
+      },
       aloitusKuulutusJulkaisu: {
         __typename: "AloitusKuulutusJulkaisu",
         yhteystiedot: [],
@@ -39,6 +43,10 @@ describe("applyProjektiStatus", () => {
         __typename: "Velho",
         asiatunnusVayla: "123",
         asiatunnusELY: "123",
+      },
+      kielitiedot: {
+        __typename: "Kielitiedot",
+        ensisijainenKieli: API.Kieli.SUOMI,
       },
       vahainenMenettely: true,
       euRahoitus: false,

--- a/common/util/typeCheckers.ts
+++ b/common/util/typeCheckers.ts
@@ -2,8 +2,8 @@ import { DBProjekti } from "../../backend/src/database/model";
 import { Projekti } from "../graphql/apiModel";
 
 export function isProjektiDBProjekti(projekti: DBProjekti | Projekti): projekti is DBProjekti {
-  return !!(projekti as DBProjekti).aloitusKuulutusJulkaisut; // Does not actually tell if projekti is DBProjekti, but is enough for our use case
+  return !(projekti as Projekti).__typename; // Does not actually tell if projekti is DBProjekti, but is enough for our use case
 }
 export function isProjektiAPIProjekti(projekti: DBProjekti | Projekti): projekti is Projekti {
-  return !!(projekti as Projekti).aloitusKuulutusJulkaisu; // Does not actually tell if projekti is Projekti, but is enough for our use case
+  return !!(projekti as Projekti).__typename; // Does not actually tell if projekti is Projekti, but is enough for our use case
 }

--- a/src/schemas/perustiedot.ts
+++ b/src/schemas/perustiedot.ts
@@ -28,8 +28,7 @@ export const perustiedotValidationSchema = Yup.object()
             then: (schema) => schema.required("Projektin nimi on pakollinen"),
           }),
       })
-      .notRequired()
-      .nullable()
+      .required()
       .default(null),
     liittyvatSuunnitelmat: Yup.array()
       .of(


### PR DESCRIPTION
Sen jälkeen kun kielivalinnan lukitus toteutettiin, tulikin mahdottomaksi edetä projektin perustamisessa: kielivalinnan muuttaminen meni lukkoon, koska kun frontissa testattiin, voiko kielivalintaa muuttaa, syötettiin projektin tiedot funktiolle, joka arvioi projektin tyypin väärin (luuli db-projektiksi) ja sitten tutki vääriä asioita.

Lisäksi BE:ssä projektin status arvioitiin väärin, koska BE käyttää arvioimiseen perustiedotValidationSchemaa, ja katsoo, onko projektilla riittävät perustiedot. Jos ei, niin status on EI_JULKAISTU. Skeemassa oli kuitenkin virhe, eikä se vaatinut kielitietoja pakolliseksi. Ne on nyt laitettu pakolliseksi. Nyt vasta perustetun projektin status tulee oikein.