### PR TITLE
chore: HASSU-1824 Aineistomuokkauksen automaattitestien lisäys

### DIFF
--- a/backend/src/testing/dateMoverTool.ts
+++ b/backend/src/testing/dateMoverTool.ts
@@ -132,7 +132,7 @@ function modifyDateFieldsByName(obj: Record<string, unknown>, numberOfDaysToMove
       if (typeof value == "string") {
         const oldStr = obj[prop] as string;
         // Jos merkkijono alkaa numerolla jonka jälkeen on väliviiva ja numero, niin yritetään parsia päivämäärä
-        if (oldStr.search(/^\d+-\d+/) !== -1) {
+        if (oldStr.search(/^\d+-\d+/) !== -1 && dayjs(oldStr).isValid()) {
           let old = parseOptionalDate(oldStr);
           if (old) {
             old = old.subtract(numberOfDaysToMoveToPast, "day");

--- a/backend/test/testing/dateMoverTool.test.ts
+++ b/backend/test/testing/dateMoverTool.test.ts
@@ -2,6 +2,8 @@ import { describe, it } from "mocha";
 import { expect } from "chai";
 import { ProjektiFixture } from "../fixture/projektiFixture";
 import { siirraProjektinAikaa } from "../../src/testing/dateMoverTool";
+import { AineistoTila } from "hassu-common/graphql/apiModel";
+import assert from "assert";
 
 describe("DateMoverTool", () => {
   it("should move dates one year to the past", async () => {
@@ -12,5 +14,16 @@ describe("DateMoverTool", () => {
     expect(projekti).toMatchSnapshot();
     expect(projekti?.aloitusKuulutusJulkaisut?.[0].kuulutusPaiva).to.eq("2021-03-28");
     expect(projekti?.hyvaksymisPaatosVaihe?.aineistoNahtavilla?.[0].tuotu).to.eq("2019-01-01T00:00:00+02:00");
+  });
+
+  it("should not change file name that doesn't include a date", async () => {
+    const projekti = new ProjektiFixture().dbProjektiKaikkiVaiheetSaame();
+    assert(projekti.nahtavillaoloVaiheJulkaisut?.[0]);
+    const tiedostonimi = "1400-72L-6708_Yleiskartta_kmv209-216.pdf";
+    projekti.nahtavillaoloVaiheJulkaisut[0].aineistoNahtavilla = [
+      { dokumenttiOid: "testi.oid", nimi: tiedostonimi, tila: AineistoTila.VALMIS },
+    ];
+    siirraProjektinAikaa(projekti, 365);
+    expect(projekti.nahtavillaoloVaiheJulkaisut[0].aineistoNahtavilla[0].nimi).to.eq(tiedostonimi);
   });
 });

--- a/cypress/e2e/4-migraatio/1-migraatio.cy.ts
+++ b/cypress/e2e/4-migraatio/1-migraatio.cy.ts
@@ -186,8 +186,14 @@ describe("Migraatio", () => {
     // Täytä nähtävilläolovaihe
     cy.get("#sidenavi_nahtavillaolovaihe").click({ force: true });
 
-    lisaaNahtavillaoloAineistot(oid);
+    lisaaNahtavillaoloAineistot({
+      oid,
+      aineistoNahtavilla: { toimeksianto: "Toimeksianto1" },
+      lisaAineisto: { toimeksianto: "Toimeksianto1" },
+    });
+    const today = formatDate(dayjs());
     const selectorToTextMap = {
+      '[name="nahtavillaoloVaihe.kuulutusPaiva"]': today,
       '[name="nahtavillaoloVaihe.hankkeenKuvaus.SUOMI"]': "nahtavillaolovaiheen kuvaus Suomeksi",
       '[name="nahtavillaoloVaihe.ilmoituksenVastaanottajat.kunnat.0.sahkoposti"]': "test@vayla.fi",
       '[name="nahtavillaoloVaihe.ilmoituksenVastaanottajat.kunnat.1.sahkoposti"]': "test@vayla.fi",

--- a/cypress/support/util.ts
+++ b/cypress/support/util.ts
@@ -57,6 +57,18 @@ export function selectAllAineistotFromCategory(accordion) {
     });
 }
 
+export function selectAineistotFromCategory(accordion: string, aineistojenNimet: string[]) {
+  cy.get(accordion).click();
+  aineistojenNimet.forEach((nimi) => {
+    cy.get("#table_body_Suunnitelma-aineisto")
+      .contains(nimi)
+      .parentsUntil("div[data-index]")
+      .find('input[name*="select_row_"]')
+      .first()
+      .click();
+  });
+}
+
 export function typeIntoFields(selectorToTextMap: Record<string, string>) {
   Object.entries(selectorToTextMap).forEach(([selector, text]) => {
     cy.get(selector, {
@@ -67,7 +79,11 @@ export function typeIntoFields(selectorToTextMap: Record<string, string>) {
   });
 }
 
-export function verifyAllDownloadLinks(opts?) {
+type VerifyAllDownloadLinksOptions = {
+  absoluteURLs?: boolean;
+};
+
+export function verifyAllDownloadLinks(opts?: VerifyAllDownloadLinksOptions) {
   const baseUrl = Cypress.env("host");
   cy.get(".file_download").then((links) => {
     for (const link of links.get()) {

--- a/src/components/projekti/AineistoSivunPainikkeet.tsx
+++ b/src/components/projekti/AineistoSivunPainikkeet.tsx
@@ -227,7 +227,7 @@ export default function AineistoSivunPainikkeet({
       <Section noDivider>
         {muokkausTila === MuokkausTila.AINEISTO_MUOKKAUS ? (
           <Stack justifyContent={{ md: "space-between" }} direction={{ xs: "column", md: "row" }}>
-            <Button id="cancel_aineistomuokkaus" type="button" onClick={open}>
+            <Button id="poistu_aineiston_muokkaus" type="button" onClick={open}>
               Poistu muokkaustilasta
             </Button>
             <Stack justifyContent={{ md: "flex-end" }} direction={{ xs: "column", md: "row" }}>
@@ -252,10 +252,10 @@ export default function AineistoSivunPainikkeet({
                 </p>
               </DialogContent>
               <DialogActions>
-                <Button type="button" onClick={cancelAineistoMuokkaus} primary>
+                <Button id="accept_poistu_aineiston_muokkaus" type="button" onClick={cancelAineistoMuokkaus} primary>
                   Kyllä
                 </Button>
-                <Button type="button" onClick={close}>
+                <Button id="cancel_poistu_aineiston_muokkaus" type="button" onClick={close}>
                   Peruuta
                 </Button>
               </DialogActions>

--- a/src/components/projekti/Ajansiirto.tsx
+++ b/src/components/projekti/Ajansiirto.tsx
@@ -57,7 +57,12 @@ export default function Ajansiirto({ oid }: { oid: string }) {
             />
             <span style={{ marginLeft: "1em", marginRight: "1em" }}>AJANSIIRTO</span>
           </h3>
-          <TextInput type="number" label="Siirrä projektin päivämääriä x päivää menneisyyteen" {...register("days")} />
+          <TextInput
+            type="number"
+            label="Siirrä projektin päivämääriä x päivää menneisyyteen"
+            id="ajansiirto_paiva_lkm"
+            {...register("days")}
+          />
           <Button
             style={{
               borderRadius: 0,
@@ -65,6 +70,7 @@ export default function Ajansiirto({ oid }: { oid: string }) {
             }}
             disabled={!formState.isValid}
             type="button"
+            id="ajansiirto_siirra"
             onClick={handleSubmit(siirraMenneisyyteen)}
           >
             <span>Siirrä</span>

--- a/src/components/projekti/common/KansalaisenAineistoNakyma.tsx
+++ b/src/components/projekti/common/KansalaisenAineistoNakyma.tsx
@@ -72,6 +72,7 @@ export default function KansalaisenAineistoNakyma({ projekti, kuulutus, uudellee
       {!paatos && !isDateTimeInThePast(kuulutus.kuulutusVaihePaattyyPaiva, "end-of-day") && (
         <ButtonFlat
           type="button"
+          id="toggle_open_close_kategoriat"
           onClick={() => {
             if (areToimeksiannotExpanded) {
               setExpandedToimeksiannot([]);

--- a/src/components/projekti/lukutila/AineistoMuokkausSection.tsx
+++ b/src/components/projekti/lukutila/AineistoMuokkausSection.tsx
@@ -55,7 +55,7 @@ export const AineistoMuokkausSection = styled(({ tyyppi, projekti, children, jul
   return (
     <Section {...sectionProps}>
       {kuulutusHyvaksyttyOdottaaJulkaisua && (
-        <Button type="button" onClick={open} className="lg:absolute lg:top-0 lg:right-0 ml-auto lg:ml-0">
+        <Button id="avaa_aineiston_muokkaus" type="button" onClick={open} className="lg:absolute lg:top-0 lg:right-0 ml-auto lg:ml-0">
           Muokkaa
         </Button>
       )}
@@ -66,10 +66,10 @@ export const AineistoMuokkausSection = styled(({ tyyppi, projekti, children, jul
           <p>Projektipäällikkö saa tiedon muokatuista aineistoista.</p>
         </DialogContent>
         <DialogActions>
-          <Button type="button" primary onClick={aktivoiAineistoMuokkaus}>
+          <Button id="jatka_aineiston_muokkaus" type="button" primary onClick={aktivoiAineistoMuokkaus}>
             Jatka
           </Button>
-          <Button type="button" onClick={close}>
+          <Button id="peruuta_aineiston_muokkaus" type="button" onClick={close}>
             Peruuta
           </Button>
         </DialogActions>

--- a/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
+++ b/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
@@ -3,7 +3,7 @@ import ExtLink from "@components/ExtLink";
 import HassuAccordion from "@components/HassuAccordion";
 import Section from "@components/layout/Section2";
 import HassuAineistoNimiExtLink from "@components/projekti/HassuAineistoNimiExtLink";
-import { Stack } from "@mui/material";
+import { experimental_sx as sx, Stack, styled } from "@mui/material";
 import { KuulutusJulkaisuTila, TilasiirtymaTyyppi } from "@services/api";
 import { isDateTimeInThePast } from "backend/src/util/dateUtil";
 import { aineistoKategoriat } from "hassu-common/aineistoKategoriat";
@@ -15,6 +15,8 @@ import { projektiOnEpaaktiivinen } from "src/util/statusUtil";
 import { AineistoMuokkausSection } from "@components/projekti/lukutila/AineistoMuokkausSection";
 import HyvaksyJaPalautaPainikkeet from "@components/projekti/HyvaksyJaPalautaPainikkeet";
 import { AineistoNahtavillaAccordion } from "@components/projekti/AineistoNahtavillaAccordion";
+import { UusiSpan } from "@components/projekti/UusiSpan";
+import dayjs from "dayjs";
 
 export default function Lukunakyma() {
   const { data: projekti } = useProjekti();
@@ -101,21 +103,22 @@ export default function Lukunakyma() {
                 id: "lisa_aineisto_accordion_lukutila",
                 title: <span>{`Lisäaineisto (${julkaisu.lisaAineisto?.length || 0})`}</span>,
                 content: (
-                  <>
                   <Stack direction="column" rowGap={2}>
                     {julkaisu.lisaAineisto?.map((aineisto) => (
-                        <span key={aineisto.dokumenttiOid}>
+                      <AineistoRow key={aineisto.dokumenttiOid}>
                         <HassuAineistoNimiExtLink
                           tiedostoPolku={aineisto.tiedosto}
                           aineistoNimi={aineisto.nimi}
                           aineistoTila={aineisto.tila}
                           sx={{ mr: 3 }}
                         />
-                          {aineisto.tuotu && formatDateTime(aineisto.tuotu)}
-                        </span>
+                        {!!aineisto.tuotu && <span>({formatDateTime(aineisto.tuotu)})</span>}
+                        {!!aineisto.tuotu &&
+                          !!julkaisu.aineistoMuokkaus?.alkuperainenHyvaksymisPaiva &&
+                          dayjs(aineisto.tuotu).isAfter(julkaisu.aineistoMuokkaus?.alkuperainenHyvaksymisPaiva) && <UusiSpan />}
+                      </AineistoRow>
                     ))}
                   </Stack>
-                  </>
                 ),
               },
             ]}
@@ -128,3 +131,5 @@ export default function Lukunakyma() {
     </>
   );
 }
+
+const AineistoRow = styled("span")(sx({ display: "flex", gap: 3 }));

--- a/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
+++ b/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
@@ -98,22 +98,23 @@ export default function Lukunakyma() {
           <HassuAccordion
             items={[
               {
+                id: "lisa_aineisto_accordion_lukutila",
                 title: <span>{`Lisäaineisto (${julkaisu.lisaAineisto?.length || 0})`}</span>,
                 content: (
                   <>
-                    <Stack direction="column" rowGap={2}>
-                      {julkaisu.lisaAineisto?.map((aineisto) => (
+                  <Stack direction="column" rowGap={2}>
+                    {julkaisu.lisaAineisto?.map((aineisto) => (
                         <span key={aineisto.dokumenttiOid}>
-                          <HassuAineistoNimiExtLink
-                            tiedostoPolku={aineisto.tiedosto}
-                            aineistoNimi={aineisto.nimi}
-                            aineistoTila={aineisto.tila}
-                            sx={{ mr: 3 }}
-                          />
+                        <HassuAineistoNimiExtLink
+                          tiedostoPolku={aineisto.tiedosto}
+                          aineistoNimi={aineisto.nimi}
+                          aineistoTila={aineisto.tila}
+                          sx={{ mr: 3 }}
+                        />
                           {aineisto.tuotu && formatDateTime(aineisto.tuotu)}
                         </span>
-                      ))}
-                    </Stack>
+                    ))}
+                  </Stack>
                   </>
                 ),
               },

--- a/src/components/table/HassuTable.tsx
+++ b/src/components/table/HassuTable.tsx
@@ -44,6 +44,7 @@ export const selectColumnDef: <T>() => ColumnDef<T> = () => ({
         disabled={!row.getCanSelect()}
         indeterminate={row.getIsSomeSelected()}
         onChange={row.getToggleSelectedHandler()}
+        name={row.id ? `select_row_${row.id}` : undefined}
       />
     </Span>
   ),
@@ -52,46 +53,44 @@ export const selectColumnDef: <T>() => ColumnDef<T> = () => ({
 
 function SelectHeader<T>(props: HeaderContext<T, unknown>) {
   return (
-    <>
-      <Span
-        sx={{
-          display: { xs: "none", md: "flex" },
-          justifyContent: "center",
-          flexDirection: "column",
-          alignItems: "center",
-          width: "100%",
-          margin: "auto",
-        }}
-      >
-        <Span>Valitse</Span>
-        <Span sx={{ position: "relative" }}>
-          <Checkbox
-            disabled={!props.table.options.enableRowSelection}
-            checked={props.table.getIsAllRowsSelected()}
-            indeterminate={props.table.getIsSomeRowsSelected()}
-            onChange={props.table.getToggleAllRowsSelectedHandler()}
-            sx={{
-              "&::before": {
-                content: '"("',
-                position: "absolute",
-                top: "50%",
-                left: "5%",
-                transform: "translateY(-50%)",
-                color: "#7A7A7A",
-              },
-              "&::after": {
-                content: '")"',
-                position: "absolute",
-                top: "50%",
-                right: "5%",
-                transform: "translateY(-50%)",
-                color: "#7A7A7A",
-              },
-            }}
-          />
-        </Span>
+    <Span
+      sx={{
+        display: { xs: "none", md: "flex" },
+        justifyContent: "center",
+        flexDirection: "column",
+        alignItems: "center",
+        width: "100%",
+        margin: "auto",
+      }}
+    >
+      <Span>Valitse</Span>
+      <Span sx={{ position: "relative" }}>
+        <Checkbox
+          disabled={!props.table.options.enableRowSelection}
+          checked={props.table.getIsAllRowsSelected()}
+          indeterminate={props.table.getIsSomeRowsSelected()}
+          onChange={props.table.getToggleAllRowsSelectedHandler()}
+          sx={{
+            "&::before": {
+              content: '"("',
+              position: "absolute",
+              top: "50%",
+              left: "5%",
+              transform: "translateY(-50%)",
+              color: "#7A7A7A",
+            },
+            "&::after": {
+              content: '")"',
+              position: "absolute",
+              top: "50%",
+              right: "5%",
+              transform: "translateY(-50%)",
+              color: "#7A7A7A",
+            },
+          }}
+        />
       </Span>
-    </>
+    </Span>
   );
 }
 


### PR DESCRIPTION
Ohessa pari pienempää muutosta:
- dayjs plugin customParseFormat aiheutti sen, että dayjs antoi validileimaa liian laveasti. Sen vuoksi lisäsin dateMoverTooliin erillisen validoinnin, jossa ei ole käytössä customParseFormattia.
- Lisäksi lisätty myös lisäaineistoihin UUSI-merkinnät. (aiemmin oli vain nähtäville asetettavassa aineistossa)