### PR TITLE
fix: Korjaa tilanne, jossa geojson lisätään ensimmäistä kertaa

### DIFF
--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -40,7 +40,6 @@ import { haeAktiivisenVaiheenAsianhallinnanTila } from "./haeAktiivisenVaiheenAs
 import { adaptAsianhallinta } from "./adaptAsianhallinta";
 import { adaptLausuntoPyynnonTaydennyksetToSave, adaptLausuntoPyynnotToSave } from "./adaptToDB/adaptLausuntoPyynnotToSave";
 import { getLinkkiAsianhallintaan } from "../../asianhallinta/getLinkkiAsianhallintaan";
-import { fileService } from "../../files/fileService";
 
 export class ProjektiAdapter {
   public async adaptProjekti(
@@ -74,7 +73,6 @@ export class ProjektiAdapter {
       muistuttajat,
       muutMuistuttajat,
       asianhallinta: _asianhallinta,
-      karttarajaus,
       ...fieldsToCopyAsIs
     } = dbProjekti;
 
@@ -150,7 +148,6 @@ export class ProjektiAdapter {
       kasittelynTila: adaptKasittelynTilaToAPI(kasittelynTila),
       muistutusMaara: (annetutMuistutukset?.length ?? 0) + (muistuttajat?.length ?? 0) + (muutMuistuttajat?.length ?? 0),
       asianhallinta: await adaptAsianhallinta(dbProjekti),
-      karttarajaus: karttarajaus ? fileService.getYllapitoPathForProjektiFile(projektiPath, karttarajaus) : null,
       ...fieldsToCopyAsIs,
     });
 

--- a/backend/test/__snapshots__/apiHandler.test.ts.snap
+++ b/backend/test/__snapshots__/apiHandler.test.ts.snap
@@ -8,7 +8,6 @@ Object {
     "aktivoitavissa": false,
     "inaktiivinen": true,
   },
-  "karttarajaus": null,
   "kayttoOikeudet": Array [
     Object {
       "__typename": "ProjektiKayttaja",
@@ -148,7 +147,6 @@ Array [
       "linkkiAsianhallintaan": undefined,
     },
     "julkinenStatus": "EI_JULKAISTU",
-    "karttarajaus": null,
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",
@@ -260,7 +258,6 @@ Array [
       "linkkiAsianhallintaan": undefined,
     },
     "julkinenStatus": "EI_JULKAISTU",
-    "karttarajaus": null,
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",
@@ -371,7 +368,6 @@ Array [
       "linkkiAsianhallintaan": undefined,
     },
     "julkinenStatus": "EI_JULKAISTU",
-    "karttarajaus": null,
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",
@@ -627,7 +623,6 @@ Array [
     },
     "euRahoitus": false,
     "julkinenStatus": "EI_JULKAISTU",
-    "karttarajaus": null,
     "kayttoOikeudet": Array [
       Object {
         "__typename": "ProjektiKayttaja",
@@ -935,7 +930,6 @@ Object {
   },
   "euRahoitus": false,
   "julkinenStatus": "ALOITUSKUULUTUS",
-  "karttarajaus": null,
   "kayttoOikeudet": Array [
     Object {
       "__typename": "ProjektiKayttaja",

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -183,7 +183,6 @@ type Projekti implements IProjekti {
   paivitetty: String
   virhetiedot: ProjektiVirhe
   kasittelynTila: KasittelynTila
-  karttarajaus: String
   asianhallinta: Asianhallinta!
 }
 
@@ -1159,7 +1158,7 @@ type AsianhallinnanTila {
   asianTila: AsianTila
 }
 
-type Omistaja  {
+type Omistaja {
   id: String!
   oid: String!
   kiinteistotunnus: String!
@@ -1180,7 +1179,7 @@ type KiinteistonOmistajat {
   omistajat: [Omistaja]!
 }
 
-type Muistuttaja  {
+type Muistuttaja {
   id: String!
   lisatty: String!
   etunimi: String

--- a/src/pages/yllapito/projekti/[oid]/kiinteistonomistajat.dev.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kiinteistonomistajat.dev.tsx
@@ -16,7 +16,7 @@ export default function Kiinteistonomistajat() {
     setIsOpen(true);
   }, []);
   return (
-    <ProjektiConsumer>
+    <ProjektiConsumer useProjektiOptions={{ revalidateOnMount: true }}>
       {(projekti) => (
         <>
           <Button onClick={open}>Avaa dialogi</Button>


### PR DESCRIPTION
Tulin tajunneeksi, että jos kun projektille ensimmäistä kertaa lisätään karttarajaus.geojson, pitää projektin tiedot hakea uudelleen, että karttarajaustiedosto haetaan kun dialogi avataan uudemman kerran. Jotta dialogi toimii riippumatta siitä onko projektin tietoja haettu uudelleen, muokkasin toteutusta niin, ettei projektin tiedoista tarkisteta onko karttarajausta vaiko ei.