### PR TITLE
feat: hassuyp 397 hyv es fe runko

### DIFF
--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -20,7 +20,26 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
   const useFormReturn = useForm<TallennaHyvaksymisEsitysInput>(formOptions);
   return (
     <FormProvider {...useFormReturn}>
-      <form></form>
+      <form>
+        <div>
+          <h2 className="vayla-title">Hyväksymisesityksen sisältö</h2>
+          <h3 className="vayla-subtitle">Linkin voimassaoloaika</h3>
+          <h3 className="vayla-subtitle">Viesti vastaanottajille</h3>
+          <h3 className="vayla-subtitle">Laskutustiedot hyväksymismaksua varten</h3>
+        </div>
+        <div>
+          <h2 className="vayla-title">Hyväksymisesitykseen liitettävä aineisto</h2>
+          <h3 className="vayla-subtitle">Linkki hyväksymisesityksen aineistoon</h3>
+          <h3 className="vayla-subtitle">Hyväksymisesitys</h3>
+          <h3 className="vayla-subtitle">Suunnitelma</h3>
+          <h3 className="vayla-subtitle">Vuorovaikutus</h3>
+          <h3 className="vayla-subtitle">Muu tekninen aineisto</h3>
+        </div>
+        <div>
+          <h3 className="vayla-subtitle">Hyväksymisesityksen vastaanottajat</h3>
+          <h3 className="vayla-subtitle">Hyväksymisesityksen sisällön esikatselu</h3>
+        </div>
+      </form>
     </FormProvider>
   );
 }

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -1,0 +1,5 @@
+import { HyvaksymisEsityksenTiedot } from "@services/api";
+
+export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
+  return <></>;
+}

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -1,5 +1,26 @@
-import { HyvaksymisEsityksenTiedot } from "@services/api";
+import { HyvaksymisEsityksenTiedot, TallennaHyvaksymisEsitysInput } from "@services/api";
+import { useMemo } from "react";
+import { FormProvider, UseFormProps, useForm } from "react-hook-form";
+import getDefaultValuesForForm from "./getDefaultValuesForForm";
 
 export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
-  return <></>;
+  const defaultValues: TallennaHyvaksymisEsitysInput = useMemo(
+    () => getDefaultValuesForForm(hyvaksymisEsityksenTiedot),
+    [hyvaksymisEsityksenTiedot]
+  );
+
+  const formOptions: UseFormProps<TallennaHyvaksymisEsitysInput> = {
+    //resolver: yupResolver(hyvaksymisEsitysSchema, { abortEarly: false, recursive: true }),
+    defaultValues,
+    mode: "onChange",
+    reValidateMode: "onChange",
+    //context: { hyvaksymisEsityksenTiedot, validationMode },
+  };
+
+  const useFormReturn = useForm<TallennaHyvaksymisEsitysInput>(formOptions);
+  return (
+    <FormProvider {...useFormReturn}>
+      <form></form>
+    </FormProvider>
+  );
 }

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -3,6 +3,14 @@ import { useMemo } from "react";
 import { FormProvider, UseFormProps, useForm } from "react-hook-form";
 import getDefaultValuesForForm from "./getDefaultValuesForForm";
 import MuuTekninenAineisto from "./MuuTekninenAineisto";
+import Section from "@components/layout/Section2";
+import { Stack } from "@mui/material";
+import Button from "@components/button/Button";
+import useLoadingSpinner from "src/hooks/useLoadingSpinner";
+import useApi from "src/hooks/useApi";
+import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
+import useSnackbars from "src/hooks/useSnackbars";
+import log from "loglevel";
 
 export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const defaultValues: TallennaHyvaksymisEsitysInput = useMemo(
@@ -19,6 +27,26 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
   };
 
   const useFormReturn = useForm<TallennaHyvaksymisEsitysInput>(formOptions);
+  const { withLoadingSpinner } = useLoadingSpinner();
+  const api = useApi();
+  const { mutate: reloadData } = useHyvaksymisEsitys();
+  const { showSuccessMessage } = useSnackbars();
+
+  const save = (formData: TallennaHyvaksymisEsitysInput) =>
+    withLoadingSpinner(
+      (async () => {
+        try {
+          await api.tallennaHyvaksymisEsitys(formData);
+
+          await reloadData();
+
+          showSuccessMessage("Tallennus onnistui");
+        } catch (e) {
+          log.error("OnSubmit Error", e);
+        }
+      })()
+    );
+
   return (
     <FormProvider {...useFormReturn}>
       <form>
@@ -40,6 +68,13 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
           <h3 className="vayla-subtitle">Hyväksymisesityksen vastaanottajat</h3>
           <h3 className="vayla-subtitle">Hyväksymisesityksen sisällön esikatselu</h3>
         </div>
+        <Section noDivider>
+          <Stack justifyContent={{ md: "flex-end" }} direction={{ xs: "column", md: "row" }}>
+            <Button primary id="save" onClick={useFormReturn.handleSubmit(save)}>
+              Tallenna
+            </Button>
+          </Stack>
+        </Section>
       </form>
     </FormProvider>
   );

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -2,6 +2,7 @@ import { HyvaksymisEsityksenTiedot, TallennaHyvaksymisEsitysInput } from "@servi
 import { useMemo } from "react";
 import { FormProvider, UseFormProps, useForm } from "react-hook-form";
 import getDefaultValuesForForm from "./getDefaultValuesForForm";
+import MuuTekninenAineisto from "./MuuTekninenAineisto";
 
 export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const defaultValues: TallennaHyvaksymisEsitysInput = useMemo(
@@ -33,7 +34,7 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
           <h3 className="vayla-subtitle">Hyväksymisesitys</h3>
           <h3 className="vayla-subtitle">Suunnitelma</h3>
           <h3 className="vayla-subtitle">Vuorovaikutus</h3>
-          <h3 className="vayla-subtitle">Muu tekninen aineisto</h3>
+          <MuuTekninenAineisto />
         </div>
         <div>
           <h3 className="vayla-subtitle">Hyväksymisesityksen vastaanottajat</h3>

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -6,11 +6,9 @@ import MuuTekninenAineisto from "./MuuTekninenAineisto";
 import Section from "@components/layout/Section2";
 import { Stack } from "@mui/material";
 import Button from "@components/button/Button";
-import useLoadingSpinner from "src/hooks/useLoadingSpinner";
 import useApi from "src/hooks/useApi";
 import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
-import useSnackbars from "src/hooks/useSnackbars";
-import log from "loglevel";
+import useSpinnerAndSuccessMessage from "src/hooks/useSpinnerAndSuccessMessage";
 
 export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const defaultValues: TallennaHyvaksymisEsitysInput = useMemo(
@@ -27,25 +25,13 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
   };
 
   const useFormReturn = useForm<TallennaHyvaksymisEsitysInput>(formOptions);
-  const { withLoadingSpinner } = useLoadingSpinner();
   const api = useApi();
   const { mutate: reloadData } = useHyvaksymisEsitys();
-  const { showSuccessMessage } = useSnackbars();
 
-  const save = (formData: TallennaHyvaksymisEsitysInput) =>
-    withLoadingSpinner(
-      (async () => {
-        try {
-          await api.tallennaHyvaksymisEsitys(formData);
-
-          await reloadData();
-
-          showSuccessMessage("Tallennus onnistui");
-        } catch (e) {
-          log.error("OnSubmit Error", e);
-        }
-      })()
-    );
+  const save = useSpinnerAndSuccessMessage(async (formData: TallennaHyvaksymisEsitysInput) => {
+    await api.tallennaHyvaksymisEsitys(formData);
+    await reloadData();
+  }, "Tallennus onnistui");
 
   return (
     <FormProvider {...useFormReturn}>

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
@@ -1,0 +1,5 @@
+import { HyvaksymisEsityksenTiedot } from "@services/api";
+
+export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
+  return <>{hyvaksymisEsityksenTiedot}</>;
+}

--- a/src/components/HyvaksymisEsitys/MuuTekninenAineisto.tsx
+++ b/src/components/HyvaksymisEsitys/MuuTekninenAineisto.tsx
@@ -1,0 +1,49 @@
+import Section from "@components/layout/Section2";
+import { ReactElement, useRef } from "react";
+import { allowedFileTypes } from "hassu-common/fileValidationSettings";
+import Button from "@components/button/Button";
+import useHandleUploadedFiles from "src/hooks/useHandleUploadedFiles";
+import { TallennaHyvaksymisEsitysInput } from "@services/api";
+import { useFormContext } from "react-hook-form";
+
+export default function MuuTekninenAineisto(): ReactElement {
+  const hiddenInputRef = useRef<HTMLInputElement | null>();
+  const { watch } = useFormContext<TallennaHyvaksymisEsitysInput>();
+  const muuAineistoKoneelta = watch(`muokattavaHyvaksymisEsitys.muuAineistoKoneelta`);
+  const handleUploadedFiles = useHandleUploadedFiles(`muokattavaHyvaksymisEsitys.muuAineistoKoneelta`);
+
+  const onButtonClick = () => {
+    if (hiddenInputRef.current) {
+      hiddenInputRef.current.click();
+    }
+  };
+
+  return (
+    <Section>
+      <h3 className="vayla-subtitle">Muu tekninen aineisto</h3>
+      <p>Voit halutessasi liittää...</p>
+      <h4 className="vayla-small-title">Projektivelho</h4>
+      <h4 className="vayla-small-title">Omalta koneelta</h4>
+      <p>Voit halutessasi liittää...</p>
+      {!!muuAineistoKoneelta?.length && muuAineistoKoneelta.map((aineisto, index) => <div key={index}>{aineisto.nimi}</div>)}
+      <input
+        type="file"
+        multiple
+        accept={allowedFileTypes.join(", ")}
+        style={{ display: "none" }}
+        id={`muu-aineisto-koneelta-input`}
+        onChange={handleUploadedFiles}
+        ref={(e) => {
+          if (hiddenInputRef) {
+            hiddenInputRef.current = e;
+          }
+        }}
+      />
+      <label htmlFor={`muu-aineisto-koneelta-input`}>
+        <Button className="mt-4" type="button" id={`tuo_muu_aineisto_button`} onClick={onButtonClick}>
+          Tuo tiedostot
+        </Button>
+      </label>
+    </Section>
+  );
+}

--- a/src/components/HyvaksymisEsitys/getDefaultValuesForForm.ts
+++ b/src/components/HyvaksymisEsitys/getDefaultValuesForForm.ts
@@ -1,0 +1,117 @@
+import {
+  AineistoInputNew,
+  AineistoNew,
+  HyvaksymisEsityksenTiedot,
+  KunnallinenLadattuTiedosto,
+  KunnallinenLadattuTiedostoInput,
+  LadattuTiedostoInputNew,
+  LadattuTiedostoNew,
+  TallennaHyvaksymisEsitysInput,
+} from "@services/api";
+
+export default function getDefaultValuesForForm(hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot): TallennaHyvaksymisEsitysInput {
+  const { oid, versio, hyvaksymisEsitys: muokattavaHyvaksymisEsitys } = hyvaksymisEsityksenTiedot;
+
+  if (!muokattavaHyvaksymisEsitys) {
+    return {
+      oid,
+      versio,
+      muokattavaHyvaksymisEsitys: {
+        poistumisPaiva: "",
+      },
+    };
+  }
+  const {
+    poistumisPaiva,
+    kiireellinen,
+    lisatiedot,
+    laskutustiedot,
+    hyvaksymisEsitys,
+    suunnitelma,
+    muistutukset,
+    lausunnot,
+    kuulutuksetJaKutsu,
+    muuAineistoVelhosta,
+    muuAineistoKoneelta,
+    maanomistajaluettelo,
+    vastaanottajat,
+  } = muokattavaHyvaksymisEsitys;
+  const { yTunnus, ovtTunnus, verkkolaskuoperaattorinTunnus, viitetieto } = laskutustiedot ?? {};
+  return {
+    oid,
+    versio,
+    muokattavaHyvaksymisEsitys: {
+      poistumisPaiva: poistumisPaiva ?? "",
+      kiireellinen: kiireellinen ?? false,
+      lisatiedot: lisatiedot ?? "",
+      laskutustiedot: {
+        yTunnus,
+        ovtTunnus,
+        verkkolaskuoperaattorinTunnus,
+        viitetieto,
+      },
+      hyvaksymisEsitys: adaptLadatutTiedostotNewToInput(hyvaksymisEsitys),
+      suunnitelma: adaptAineistotNewToInput(suunnitelma),
+      muistutukset: adaptKunnallisetLadatutTiedostoToInput(muistutukset),
+      lausunnot: adaptLadatutTiedostotNewToInput(lausunnot),
+      kuulutuksetJaKutsu: adaptLadatutTiedostotNewToInput(kuulutuksetJaKutsu),
+      muuAineistoVelhosta: adaptAineistotNewToInput(muuAineistoVelhosta),
+      muuAineistoKoneelta: adaptLadatutTiedostotNewToInput(muuAineistoKoneelta),
+      maanomistajaluettelo: adaptLadatutTiedostotNewToInput(maanomistajaluettelo),
+      vastaanottajat: vastaanottajat?.map(({ sahkoposti }) => sahkoposti) ?? [],
+    },
+  };
+}
+
+function adaptLadatutTiedostotNewToInput(ladatutTiedostot: LadattuTiedostoNew[] | undefined | null): LadattuTiedostoInputNew[] {
+  if (!ladatutTiedostot) {
+    return [];
+  }
+  return ladatutTiedostot.map(adaptLadattuTiedostoNewToInput);
+}
+
+function adaptLadattuTiedostoNewToInput(ladattuTiedosto: LadattuTiedostoNew): LadattuTiedostoInputNew {
+  const { nimi, uuid, jarjestys } = ladattuTiedosto;
+  return {
+    nimi,
+    uuid,
+    jarjestys,
+  };
+}
+
+function adaptKunnallisetLadatutTiedostoToInput(
+  ladatutTiedostot: KunnallinenLadattuTiedosto[] | undefined | null
+): KunnallinenLadattuTiedostoInput[] {
+  if (!ladatutTiedostot) {
+    return [];
+  }
+  return ladatutTiedostot.map(adaptKunnallinenLadattuTiedostoToInput);
+}
+
+function adaptKunnallinenLadattuTiedostoToInput(ladattuTiedosto: KunnallinenLadattuTiedosto): KunnallinenLadattuTiedostoInput {
+  const { nimi, uuid, jarjestys, kunta } = ladattuTiedosto;
+  return {
+    nimi,
+    uuid,
+    jarjestys,
+    kunta,
+  };
+}
+
+function adaptAineistotNewToInput(aineistot: AineistoNew[] | undefined | null): AineistoInputNew[] {
+  if (!aineistot) {
+    return [];
+  }
+  return aineistot.map(adaptAineistoNewToInput);
+}
+
+function adaptAineistoNewToInput(aineisto: AineistoNew): AineistoInputNew {
+  const { dokumenttiOid, uuid, kategoriaId, nimi, jarjestys } = aineisto;
+  return {
+    dokumenttiOid,
+    uuid,
+    kategoriaId,
+    nimi,
+    jarjestys,
+  };
+}

--- a/src/hooks/useHandleUploadedFiles.ts
+++ b/src/hooks/useHandleUploadedFiles.ts
@@ -1,0 +1,66 @@
+import { allowedFileTypes } from "common/fileValidationSettings";
+import { lataaTiedosto } from "../util/fileUtil";
+import { LadattuTiedostoInputNew } from "@services/api";
+import { uuid } from "common/util/uuid";
+import { FieldValues, Path, PathValue, UnpackNestedValue, useFormContext } from "react-hook-form";
+import useApi from "src/hooks/useApi";
+import useSnackbars from "src/hooks/useSnackbars";
+import useLoadingSpinner from "src/hooks/useLoadingSpinner";
+import { useCallback } from "react";
+
+/**
+ *
+ * @param keyToLadatutTiedostot avain FielValueseissa, jonka takana on LadattuTiedostoNew[]-tyyppistä dataa
+ * @returns funktio, jonka voi antaa monivalinta-tiedosto-inputin onChange-kohtaan
+ */
+export default function useHandleUploadedFiles<F extends FieldValues>(keyToLadatutTiedostot: Path<F>) {
+  const { setValue, watch } = useFormContext<F>();
+  const ladatutTiedostot = watch(keyToLadatutTiedostot);
+
+  const { withLoadingSpinner } = useLoadingSpinner();
+  const { showErrorMessage } = useSnackbars();
+  const api = useApi();
+
+  return useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) =>
+      withLoadingSpinner(
+        (async () => {
+          const files: FileList | null = event.target.files;
+
+          if (files?.length) {
+            const nonAllowedTypeFiles: File[] = [];
+            const allowedTypeFiles: File[] = [];
+            const uploadedFileNamesPromises: Promise<string>[] = [];
+
+            Array.from(Array(files.length).keys()).forEach((key: number) => {
+              if (allowedFileTypes.find((type) => type === files[key].type)) {
+                uploadedFileNamesPromises.push(lataaTiedosto(api, files[key]));
+                allowedTypeFiles.push(files[key]);
+              } else {
+                nonAllowedTypeFiles.push(files[key]);
+              }
+            });
+
+            const uploadedFileNames: string[] = await Promise.all(uploadedFileNamesPromises);
+
+            const tiedostoInputs: LadattuTiedostoInputNew[] = uploadedFileNames.map((filename, index) => ({
+              nimi: allowedTypeFiles[index].name,
+              tiedosto: filename,
+              uuid: uuid.v4(),
+            }));
+
+            const newValue = ((ladatutTiedostot ?? []) as LadattuTiedostoInputNew[]).concat(tiedostoInputs);
+            setValue(keyToLadatutTiedostot, newValue as UnpackNestedValue<PathValue<F, Path<F>>>, {
+              shouldDirty: true,
+            });
+
+            if (nonAllowedTypeFiles.length) {
+              const nonAllowedTypeFileNames = nonAllowedTypeFiles.map((f) => f.name);
+              showErrorMessage("Väärä tiedostotyyppi: " + nonAllowedTypeFileNames + ". Sallitut tyypit JPG, PNG, PDF ja MS Word.");
+            }
+          }
+        })()
+      ),
+    [api, keyToLadatutTiedostot, ladatutTiedostot, setValue, showErrorMessage, withLoadingSpinner]
+  );
+}

--- a/src/hooks/useHyvaksymisEsitys.ts
+++ b/src/hooks/useHyvaksymisEsitys.ts
@@ -1,0 +1,26 @@
+import { NykyinenKayttaja, apiConfig } from "@services/api";
+import { useCallback } from "react";
+import useApi from "./useApi";
+import useSWR from "swr";
+import { useRouter } from "next/router";
+import useCurrentUser from "./useCurrentUser";
+
+export default function useHyvaksymisEsitys() {
+  const api = useApi();
+  const router = useRouter();
+  const oid = router.query.oid;
+  const { data: kayttaja } = useCurrentUser();
+  const hyvaksymisEsitysLoader = useCallback(
+    async (_query: string, oid: string | undefined, kayttaja: NykyinenKayttaja | undefined) => {
+      if (!oid) {
+        return null;
+      }
+      if (!kayttaja) {
+        return null;
+      }
+      return await api.haeHyvaksymisEsityksenTiedot(oid);
+    },
+    [api]
+  );
+  return useSWR([apiConfig.haeHyvaksymisEsityksenTiedot.graphql, oid, kayttaja], hyvaksymisEsitysLoader);
+}

--- a/src/hooks/useSpinnerAndSuccessMessage.ts
+++ b/src/hooks/useSpinnerAndSuccessMessage.ts
@@ -1,0 +1,26 @@
+import log from "loglevel";
+import useLoadingSpinner from "./useLoadingSpinner";
+import useSnackbars from "./useSnackbars";
+
+/**
+ *
+ * @param func asynktroninen funktio, joka ajetaan spinnerin kanssa, ja jonka jälkeen tulee annettu successMessage, jos ei tule virhetilannetta
+ * @param successMessage Viesti, joka näytetään funktion onnistuneen suorituksen jälkeen
+ * @param errorText Viesti, joka tulee virheen eteen logitukseen. Oletuksena "Error".
+ * @returns asynkroninen funktio, joka ajaa annetun funktion spinnerillä varustettuna ja näyttää onnistumisviestin suorituksen päätteeksi
+ */
+export default function useSpinnerAndSuccessMessage(func: (...props: any) => Promise<any>, successMessage: string, errorText?: string) {
+  const { withLoadingSpinner } = useLoadingSpinner();
+  const { showSuccessMessage } = useSnackbars();
+  return (...props: any) =>
+    withLoadingSpinner(
+      (async () => {
+        try {
+          await func(...props);
+          showSuccessMessage(successMessage);
+        } catch (e) {
+          log.error(errorText ?? "Error", e);
+        }
+      })()
+    );
+}

--- a/src/pages/yllapito/projekti/[oid]/hyvaksymisesitys.tsx
+++ b/src/pages/yllapito/projekti/[oid]/hyvaksymisesitys.tsx
@@ -1,0 +1,50 @@
+import HyvaksymisEsitysLomake from "@components/HyvaksymisEsitys/HyvaksymisEsitysLomake";
+import HyvaksymisEsitysLukutila from "@components/HyvaksymisEsitys/HyvaksymisEsitysLukutila";
+import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
+import { HyvaksymisTila, NykyinenKayttaja, Vaihe, apiConfig } from "@services/api";
+import { useRouter } from "next/router";
+import { ReactElement, useCallback } from "react";
+import useApi from "src/hooks/useApi";
+import useCurrentUser from "src/hooks/useCurrentUser";
+import useSWR from "swr";
+
+export default function HyvaksymisEsitysPage(): ReactElement {
+  const api = useApi();
+  const router = useRouter();
+  const oid = router.query.oid;
+  const { data: kayttaja } = useCurrentUser();
+  const hyvaksymisEsitysLoader = useCallback(
+    async (_query: string, oid: string | undefined, kayttaja: NykyinenKayttaja | undefined) => {
+      if (!oid) {
+        return null;
+      }
+      if (!kayttaja) {
+        return null;
+      }
+      return await api.haeHyvaksymisEsityksenTiedot(oid);
+    },
+    [api]
+  );
+  const { data: hyvaksymisEsityksenTiedot } = useSWR(
+    [apiConfig.haeHyvaksymisEsityksenTiedot.graphql, oid, kayttaja],
+    hyvaksymisEsitysLoader
+  );
+
+  const muokkaustila =
+    !hyvaksymisEsityksenTiedot?.hyvaksymisEsitys || hyvaksymisEsityksenTiedot?.hyvaksymisEsitys?.tila == HyvaksymisTila.MUOKKAUS;
+
+  return (
+    <>
+      {hyvaksymisEsityksenTiedot && (
+        // TODO: Uusi oma vaihe Hyväksymisesitykselle(?), ja vaihda alta vaihe vastaavaksi
+        <ProjektiPageLayout title="Hyväksymisesitys" vaihe={Vaihe.HYVAKSYMISPAATOS} showInfo={muokkaustila}>
+          {muokkaustila ? (
+            <HyvaksymisEsitysLomake hyvaksymisEsityksenTiedot={hyvaksymisEsityksenTiedot} />
+          ) : (
+            <HyvaksymisEsitysLukutila hyvaksymisEsityksenTiedot={hyvaksymisEsityksenTiedot} />
+          )}
+        </ProjektiPageLayout>
+      )}
+    </>
+  );
+}

--- a/src/pages/yllapito/projekti/[oid]/hyvaksymisesitys.tsx
+++ b/src/pages/yllapito/projekti/[oid]/hyvaksymisesitys.tsx
@@ -1,34 +1,12 @@
 import HyvaksymisEsitysLomake from "@components/HyvaksymisEsitys/HyvaksymisEsitysLomake";
 import HyvaksymisEsitysLukutila from "@components/HyvaksymisEsitys/HyvaksymisEsitysLukutila";
 import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
-import { HyvaksymisTila, NykyinenKayttaja, Vaihe, apiConfig } from "@services/api";
-import { useRouter } from "next/router";
-import { ReactElement, useCallback } from "react";
-import useApi from "src/hooks/useApi";
-import useCurrentUser from "src/hooks/useCurrentUser";
-import useSWR from "swr";
+import { HyvaksymisTila, Vaihe } from "@services/api";
+import { ReactElement } from "react";
+import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
 
 export default function HyvaksymisEsitysPage(): ReactElement {
-  const api = useApi();
-  const router = useRouter();
-  const oid = router.query.oid;
-  const { data: kayttaja } = useCurrentUser();
-  const hyvaksymisEsitysLoader = useCallback(
-    async (_query: string, oid: string | undefined, kayttaja: NykyinenKayttaja | undefined) => {
-      if (!oid) {
-        return null;
-      }
-      if (!kayttaja) {
-        return null;
-      }
-      return await api.haeHyvaksymisEsityksenTiedot(oid);
-    },
-    [api]
-  );
-  const { data: hyvaksymisEsityksenTiedot } = useSWR(
-    [apiConfig.haeHyvaksymisEsityksenTiedot.graphql, oid, kayttaja],
-    hyvaksymisEsitysLoader
-  );
+  const { data: hyvaksymisEsityksenTiedot } = useHyvaksymisEsitys();
 
   const muokkaustila =
     !hyvaksymisEsityksenTiedot?.hyvaksymisEsitys || hyvaksymisEsityksenTiedot?.hyvaksymisEsitys?.tila == HyvaksymisTila.MUOKKAUS;


### PR DESCRIPTION
Hahmottelua sille, miten hyväksymisesityksen FE-puolen jäsentelisi. Toteutettu toimiva lomake, jossa on tosin mukana vasta vain yksi datapiste (muu aineisto koneelta on mahdollista lisätä).