### PR TITLE
feat: HASSUYP-238 haun korjaus

### DIFF
--- a/backend/src/projektiSearch/projektiSearchService.ts
+++ b/backend/src/projektiSearch/projektiSearchService.ts
@@ -305,7 +305,7 @@ class ProjektiSearchService {
         bool: {
           must: words.map((word) => ({
             prefix: {
-              nimi: word.trim(),
+              nimi: this.keepAlphanumeric(word),
             },
           })),
         },
@@ -376,6 +376,10 @@ class ProjektiSearchService {
       sort.push({ "nimi.keyword": { order: "asc" } });
     }
     return sort;
+  }
+
+  private static keepAlphanumeric(input: string): string {
+    return input.replace(/[^a-zA-Z0-9åäöÅÄÖ]/g, "").toLocaleLowerCase();
   }
 }
 


### PR DESCRIPTION
* poista meidän pilkkomista hakutermeistä välimerkit ym koska:
"Standard analyzer – Parses strings into terms at word boundaries according to the Unicode text segmentation algorithm. It removes most, but not all, punctuation and converts strings to lowercase. You can remove stop words if you enable that option, but it does not remove stop words by default."