### PR TITLE
fix: HASSUYP-157 Korjaa Suunnittelusopimustiedon (ja muiden lukituksen alaisten tietojen) muuttamisvalidointilogiikkaa

### DIFF
--- a/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptAloitusKuulutus.ts
@@ -51,6 +51,7 @@ export function adaptAloitusKuulutusJulkaisu(
   const julkaisu =
     findJulkaisuWithTila(aloitusKuulutusJulkaisut, KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA) ||
     findJulkaisuWithTila(aloitusKuulutusJulkaisut, KuulutusJulkaisuTila.HYVAKSYTTY) ||
+    findJulkaisuWithTila(aloitusKuulutusJulkaisut, KuulutusJulkaisuTila.PERUUTETTU) ||
     findJulkaisuWithTila(aloitusKuulutusJulkaisut, KuulutusJulkaisuTila.MIGROITU);
   if (!julkaisu) {
     return undefined;

--- a/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptHyvaksymisPaatosVaihe.ts
@@ -70,6 +70,7 @@ export function adaptHyvaksymisPaatosVaiheJulkaisu(
   const julkaisu =
     findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA) ||
     findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.HYVAKSYTTY) ||
+    findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.PERUUTETTU) ||
     findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.MIGROITU);
 
   if (!julkaisu) {

--- a/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/adaptNahtavillaoloVaihe.ts
@@ -66,6 +66,7 @@ export function adaptNahtavillaoloVaiheJulkaisu(
   const julkaisu =
     findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA) ||
     findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.HYVAKSYTTY) ||
+    findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.PERUUTETTU) ||
     findJulkaisuWithTila(julkaisut, API.KuulutusJulkaisuTila.MIGROITU);
 
   if (julkaisu) {

--- a/backend/src/projekti/validator/projektiValidator.ts
+++ b/backend/src/projekti/validator/projektiValidator.ts
@@ -135,7 +135,7 @@ function validateSuunnitteluSopimus(dbProjekti: DBProjekti, projekti: Projekti, 
 
   if (isSuunnitteluSopimusAddedOrDeleted && !allowedToChangeSuunnittelusopimus) {
     throw new IllegalArgumentError(
-      "Suunnittelusopimuksen olemassaoloa ei voi muuttaa, jos ensimmäinen HASSUssa tehty vaihe ei ole muokkaustilassa, tai jos ensimmäinen vaihe on suunnittelu, yhtäkään kutsua ei ole tehty."
+      "Suunnittelusopimuksen olemassaoloa ei voi muuttaa, jos ensimmäinen HASSUssa tehty vaihe ei ole muokkaustilassa."
     );
   }
 }
@@ -149,7 +149,7 @@ function validateEuRahoitus(dbProjekti: DBProjekti, projekti: Projekti, input: T
 
   if (isEuSopimusAddedOrDeleted && !allowedToChangeEuSopimus) {
     throw new IllegalArgumentError(
-      "EU-rahoituksen olemassaoloa ei voi muuttaa, jos ensimmäinen HASSUssa tehty vaihe ei ole muokkaustilassa, tai jos ensimmäinen vaihe on suunnittelu, yhtäkään kutsua ei ole tehty."
+      "EU-rahoituksen olemassaoloa ei voi muuttaa, jos ensimmäinen HASSUssa tehty vaihe ei ole muokkaustilassa."
     );
   }
 }
@@ -236,7 +236,7 @@ function validateVahainenMenettely(dbProjekti: DBProjekti, projekti: Projekti, i
   const allowedToChangeVahainenMenettely = isAllowedToChangeVahainenMenettely(projekti);
   if (isVahainenMenettelyValueChanged && !allowedToChangeVahainenMenettely) {
     throw new IllegalArgumentError(
-      "Vähäisen menettelyn olemassaoloa ei voi muuttaa, jos ensimmäinen HASSUssa tehty vaihe ei ole muokkaustilassa, tai jos ensimmäinen vaihe on suunnittelu, yhtäkään kutsua ei ole tehty."
+      "Vähäisen menettelyn olemassaoloa ei voi muuttaa, jos ensimmäinen HASSUssa tehty vaihe ei ole muokkaustilassa."
     );
   }
 }

--- a/backend/test/projekti/validator/projektiValidator/euRahoitus.test.ts
+++ b/backend/test/projekti/validator/projektiValidator/euRahoitus.test.ts
@@ -193,7 +193,7 @@ describe("validateTallennaProjekti (suunnittelusopimusValidator)", () => {
     expect(validateTallennaProjekti(projekti, input)).to.eventually.be.rejectedWith(IllegalArgumentError);
   });
 
-  it("should allow euRahoitus being added if aloituskuulutus and suunnitteluvihe are migrated", async () => {
+  it("should allow euRahoitus being added if aloituskuulutus and suunnitteluvaihe are migrated", async () => {
     const projekti = fixture.dbProjektiLackingNahtavillaoloVaihe();
     delete projekti.aloitusKuulutusJulkaisut;
     delete projekti.aloitusKuulutus;
@@ -243,7 +243,7 @@ describe("validateTallennaProjekti (suunnittelusopimusValidator)", () => {
     expect(allOk).to.eql(true);
   });
 
-  it("should allow euRahoitus being added if aloituskuulutus and suunnitteluvihe are migrated, nahtavillaolo is published but there is uudelleenkuulutus open", async () => {
+  it("should allow euRahoitus being added if aloituskuulutus and suunnitteluvaihe are migrated, nahtavillaolo is published but there is uudelleenkuulutus open", async () => {
     const projekti = fixture.dbProjektiHyvaksymisMenettelyssa();
     projekti.aloitusKuulutus = {
       id: 1,
@@ -298,7 +298,7 @@ describe("validateTallennaProjekti (suunnittelusopimusValidator)", () => {
     expect(allOk).to.eql(true);
   });
 
-  it("should not allow euRahoitus being added if aloituskuulutus and suunnitteluvihe are migrated, nahtavillaolo is published and there is uudelleenkuulutus waiting to be accepted", async () => {
+  it("should not allow euRahoitus being added if aloituskuulutus and suunnitteluvaihe are migrated, nahtavillaolo is published and there is uudelleenkuulutus waiting to be accepted", async () => {
     const projekti = fixture.dbProjektiHyvaksymisMenettelyssa();
     projekti.aloitusKuulutus = {
       id: 1,

--- a/backend/test/projekti/validator/projektiValidator/kielitiedot.test.ts
+++ b/backend/test/projekti/validator/projektiValidator/kielitiedot.test.ts
@@ -38,7 +38,13 @@ describe("projektiValidator (kielitiedotValidator)", () => {
 
   it("antaa muuttaa kielitietoja projektille, jolla ei ole aloituskuulutusjulkaisua", async () => {
     userFixture.loginAs(UserFixture.pekkaProjari);
-    const { suunnitteluSopimus, nahtavillaoloVaihe, hyvaksymisPaatosVaihe, aloitusKuulutusJulkaisut, ...projekti } = fixture.dbProjekti2();
+    const {
+      suunnitteluSopimus: _s,
+      nahtavillaoloVaihe: _n,
+      hyvaksymisPaatosVaihe: _h,
+      aloitusKuulutusJulkaisut: _a,
+      ...projekti
+    } = fixture.dbProjekti2();
     const input: TallennaProjektiInput = {
       oid: projekti.oid,
       versio: projekti.versio,
@@ -52,8 +58,14 @@ describe("projektiValidator (kielitiedotValidator)", () => {
 
   it("antaa muuttaa kielitietoja projektille, jolla on migroitu aloituskuulutusjulkaisu", async () => {
     userFixture.loginAs(UserFixture.pekkaProjari);
-    const { suunnitteluSopimus, nahtavillaoloVaihe, hyvaksymisPaatosVaihe, aloitusKuulutusJulkaisut, aloitusKuulutus, ...projekti } =
-      fixture.dbProjekti2();
+    const {
+      suunnitteluSopimus: _s,
+      nahtavillaoloVaihe: _n,
+      hyvaksymisPaatosVaihe: _h,
+      aloitusKuulutusJulkaisut: _aj,
+      aloitusKuulutus: _a,
+      ...projekti
+    } = fixture.dbProjekti2();
     const testiProjekti: DBProjekti = {
       ...projekti,
       aloitusKuulutusJulkaisut: [
@@ -80,7 +92,7 @@ describe("projektiValidator (kielitiedotValidator)", () => {
 
   it("ei anna muuttaa kielitietoja projektille, jolla on julkaistu aloituskuulutus eikä muokkaustilaista uudelleenkuulutusta", async () => {
     userFixture.loginAs(UserFixture.pekkaProjari);
-    const { suunnitteluSopimus, nahtavillaoloVaihe, hyvaksymisPaatosVaihe, ...projekti } = fixture.dbProjekti2();
+    const { suunnitteluSopimus: _s, nahtavillaoloVaihe: _n, hyvaksymisPaatosVaihe: _h, ...projekti } = fixture.dbProjekti2();
     const input: TallennaProjektiInput = {
       oid: projekti.oid,
       versio: projekti.versio,
@@ -94,7 +106,7 @@ describe("projektiValidator (kielitiedotValidator)", () => {
 
   it("antaa muuttaa kielitietoja projektille, jos sillä on avattu aloituskuulutuksen uudelleenkuulutus", async () => {
     userFixture.loginAs(UserFixture.pekkaProjari);
-    const { suunnitteluSopimus, nahtavillaoloVaihe, hyvaksymisPaatosVaihe, ...projekti } = fixture.dbProjekti2();
+    const { suunnitteluSopimus: _s, nahtavillaoloVaihe: _n, hyvaksymisPaatosVaihe: _h, ...projekti } = fixture.dbProjekti2();
     const input: TallennaProjektiInput = {
       oid: projekti.oid,
       versio: projekti.versio,
@@ -116,7 +128,7 @@ describe("projektiValidator (kielitiedotValidator)", () => {
 
   it("ei anna muuttaa kielitietoja projektille, jos sillä on avattu aloituskuulutuksen uudelleenkuulutus ja se on hyväksytty", async () => {
     userFixture.loginAs(UserFixture.pekkaProjari);
-    const { suunnitteluSopimus, nahtavillaoloVaihe, hyvaksymisPaatosVaihe, ...projekti } = fixture.dbProjekti2();
+    const { suunnitteluSopimus: _s, nahtavillaoloVaihe: _n, hyvaksymisPaatosVaihe: _h, ...projekti } = fixture.dbProjekti2();
     const input: TallennaProjektiInput = {
       oid: projekti.oid,
       versio: projekti.versio,
@@ -152,7 +164,7 @@ describe("projektiValidator (kielitiedotValidator)", () => {
 
   it("antaa muuttaa kielitietoja projektille, jos sillä on muokattavaksi palautettu aloituskuulutuksen uudelleenkuulutus", async () => {
     userFixture.loginAs(UserFixture.pekkaProjari);
-    const { suunnitteluSopimus, nahtavillaoloVaihe, hyvaksymisPaatosVaihe, ...projekti } = fixture.dbProjekti2();
+    const { suunnitteluSopimus: _s, nahtavillaoloVaihe: _n, hyvaksymisPaatosVaihe: _h, ...projekti } = fixture.dbProjekti2();
     const input: TallennaProjektiInput = {
       oid: projekti.oid,
       versio: projekti.versio,
@@ -246,7 +258,7 @@ describe("projektiValidator (kielitiedotValidator)", () => {
     expect(validateTallennaProjekti(projekti, input)).to.eventually.be.rejectedWith(IllegalArgumentError);
   });
 
-  it("should allow kielitiedot being changed if aloituskuulutus and suunnitteluvihe are migrated", async () => {
+  it("should allow kielitiedot being changed if aloituskuulutus and suunnitteluvaihe are migrated", async () => {
     userFixture.loginAs(UserFixture.pekkaProjari);
     const projekti = fixture.dbProjektiLackingNahtavillaoloVaihe();
     delete projekti.suunnitteluSopimus;

--- a/backend/test/projekti/validator/projektiValidator/suunnitteluSopimus.ts
+++ b/backend/test/projekti/validator/projektiValidator/suunnitteluSopimus.ts
@@ -8,13 +8,7 @@ import { Kayttajas } from "../../../../src/personSearch/kayttajas";
 import { validateTallennaProjekti } from "../../../../src/projekti/validator/projektiValidator";
 import { UserFixture } from "../../../fixture/userFixture";
 import { userService } from "../../../../src/user";
-import {
-  Kieli,
-  KuulutusJulkaisuTila,
-  NykyinenKayttaja,
-  ProjektiTyyppi,
-  VuorovaikutusKierrosTila,
-} from "hassu-common/graphql/apiModel";
+import { Kieli, KuulutusJulkaisuTila, NykyinenKayttaja, ProjektiTyyppi, VuorovaikutusKierrosTila } from "hassu-common/graphql/apiModel";
 import { UudelleenkuulutusTila } from "../../../../src/database/model";
 
 import { expect } from "chai";
@@ -266,7 +260,7 @@ describe("validateTallennaProjekti (suunnittelusopimusValidator)", () => {
     ).to.eventually.be.rejectedWith(IllegalArgumentError);
   });
 
-  it("should allow suunnittelusopimus being added if aloituskuulutus and suunnitteluvihe are migrated", async () => {
+  it("should allow suunnittelusopimus being added if aloituskuulutus and suunnitteluvaihe are migrated", async () => {
     const projekti = fixture.dbProjektiLackingNahtavillaoloVaihe();
     delete projekti.suunnitteluSopimus;
     delete projekti.aloitusKuulutusJulkaisut;
@@ -320,7 +314,7 @@ describe("validateTallennaProjekti (suunnittelusopimusValidator)", () => {
     expect(allOk).to.eql(true);
   });
 
-  it("should allow suunnittelusopimus being added if aloituskuulutus and suunnitteluvihe are migrated, nahtavillaolo is published but there is uudelleenkuulutus open", async () => {
+  it("should allow suunnittelusopimus being added if aloituskuulutus and suunnitteluvaihe are migrated, nahtavillaolo is published but there is uudelleenkuulutus open", async () => {
     const projekti = fixture.dbProjektiHyvaksymisMenettelyssa();
     delete projekti.suunnitteluSopimus;
     projekti.aloitusKuulutus = {
@@ -378,7 +372,7 @@ describe("validateTallennaProjekti (suunnittelusopimusValidator)", () => {
     expect(allOk).to.eql(true);
   });
 
-  it("should not allow suunnittelusopimus being added if aloituskuulutus and suunnitteluvihe are migrated, nahtavillaolo is published and there is uudelleenkuulutus waiting to be accepted", async () => {
+  it("should not allow suunnittelusopimus being added if aloituskuulutus and suunnitteluvaihe are migrated, nahtavillaolo is published and there is uudelleenkuulutus waiting to be accepted", async () => {
     const projekti = fixture.dbProjektiHyvaksymisMenettelyssa();
     delete projekti.suunnitteluSopimus;
     projekti.aloitusKuulutus = {

--- a/common/util/operationValidators.ts
+++ b/common/util/operationValidators.ts
@@ -1,6 +1,6 @@
 import { DBProjekti } from "../../backend/src/database/model";
-import { KuulutusJulkaisuTila, TilasiirtymaTyyppi, Projekti, MuokkausTila, VuorovaikutusKierrosTila } from "../graphql/apiModel";
-import { isProjektiAPIProjekti, isProjektiDBProjekti } from "./typeCheckers";
+import { KuulutusJulkaisuTila, MuokkausTila, Projekti, Status, TilasiirtymaTyyppi, VuorovaikutusKierrosTila } from "../graphql/apiModel";
+import { statusOrder } from "../statusOrder";
 
 export function isAllowedToMoveBack(tilasiirtymatyyppi: TilasiirtymaTyyppi, projekti: DBProjekti | Projekti): boolean {
   if (tilasiirtymatyyppi === TilasiirtymaTyyppi.NAHTAVILLAOLO) {
@@ -40,141 +40,100 @@ export function isAllowedToMoveBackToSuunnitteluvaihe(projekti: DBProjekti | Pro
   return true;
 }
 
-export function noJulkaisuOrKutsuIsInReadState({
-  aloitusKuulutusMuokkausTila,
-  vuorovaikutusKierrosTila,
-  nahtavillaoloVaiheMuokkausTila,
-  hyvaksymisVaiheMuokkausTila,
-  jatkoPaatos1VaiheMuokkausTila,
-  jatkoPaatos2VaiheMuokkausTila,
-}: {
-  aloitusKuulutusMuokkausTila: MuokkausTila | undefined | null;
-  vuorovaikutusKierrosTila: VuorovaikutusKierrosTila | undefined | null;
-  nahtavillaoloVaiheMuokkausTila: MuokkausTila | undefined | null;
-  hyvaksymisVaiheMuokkausTila: MuokkausTila | undefined | null;
-  jatkoPaatos1VaiheMuokkausTila: MuokkausTila | undefined | null;
-  jatkoPaatos2VaiheMuokkausTila: MuokkausTila | undefined | null;
-}): boolean {
-  if (!aloitusKuulutusMuokkausTila) {
-    return true;
-  }
-  if (aloitusKuulutusMuokkausTila === MuokkausTila.LUKU) {
-    return false;
-  }
-  if (aloitusKuulutusMuokkausTila === MuokkausTila.MUOKKAUS) {
-    return true;
-  }
-  // aloitusKuulutusMuokkausTila === MuokkausTila.MIGROITU
-  if (!vuorovaikutusKierrosTila) {
-    return true;
-  }
-  if (vuorovaikutusKierrosTila !== VuorovaikutusKierrosTila.MIGROITU) {
-    return false;
-  }
-  // vuorovaikutusKierrosTila === VuorovaikutusKierrosTila.MIGROITU
-  if (!nahtavillaoloVaiheMuokkausTila) {
-    return true;
-  }
-  if (nahtavillaoloVaiheMuokkausTila === MuokkausTila.MUOKKAUS) {
-    return true;
-  }
-  if (nahtavillaoloVaiheMuokkausTila === MuokkausTila.LUKU) {
-    return false;
-  }
-  if (!hyvaksymisVaiheMuokkausTila) {
-    return true;
-  }
-  if (hyvaksymisVaiheMuokkausTila === MuokkausTila.MUOKKAUS) {
-    return true;
-  }
-  if (hyvaksymisVaiheMuokkausTila === MuokkausTila.LUKU) {
-    return false;
-  }
-  // hyvaksymisVaiheMuokkausTila === MuokkausTila.MIGROITU
-  if (!jatkoPaatos1VaiheMuokkausTila) {
-    return true;
-  }
-  if (jatkoPaatos1VaiheMuokkausTila === MuokkausTila.MUOKKAUS) {
-    return true;
-  }
-  if (jatkoPaatos1VaiheMuokkausTila === MuokkausTila.LUKU) {
-    return false;
-  }
-  // jatkoPaatos1VaiheMuokkausTila === MuokkausTila.MIGROITU
-  if (!jatkoPaatos2VaiheMuokkausTila) {
-    return true;
-  }
-  if (jatkoPaatos2VaiheMuokkausTila === MuokkausTila.MUOKKAUS) {
-    return true;
-  }
-  if (jatkoPaatos2VaiheMuokkausTila === MuokkausTila.LUKU) {
-    return false;
-  }
-  return false;
+type JulkaisuStatus =
+  | Status.ALOITUSKUULUTUS
+  | Status.SUUNNITTELU
+  | Status.NAHTAVILLAOLO
+  | Status.HYVAKSYTTY
+  | Status.JATKOPAATOS_1
+  | Status.JATKOPAATOS_2;
+
+type JulkaisuAvain = keyof Pick<
+  Projekti,
+  | "aloitusKuulutusJulkaisu"
+  | "vuorovaikutusKierrosJulkaisut"
+  | "nahtavillaoloVaiheJulkaisu"
+  | "hyvaksymisPaatosVaiheJulkaisu"
+  | "jatkoPaatos1VaiheJulkaisu"
+  | "jatkoPaatos2VaiheJulkaisu"
+>;
+
+type VaiheAvain = keyof Pick<
+  Projekti,
+  "aloitusKuulutus" | "vuorovaikutusKierros" | "nahtavillaoloVaihe" | "hyvaksymisPaatosVaihe" | "jatkoPaatos1Vaihe" | "jatkoPaatos2Vaihe"
+>;
+
+type Julkaisu = Projekti[JulkaisuAvain];
+type Vaihe = Projekti[VaiheAvain];
+
+type TilakohtaisetVaiheet = Record<JulkaisuStatus, { julkaisu: Julkaisu; vaihe: Vaihe }>;
+
+function isJulkaisuUserCreated(julkaisu: Julkaisu): julkaisu is NonNullable<Julkaisu> {
+  return Array.isArray(julkaisu)
+    ? julkaisu.some((kierrosJulkaisu) => !!kierrosJulkaisu?.tila && kierrosJulkaisu.tila !== VuorovaikutusKierrosTila.MIGROITU)
+    : !!julkaisu && julkaisu.tila !== KuulutusJulkaisuTila.MIGROITU;
 }
 
-function noJulkaisuOrKutsuIsInReadStateProjekti(projekti: Projekti) {
-  return noJulkaisuOrKutsuIsInReadState({
-    aloitusKuulutusMuokkausTila: projekti.aloitusKuulutus?.muokkausTila,
-    vuorovaikutusKierrosTila: projekti.vuorovaikutusKierros?.tila,
-    nahtavillaoloVaiheMuokkausTila: projekti.nahtavillaoloVaihe?.muokkausTila,
-    hyvaksymisVaiheMuokkausTila: projekti.hyvaksymisPaatosVaihe?.muokkausTila,
-    jatkoPaatos1VaiheMuokkausTila: projekti.jatkoPaatos1Vaihe?.muokkausTila,
-    jatkoPaatos2VaiheMuokkausTila: projekti.jatkoPaatos2Vaihe?.muokkausTila,
-  });
-}
+const isVaiheMuokkaustilassa = (vaihe: Vaihe) =>
+  !vaihe ||
+  (vaihe.__typename === "VuorovaikutusKierros"
+    ? vaihe.tila === VuorovaikutusKierrosTila.MUOKATTAVISSA
+    : vaihe.muokkausTila === MuokkausTila.MUOKKAUS);
 
-function thereAreNoVuorovaikutusKierrosJulkaisutThatAreNotMigroitu(projekti: Projekti) {
-  return (
-    !projekti.vuorovaikutusKierrosJulkaisut ||
-    !projekti.vuorovaikutusKierrosJulkaisut.length ||
-    (projekti.vuorovaikutusKierrosJulkaisut.length === 1 &&
-      projekti.vuorovaikutusKierrosJulkaisut[0].tila === VuorovaikutusKierrosTila.MIGROITU)
-  );
+type AdditionalValidation = (tila: JulkaisuStatus, julkaisu: Julkaisu, vaihe: Vaihe) => boolean;
+
+function noUserCreatedJulkaisuPreventingChange(projekti: Projekti, additionalVaiheChecks?: AdditionalValidation): boolean {
+  const tilakohtaisetVaiheet: TilakohtaisetVaiheet = {
+    ALOITUSKUULUTUS: { julkaisu: projekti.aloitusKuulutusJulkaisu, vaihe: projekti.aloitusKuulutus },
+    SUUNNITTELU: { julkaisu: projekti.vuorovaikutusKierrosJulkaisut, vaihe: projekti.vuorovaikutusKierros },
+    NAHTAVILLAOLO: { julkaisu: projekti.nahtavillaoloVaiheJulkaisu, vaihe: projekti.nahtavillaoloVaihe },
+    HYVAKSYTTY: { julkaisu: projekti.hyvaksymisPaatosVaiheJulkaisu, vaihe: projekti.hyvaksymisPaatosVaihe },
+    JATKOPAATOS_1: { julkaisu: projekti.jatkoPaatos1VaiheJulkaisu, vaihe: projekti.jatkoPaatos1Vaihe },
+    JATKOPAATOS_2: { julkaisu: projekti.jatkoPaatos2VaiheJulkaisu, vaihe: projekti.jatkoPaatos2Vaihe },
+  };
+
+  const noJulkaisuPreventingChange = !Object.entries(tilakohtaisetVaiheet)
+    // Jos julkaisua ei ole tai se on migratoitu, vaihe on OK
+    .filter(([_, { julkaisu }]) => isJulkaisuUserCreated(julkaisu))
+    // Tarkastetaan salliiko vaiheen ja julkaisun tiedot
+    .some(([tilaString, { julkaisu, vaihe }]) => {
+      const tila = tilaString as JulkaisuStatus;
+      const statusNro = statusOrder[tila];
+
+      // Haetaan julkaisut, jotka on järjestyksessä ennen kyseistä vaihetta
+      const aiemmatJulkaisut = Object.entries(tilakohtaisetVaiheet)
+        .filter(([t]) => statusOrder[t as JulkaisuStatus] < statusNro)
+        .map(([_, { julkaisu: j }]) => j);
+
+      const vaiheNotEditable = !isVaiheMuokkaustilassa(vaihe);
+      const hasPriorUserCreatedJulkaisu = aiemmatJulkaisut.some(isJulkaisuUserCreated);
+      const doesntPassAdditionalChecks = additionalVaiheChecks ? !additionalVaiheChecks(tila, julkaisu, vaihe) : false;
+
+      // Jos vaihe ei ole muokattavissa
+      // TAI sitä edeltävissä vaiheissa on käyttäjän luomia julkaisuja
+      // TAI se ei läpäise lisäehtoja
+      return vaiheNotEditable || hasPriorUserCreatedJulkaisu || doesntPassAdditionalChecks;
+    });
+
+  return noJulkaisuPreventingChange;
 }
 
 export function isAllowedToChangeVahainenMenettely(projekti: Projekti): boolean {
-  return thereAreNoVuorovaikutusKierrosJulkaisutThatAreNotMigroitu(projekti) && noJulkaisuOrKutsuIsInReadStateProjekti(projekti);
+  return noUserCreatedJulkaisuPreventingChange(projekti);
 }
 
 export function isAllowedToChangeSuunnittelusopimus(projekti: Projekti): boolean {
-  return thereAreNoVuorovaikutusKierrosJulkaisutThatAreNotMigroitu(projekti) && noJulkaisuOrKutsuIsInReadStateProjekti(projekti);
+  return noUserCreatedJulkaisuPreventingChange(projekti);
 }
 
 export function isAllowedToChangeKielivalinta(projekti: Projekti): boolean {
-  return (
-    thereAreNoVuorovaikutusKierrosJulkaisutThatAreNotMigroitu(projekti) &&
-    noJulkaisuOrKutsuIsInReadStateProjekti(projekti) &&
-    thereAreNoUudelleenkuulutusAfterAloituskuulutus(projekti)
-  );
+  // Jos tila on jotain muuta kuin ALOITUSKUULUTUS, tarkistetaan, että vaiheella ei ole uudelleenkuulutusta
+  const preventNonAloituskuulutusUudelleenkuulutus: AdditionalValidation = (tila, _julkaisu, vaihe) => {
+    return tila === Status.ALOITUSKUULUTUS || (vaihe?.__typename === "VuorovaikutusKierros" ? true : !vaihe?.uudelleenKuulutus);
+  };
+  return noUserCreatedJulkaisuPreventingChange(projekti, preventNonAloituskuulutusUudelleenkuulutus);
 }
 
 export function isAllowedToChangeEuRahoitus(projekti: Projekti): boolean {
-  return thereAreNoVuorovaikutusKierrosJulkaisutThatAreNotMigroitu(projekti) && noJulkaisuOrKutsuIsInReadStateProjekti(projekti);
-}
-
-export function thereAreNoUudelleenkuulutusAfterAloituskuulutus(projekti: DBProjekti | Projekti): boolean {
-  if (isProjektiAPIProjekti(projekti)) {
-    return thereAreNoUudelleenkuulutusAfterAloituskuulutusAPIProjekti(projekti);
-  } else if (isProjektiDBProjekti(projekti)) {
-    return thereAreNoUudelleenkuulutusAfterAloituskuulutusDBProjekti(projekti);
-  } else {
-    return false;
-  }
-}
-
-function thereAreNoUudelleenkuulutusAfterAloituskuulutusAPIProjekti(projekti: Projekti) {
-  if (projekti.nahtavillaoloVaihe?.uudelleenKuulutus) return false;
-  if (projekti.hyvaksymisPaatosVaihe?.uudelleenKuulutus) return false;
-  if (projekti.jatkoPaatos1Vaihe?.uudelleenKuulutus) return false;
-  if (projekti.jatkoPaatos2Vaihe?.uudelleenKuulutus) return false;
-  return true;
-}
-
-function thereAreNoUudelleenkuulutusAfterAloituskuulutusDBProjekti(dbProjekti: DBProjekti) {
-  if (dbProjekti.nahtavillaoloVaihe?.uudelleenKuulutus) return false;
-  if (dbProjekti.hyvaksymisPaatosVaihe?.uudelleenKuulutus) return false;
-  if (dbProjekti.jatkoPaatos1Vaihe?.uudelleenKuulutus) return false;
-  if (dbProjekti.jatkoPaatos2Vaihe?.uudelleenKuulutus) return false;
-  return true;
+  return noUserCreatedJulkaisuPreventingChange(projekti);
 }

--- a/common/util/operationValidators.ts
+++ b/common/util/operationValidators.ts
@@ -74,11 +74,14 @@ function isJulkaisuUserCreated(julkaisu: Julkaisu): julkaisu is NonNullable<Julk
     : !!julkaisu && julkaisu.tila !== KuulutusJulkaisuTila.MIGROITU;
 }
 
-const isVaiheMuokkaustilassa = (vaihe: Vaihe) =>
-  !vaihe ||
-  (vaihe.__typename === "VuorovaikutusKierros"
-    ? vaihe.tila === VuorovaikutusKierrosTila.MUOKATTAVISSA
-    : vaihe.muokkausTila === MuokkausTila.MUOKKAUS);
+function isVaiheMuokkaustilassa(vaihe: Vaihe): boolean {
+  return (
+    !vaihe ||
+    (vaihe.__typename === "VuorovaikutusKierros"
+      ? vaihe.tila === VuorovaikutusKierrosTila.MUOKATTAVISSA
+      : vaihe.muokkausTila === MuokkausTila.MUOKKAUS)
+  );
+}
 
 type AdditionalValidation = (tila: JulkaisuStatus, julkaisu: Julkaisu, vaihe: Vaihe) => boolean;
 


### PR DESCRIPTION
En ole tästä logiikasta hirveän ylpeä. Vähän monimutkaiseksi jäi. Olen parannusehdotuksille avoin. 