### PR TITLE
fix: HASSUYP-343 Korjaa jatkopäätöksien julkaisujen käsittelyä

### DIFF
--- a/backend/src/handler/asiakirjaHandler.ts
+++ b/backend/src/handler/asiakirjaHandler.ts
@@ -12,6 +12,8 @@ import { NahtavillaoloKuulutusAsiakirjaTyyppi } from "../asiakirja/asiakirjaType
 import { isKieliTranslatable, KaannettavaKieli } from "hassu-common/kaannettavatKielet";
 import { findAloitusKuulutusWaitingForApproval } from "../projekti/projektiUtil";
 import { HyvaksymisPaatosKuulutusAsiakirjaTyyppi } from "hassu-common/hyvaksymisPaatosUtil";
+import { isProjektiAsianhallintaIntegrationEnabled } from "../util/isProjektiAsianhallintaIntegrationEnabled";
+import { getLinkkiAsianhallintaan } from "../asianhallinta/getLinkkiAsianhallintaan";
 
 async function handleAloitusKuulutus(
   projekti: DBProjekti,
@@ -32,6 +34,8 @@ async function handleAloitusKuulutus(
       kayttoOikeudet: projekti.kayttoOikeudet,
       euRahoitusLogot: projekti.euRahoitusLogot,
       vahainenMenettely: projekti.vahainenMenettely,
+      asianhallintaPaalla: await isProjektiAsianhallintaIntegrationEnabled(projekti),
+      linkkiAsianhallintaan: await getLinkkiAsianhallintaan(projekti),
     });
   } else {
     // Previewing projekti with unsaved changes. adaptProjektiToPreview combines database content with the user provided changes
@@ -49,6 +53,8 @@ async function handleAloitusKuulutus(
       kayttoOikeudet: projekti.kayttoOikeudet,
       euRahoitusLogot: projekti.euRahoitusLogot,
       vahainenMenettely: projekti.vahainenMenettely,
+      asianhallintaPaalla: await isProjektiAsianhallintaIntegrationEnabled(projekti),
+      linkkiAsianhallintaan: await getLinkkiAsianhallintaan(projekti),
     });
   }
 }
@@ -82,6 +88,8 @@ async function handleYleisotilaisuusKutsu(
     kieli,
     luonnos: true,
     euRahoitusLogot: projekti.euRahoitusLogot,
+    asianhallintaPaalla: await isProjektiAsianhallintaIntegrationEnabled(projekti),
+    linkkiAsianhallintaan: await getLinkkiAsianhallintaan(projekti),
   });
 }
 
@@ -110,6 +118,8 @@ async function handleNahtavillaoloKuulutus(
     asiakirjaTyyppi,
     euRahoitusLogot: projekti.euRahoitusLogot,
     vahainenMenettely: projekti.vahainenMenettely,
+    asianhallintaPaalla: await isProjektiAsianhallintaIntegrationEnabled(projekti),
+    linkkiAsianhallintaan: await getLinkkiAsianhallintaan(projekti),
   });
 }
 
@@ -144,6 +154,8 @@ async function handleHyvaksymisPaatosKuulutus(
     luonnos: true,
     asiakirjaTyyppi,
     euRahoitusLogot: projekti.euRahoitusLogot,
+    asianhallintaPaalla: await isProjektiAsianhallintaIntegrationEnabled(projekti),
+    linkkiAsianhallintaan: await getLinkkiAsianhallintaan(projekti),
   });
 }
 

--- a/backend/src/handler/tila/KuulutusTilaManager.ts
+++ b/backend/src/handler/tila/KuulutusTilaManager.ts
@@ -9,7 +9,6 @@ import {
   sortByKuulutusPaivaDesc,
 } from "../../projekti/projektiUtil";
 import { assertIsDefined } from "../../util/assertions";
-import { isKuulutusPaivaInThePast } from "../../projekti/status/projektiJulkinenStatusHandler";
 import { fileService } from "../../files/fileService";
 import { PathTuple, ProjektiPaths } from "../../files/ProjektiPath";
 import { auditLog } from "../../logger";
@@ -152,7 +151,8 @@ export abstract class KuulutusTilaManager<
   }
 
   private getUpdatedVaiheTiedotForUudelleenkuulutus(projekti: DBProjekti, kuulutusLuonnos: T, hyvaksyttyJulkaisu: Y, julkaisut: Y[]) {
-    const julkinenUudelleenKuulutus = isKuulutusPaivaInThePast(hyvaksyttyJulkaisu.kuulutusPaiva);
+    const julkinenUudelleenKuulutus =
+      !!hyvaksyttyJulkaisu.kuulutusPaiva && isDateTimeInThePast(hyvaksyttyJulkaisu.kuulutusPaiva, "start-of-day");
     const uudelleenKuulutus = julkinenUudelleenKuulutus
       ? {
           tila: UudelleenkuulutusTila.JULKAISTU_PERUUTETTU,

--- a/backend/src/ilmoitustauluSyote/ilmoitustauluSyoteAdapter.ts
+++ b/backend/src/ilmoitustauluSyote/ilmoitustauluSyoteAdapter.ts
@@ -1,16 +1,14 @@
 import { IlmoitusKuulutus, IlmoitusKuulutusType } from "./ilmoitusKuulutus";
 import {
   AloitusKuulutusJulkaisuJulkinen,
-  HyvaksymisPaatosVaiheJulkaisuJulkinen,
   Kieli,
   Kielitiedot,
-  NahtavillaoloVaiheJulkaisuJulkinen,
   ProjektiJulkinen,
   VelhoJulkinen,
   VuorovaikutusJulkinen,
 } from "hassu-common/graphql/apiModel";
 import { translate } from "../util/localization";
-import { linkAloituskuulutus, linkHyvaksymisPaatos, linkNahtavillaOlo, linkSuunnitteluVaihe } from "hassu-common/links";
+import { linkSuunnitteluVaihe } from "hassu-common/links";
 import { parseDate } from "../util/dateUtil";
 import { kuntametadata } from "hassu-common/kuntametadata";
 import { assertIsDefined } from "../util/assertions";
@@ -18,14 +16,25 @@ import { sortedUniq } from "lodash";
 
 type LyhytOsoite = string | undefined | null;
 
+export type JulkaisuVaiheIndexPart =
+  | "aloitusKuulutus"
+  | "vuorovaikutuskierros"
+  | "nahtavillaoloVaihe"
+  | "hyvaksymisPaatos"
+  | "jatkopaatos1"
+  | "jatkopaatos2";
+
+export type GenericKuulutusJulkaisuJulkinen = Pick<AloitusKuulutusJulkaisuJulkinen, "velho" | "kielitiedot" | "kuulutusPaiva" | "tila">;
+
 class IlmoitustauluSyoteAdapter {
-  adaptAloitusKuulutusJulkaisu(
+  adaptKuulutusJulkaisu(
     oid: string,
-    lyhytOsoite: LyhytOsoite,
-    aloitusKuulutusJulkaisu: AloitusKuulutusJulkaisuJulkinen,
-    kieli: Kieli
+    url: string,
+    kuulutusJulkaisu: GenericKuulutusJulkaisuJulkinen,
+    kieli: Kieli,
+    uiOtsikkoPath: string
   ): Omit<IlmoitusKuulutus, "key"> {
-    const velho = aloitusKuulutusJulkaisu.velho;
+    const velho = kuulutusJulkaisu.velho;
     if (!velho.nimi) {
       throw new Error("velho.nimi puuttuu");
     }
@@ -38,31 +47,28 @@ class IlmoitustauluSyoteAdapter {
     if (!velho.vaylamuoto) {
       throw new Error("velho.vaylamuoto puuttuu");
     }
-    if (!aloitusKuulutusJulkaisu.kielitiedot) {
-      throw new Error("aloitusKuulutusJulkaisu.kielitiedot puuttuu");
+    if (!kuulutusJulkaisu.kielitiedot) {
+      throw new Error("kielitiedot puuttuu");
     }
-    if (!aloitusKuulutusJulkaisu.kuulutusPaiva) {
-      throw new Error("aloitusKuulutusJulkaisu.kuulutusPaiva puuttuu");
+    if (!kuulutusJulkaisu.kuulutusPaiva) {
+      throw new Error("kuulutusPaiva puuttuu");
     }
-    const nimi = selectNimi(velho.nimi, aloitusKuulutusJulkaisu.kielitiedot, kieli);
-    const url = linkAloituskuulutus({ oid, lyhytOsoite: lyhytOsoite ?? undefined }, kieli);
+    const nimi = selectNimi(velho.nimi, kuulutusJulkaisu.kielitiedot, kieli);
     return {
       type: IlmoitusKuulutusType.KUULUTUS,
-      title: getTitle(kieli, nimi),
+      title: getTitle(kieli, nimi, uiOtsikkoPath),
       url,
-      ...this.getCommonFields(oid, velho, kieli, aloitusKuulutusJulkaisu.kuulutusPaiva),
+      ...this.getCommonFields(oid, velho, kieli, kuulutusJulkaisu.kuulutusPaiva),
     };
 
-    function getTitle(kieli: Kieli, nimi: string) {
+    function getTitle(kieli: Kieli, nimi: string, uiOtsikkoPath: string) {
       // TODO: replace these with strings = the actual translations, do not use translate function
       switch (kieli) {
         case Kieli.RUOTSI:
-          return translate("ui-otsikot.kuulutus_suunnitelman_alkamisesta", kieli) + ": " + nimi;
-        case Kieli.POHJOISSAAME:
-          return translate("ui-otsikot.kuulutus_suunnitelman_alkamisesta", Kieli.SUOMI) + ": " + nimi;
+          return translate(uiOtsikkoPath, kieli) + ": " + nimi;
         default:
-          //SUOMI
-          return translate("ui-otsikot.kuulutus_suunnitelman_alkamisesta", kieli) + ": " + nimi;
+          //SUOMI JA SAAME
+          return translate(uiOtsikkoPath, Kieli.SUOMI) + ": " + nimi;
       }
     }
   }
@@ -103,108 +109,9 @@ class IlmoitustauluSyoteAdapter {
       switch (kieli) {
         case Kieli.RUOTSI:
           return translate("asiakirja.kutsu_vuorovaikutukseen.otsikko", kieli) + ": " + nimi;
-        case Kieli.POHJOISSAAME:
+        default:
+          //SUOMI JA SAAME
           return translate("asiakirja.kutsu_vuorovaikutukseen.otsikko", Kieli.SUOMI) + ": " + nimi;
-        default:
-          //SUOMI
-          return translate("asiakirja.kutsu_vuorovaikutukseen.otsikko", kieli) + ": " + nimi;
-      }
-    }
-  }
-
-  adaptNahtavillaoloVaihe(
-    oid: string,
-    lyhytOsoite: string | undefined | null,
-    nahtavillaoloVaihe: NahtavillaoloVaiheJulkaisuJulkinen,
-    kieli: Kieli
-  ): Omit<IlmoitusKuulutus, "key"> {
-    const velho = nahtavillaoloVaihe.velho;
-    if (!velho.nimi) {
-      throw new Error("velho.nimi puuttuu");
-    }
-    if (!velho.kunnat) {
-      throw new Error("velho.kunnat puuttuu");
-    }
-    if (!velho.maakunnat) {
-      throw new Error("velho.maakunnat puuttuu");
-    }
-    if (!velho.vaylamuoto) {
-      throw new Error("velho.vaylamuoto puuttuu");
-    }
-    if (!nahtavillaoloVaihe.kielitiedot) {
-      throw new Error("nahtavillaoloVaihe.kielitiedot puuttuu");
-    }
-    const kuulutusPaiva = nahtavillaoloVaihe.kuulutusPaiva;
-    if (!kuulutusPaiva) {
-      throw new Error("nahtavillaoloVaihe.kuulutusPaiva puuttuu");
-    }
-    const nimi = selectNimi(velho.nimi, nahtavillaoloVaihe.kielitiedot, kieli);
-    const url = linkNahtavillaOlo({ oid, lyhytOsoite: lyhytOsoite ?? undefined }, kieli);
-    return {
-      ...this.getCommonFields(oid, velho, kieli, kuulutusPaiva),
-      type: IlmoitusKuulutusType.KUULUTUS,
-      title: getTitle(kieli, nimi),
-      url,
-    };
-
-    function getTitle(kieli: Kieli, nimi: string) {
-      // TODO: replace these with strings = the actual translations, do not use translate function
-      switch (kieli) {
-        case Kieli.RUOTSI:
-          return translate("ui-otsikot.kuulutus_suunnitelman_nahtaville_asettamisesta", kieli) + ": " + nimi;
-        case Kieli.POHJOISSAAME:
-          return translate("ui-otsikot.kuulutus_suunnitelman_nahtaville_asettamisesta", Kieli.SUOMI) + ": " + nimi;
-        default:
-          //SUOMI
-          return translate("ui-otsikot.kuulutus_suunnitelman_nahtaville_asettamisesta", kieli) + ": " + nimi;
-      }
-    }
-  }
-
-  adaptHyvaksymisPaatosVaihe(
-    oid: string,
-    lyhytOsoite: string | undefined | null,
-    hyvaksymisPaatosVaihe: HyvaksymisPaatosVaiheJulkaisuJulkinen,
-    kieli: Kieli
-  ): Omit<IlmoitusKuulutus, "key"> {
-    const velho = hyvaksymisPaatosVaihe.velho;
-    if (!velho.nimi) {
-      throw new Error("velho.nimi puuttuu");
-    }
-    if (!velho.kunnat) {
-      throw new Error("velho.kunnat puuttuu");
-    }
-    if (!velho.maakunnat) {
-      throw new Error("velho.maakunnat puuttuu");
-    }
-    if (!velho.vaylamuoto) {
-      throw new Error("velho.vaylamuoto puuttuu");
-    }
-    if (!hyvaksymisPaatosVaihe.kielitiedot) {
-      throw new Error("hyvaksymisPaatosVaihe.kielitiedot puuttuu");
-    }
-    if (!hyvaksymisPaatosVaihe.kuulutusPaiva) {
-      throw new Error("hyvaksymisPaatosVaihe.kuulutusPaiva puuttuu");
-    }
-    const nimi = selectNimi(velho.nimi, hyvaksymisPaatosVaihe.kielitiedot, kieli);
-    const url = linkHyvaksymisPaatos({ oid, lyhytOsoite: lyhytOsoite ?? undefined }, kieli);
-    return {
-      type: IlmoitusKuulutusType.KUULUTUS,
-      title: getTitle(kieli, nimi),
-      url,
-      ...this.getCommonFields(oid, velho, kieli, hyvaksymisPaatosVaihe.kuulutusPaiva),
-    };
-
-    function getTitle(kieli: Kieli, nimi: string) {
-      // TODO: replace these with strings = the actual translations, do not use translate function
-      switch (kieli) {
-        case Kieli.RUOTSI:
-          return translate("ui-otsikot.kuulutus_suunnitelman_hyvaksymispaatoksestä", kieli) + ": " + nimi;
-        case Kieli.POHJOISSAAME:
-          return translate("ui-otsikot.kuulutus_suunnitelman_hyvaksymispaatoksestä", Kieli.SUOMI) + ": " + nimi;
-        default:
-          //SUOMI
-          return translate("ui-otsikot.kuulutus_suunnitelman_hyvaksymispaatoksestä", kieli) + ": " + nimi;
       }
     }
   }
@@ -239,20 +146,8 @@ class IlmoitustauluSyoteAdapter {
     };
   }
 
-  createKeyForAloitusKuulutusJulkaisu(oid: string, aloitusKuulutusJulkaisu: AloitusKuulutusJulkaisuJulkinen, kieli: Kieli) {
-    return [oid, "aloitusKuulutus", kieli, aloitusKuulutusJulkaisu.kuulutusPaiva].join("_");
-  }
-
-  createKeyForVuorovaikutusKierrosJulkaisu(oid: string, vuorovaikutusKierros: VuorovaikutusJulkinen, kieli: Kieli) {
-    return [oid, "vuorovaikutuskierros", kieli, vuorovaikutusKierros.vuorovaikutusJulkaisuPaiva].join("_");
-  }
-
-  createKeyForNahtavillaoloVaihe(oid: string, nahtavillaoloVaihe: NahtavillaoloVaiheJulkaisuJulkinen, kieli: Kieli) {
-    return [oid, "nahtavillaoloVaihe", kieli, nahtavillaoloVaihe.kuulutusPaiva].join("_");
-  }
-
-  createKeyForHyvaksymisPaatosVaihe(oid: string, hyvaksymisPaatos: HyvaksymisPaatosVaiheJulkaisuJulkinen, kieli: Kieli) {
-    return [oid, "hyvaksymisPaatos", kieli, hyvaksymisPaatos.kuulutusPaiva].join("_");
+  createKeyForJulkaisu(oid: string, vaihe: JulkaisuVaiheIndexPart, julkaisuPaiva: string | undefined | null = "", kieli: Kieli) {
+    return [oid, vaihe, kieli, julkaisuPaiva].join("_");
   }
 
   public getProjektiKielet(projekti: ProjektiJulkinen): Kieli[] {

--- a/common/links.ts
+++ b/common/links.ts
@@ -19,33 +19,35 @@ export function linkSuunnitelma(projekti: LinkableProjekti, kieli: Kieli): strin
   return "https://" + process.env.FRONTEND_DOMAIN_NAME + langPrefix + path;
 }
 
-export function linkAloituskuulutus(projekti: LinkableProjekti, kieli: Kieli): string {
+export type JulkinenLinkFunction = (projekti: LinkableProjekti, kieli: Kieli) => string;
+
+export const linkAloituskuulutus: JulkinenLinkFunction = (projekti, kieli) => {
   return linkSuunnitelma(projekti, kieli) + "/aloituskuulutus";
-}
+};
 
-export function linkSuunnitteluVaihe(projekti: LinkableProjekti, kieli: Kieli): string {
+export const linkSuunnitteluVaihe: JulkinenLinkFunction = (projekti, kieli) => {
   return linkSuunnitelma(projekti, kieli) + "/suunnittelu";
-}
+};
 
-export function linkNahtavillaOlo(projekti: LinkableProjekti, kieli: Kieli): string {
+export const linkNahtavillaOlo: JulkinenLinkFunction = (projekti, kieli) => {
   return linkSuunnitelma(projekti, kieli) + "/nahtavillaolo";
-}
+};
 
-export function linkHyvaksymismenettelyssa(projekti: LinkableProjekti, kieli: Kieli): string {
+export const linkHyvaksymismenettelyssa: JulkinenLinkFunction = (projekti, kieli) => {
   return linkSuunnitelma(projekti, kieli) + "/hyvaksymismenettelyssa";
-}
+};
 
-export function linkHyvaksymisPaatos(projekti: LinkableProjekti, kieli: Kieli): string {
+export const linkHyvaksymisPaatos: JulkinenLinkFunction = (projekti, kieli) => {
   return linkSuunnitelma(projekti, kieli) + "/hyvaksymispaatos";
-}
+};
 
-export function linkJatkoPaatos1(projekti: LinkableProjekti, kieli: Kieli): string {
+export const linkJatkoPaatos1: JulkinenLinkFunction = (projekti, kieli) => {
   return linkSuunnitelma(projekti, kieli) + "/jatkopaatos1";
-}
+};
 
-export function linkJatkoPaatos2(projekti: LinkableProjekti, kieli: Kieli): string {
+export const linkJatkoPaatos2: JulkinenLinkFunction = (projekti, kieli) => {
   return linkSuunnitelma(projekti, kieli) + "/jatkopaatos2";
-}
+};
 
 export function linkSuunnitelmaYllapito(oid: string): string {
   return "https://" + process.env.FRONTEND_API_DOMAIN_NAME + "/yllapito/projekti/" + oid;

--- a/src/components/projekti/lukutila/HenkilotLukutila.tsx
+++ b/src/components/projekti/lukutila/HenkilotLukutila.tsx
@@ -1,8 +1,7 @@
 import HassuGrid from "@components/HassuGrid";
 import HassuGridItem from "@components/HassuGridItem";
 import Section from "@components/layout/Section";
-import { ProjektiKayttaja } from "@services/api";
-import lowerCase from "lodash/lowerCase";
+import { KayttajaTyyppi, ProjektiKayttaja } from "@services/api";
 import { formatNimi } from "../../../util/userUtil";
 
 type Props = {
@@ -14,15 +13,12 @@ export default function HenkilotLukutila({ kayttoOikeudet }: Props) {
       <p>Projektiin voi lisätä henkilöitä tai muokata heidän oikeuksiaan, kun pääkäyttäjä on palauttanut projektin aktiiviseen tilaan.</p>
       <HassuGrid cols={{ xs: 1, md: 2, lg: 4, xl: 5 }}>
         {kayttoOikeudet.map((hlo) => {
-          const tyyppi = lowerCase(hlo.tyyppi || "Muu henkilö");
-          const label = tyyppi.charAt(0).toUpperCase() + tyyppi.slice(1);
+          const tyyppi = getTyyppiText(hlo);
           return (
             <HassuGridItem key={hlo.kayttajatunnus}>
-              <p className="vayla-label">{label}</p>
+              <p className="vayla-label">{tyyppi}</p>
               <p className="mb-0">{hlo.organisaatio}</p>
-              <p className="mb-0">
-                {formatNimi(hlo)}
-              </p>
+              <p className="mb-0">{formatNimi(hlo)}</p>
               <p>{hlo.puhelinnumero}</p>
             </HassuGridItem>
           );
@@ -30,4 +26,17 @@ export default function HenkilotLukutila({ kayttoOikeudet }: Props) {
       </HassuGrid>
     </Section>
   );
+}
+
+function getTyyppiText(hlo: ProjektiKayttaja) {
+  let text = "Muu henkilö";
+  switch (hlo.tyyppi) {
+    case KayttajaTyyppi.PROJEKTIPAALLIKKO:
+      text = "Projektipäällikkö";
+      break;
+    case KayttajaTyyppi.VARAHENKILO:
+      text = "Varahenkilö";
+      break;
+  }
+  return text;
 }

--- a/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/HyvaksymisPaatosTiedostotTaulu.tsx
+++ b/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/HyvaksymisPaatosTiedostotTaulu.tsx
@@ -1,10 +1,9 @@
 import IconButton from "@components/button/IconButton";
 import HassuTable from "@components/table/HassuTable";
 import HassuAineistoNimiExtLink from "@components/projekti/HassuAineistoNimiExtLink";
-import { Aineisto, AineistoInput, AineistoTila } from "@services/api";
+import { Aineisto, AineistoInput, AineistoTila, HyvaksymisPaatosVaihe } from "@services/api";
 import React, { ComponentProps, useCallback, useMemo } from "react";
 import { FieldArrayWithId, useFieldArray, UseFieldArrayAppend, UseFieldArrayRemove, useFormContext } from "react-hook-form";
-import { useProjekti } from "src/hooks/useProjekti";
 import { formatDateTime } from "hassu-common/util/dateUtils";
 import { ColumnDef, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { experimental_sx as sx, MUIStyledCommonProps, styled } from "@mui/system";
@@ -18,8 +17,7 @@ interface FormValues {
 
 type FormAineisto = FieldArrayWithId<FormValues, "hyvaksymisPaatos", "id"> & Pick<Aineisto, "tila" | "tuotu" | "tiedosto">;
 
-export default function AineistoTable() {
-  const { data: projekti } = useProjekti();
+export default function AineistoTable({ vaihe }: { vaihe: HyvaksymisPaatosVaihe | null | undefined }) {
   const { control, formState, register, setValue } = useFormContext<FormValues>();
   const { fields, move, remove } = useFieldArray({ name: "hyvaksymisPaatos", control });
   const { append: appendToPoistetut } = useFieldArray({ name: "poistetutHyvaksymisPaatos", control });
@@ -27,12 +25,12 @@ export default function AineistoTable() {
   const enrichedFields: FormAineisto[] = useMemo(
     () =>
       fields.map((field) => {
-        const aineistoData = projekti?.hyvaksymisPaatosVaihe?.hyvaksymisPaatos || [];
+        const aineistoData = vaihe?.hyvaksymisPaatos || [];
         const { tila, tuotu, tiedosto } = aineistoData.find(({ uuid }) => uuid === field.uuid) || {};
 
         return { ...field, tila: tila ?? AineistoTila.ODOTTAA_TUONTIA, tuotu, tiedosto };
       }),
-    [fields, projekti]
+    [fields, vaihe?.hyvaksymisPaatos]
   );
 
   const columns = useMemo<ColumnDef<FormAineisto>[]>(

--- a/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/MuokkaustilainenPaatosTiedostot.tsx
+++ b/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/MuokkaustilainenPaatosTiedostot.tsx
@@ -7,12 +7,14 @@ import { PaatosTyyppi } from "common/hyvaksymisPaatosUtil";
 import { getPaatosInfoText } from "../textsForDifferentPaatos";
 import { HyvaksymisPaatosVaiheAineistotFormValues } from "..";
 import { adaptVelhoAineistoToAineistoInput, combineOldAndNewAineisto } from "@components/projekti/common/Aineistot/util";
+import { HyvaksymisPaatosVaihe } from "@services/api";
 
 type Props = {
   paatosTyyppi: PaatosTyyppi;
+  vaihe: HyvaksymisPaatosVaihe | null | undefined;
 };
 
-export default function MuokkaustilainenPaatosTiedostot({ paatosTyyppi }: Props) {
+export default function MuokkaustilainenPaatosTiedostot({ paatosTyyppi, vaihe }: Props) {
   const { watch, control } = useFormContext<HyvaksymisPaatosVaiheAineistotFormValues>();
   const hyvaksymisPaatos = watch("hyvaksymisPaatos");
   const { replace: replaceHyvaksymisPaatos } = useFieldArray({ control, name: "hyvaksymisPaatos" });
@@ -22,7 +24,7 @@ export default function MuokkaustilainenPaatosTiedostot({ paatosTyyppi }: Props)
   return (
     <>
       <p>{getPaatosInfoText(paatosTyyppi)}</p>
-      {!!hyvaksymisPaatos?.length && <HyvaksymisPaatosTiedostot />}
+      {!!hyvaksymisPaatos?.length && <HyvaksymisPaatosTiedostot vaihe={vaihe} />}
       <Button type="button" onClick={() => setPaatosDialogOpen(true)} id="tuo_paatos_button">
         Tuo päätös
       </Button>

--- a/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/index.tsx
+++ b/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/index.tsx
@@ -17,7 +17,7 @@ export default function TiedostoLomake({ paatosTyyppi, vaihe }: TiedostoLomakePr
       {vaihe?.muokkausTila === MuokkausTila.AINEISTO_MUOKKAUS ? (
         <LukutilainenPaatos vaihe={vaihe} />
       ) : (
-        <MuokkaustilainenPaatosTiedostot paatosTyyppi={paatosTyyppi} />
+        <MuokkaustilainenPaatosTiedostot vaihe={vaihe} paatosTyyppi={paatosTyyppi} />
       )}
     </>
   );

--- a/src/locales/fi/projekti.json
+++ b/src/locales/fi/projekti.json
@@ -62,7 +62,7 @@
     "kuulutus_suunnitelman_hyvaksymisesta": "Kuulutus suunnitelman hyväksymisestä",
     "kuulutus_hyvaksymispaatoksen_jatkamisesta": "Kuulutus hyväksymispäätöksen jatkamisesta",
     "kuulutus_suunnitelman_nahtaville_asettamisesta": "Kuulutus suunnitelman nähtäville asettamisesta",
-    "kuulutus_suunnitelman_hyvaksymispaatoksestä": "Kuulutus suunnitelman hyväksymispäätöksestä",
+    "kuulutus_suunnitelman_hyvaksymispaatoksesta": "Kuulutus suunnitelman hyväksymispäätöksestä",
     "kuulutus_jatkopaatoksesta": "Kuulutus jatkopäätöksestä",
     "kuulutus_suunnitelman_hyvaksymispaatoksen_voimassaoloajan_pidentamisesta": "Kuulutus suunnitelman hyväksymispäätöksen voimassaoloajan pidentämisestä",
     "nahtavillaoloaika": "Nähtävilläoloaika",

--- a/src/locales/sv/projekti.json
+++ b/src/locales/sv/projekti.json
@@ -62,7 +62,7 @@
     "kuulutus_suunnitelman_hyvaksymisesta": "Kungörelse om godkännande av planen",
     "kuulutus_hyvaksymispaatoksen_jatkamisesta": "Kungörelse om förlängning av beslutet om godkännande",
     "kuulutus_suunnitelman_nahtaville_asettamisesta": "Kungörelse om framläggande av plan",
-    "kuulutus_suunnitelman_hyvaksymispaatoksestä": "Kungörelse av beslutet att godkänna planen",
+    "kuulutus_suunnitelman_hyvaksymispaatoksesta": "Kungörelse av beslutet att godkänna planen",
     "kuulutus_jatkopaatoksesta": "Meddelande om beslut om fortsättning",
     "kuulutus_suunnitelman_hyvaksymispaatoksen_voimassaoloajan_pidentamisesta": "Meddelande om förlängning av giltighetstiden för beslutet om plangodkännande",
     "nahtavillaoloaika": "Framläggningstid",


### PR DESCRIPTION
Jatkopäätöksien käsittelyissä oli selkeitä puutteita. 

- Syöteindeksiin ei mennyt 1. tai 2. jatkopäätöksistä dokumentteja.
-  `2. jatkopäätökseen migroidut projektit ei saanut oikeita statuksia kun 2. kuulutus julkaistiin. Seurauksena oli se, ettei projektia/suunnitelmaa ikinä näkynyt julkisella puolella

Lisäksi korjattu

- Lisätty ääkköstystä Henkilöt -sivulle
- Korjattu muokkaustilaisilla sivuilla olevien päätöstiedostojen tilan näyttäminen
- Lisätty puuttuvia parametreja asiakirjaHandlerista