### PR TITLE
feat: hassuyp 404 hyv es tilasiirtymat

### DIFF
--- a/backend/integrationtest/HyvaksymisEsitys/adaptHyvaksymisEsitysToAPI.test.ts
+++ b/backend/integrationtest/HyvaksymisEsitys/adaptHyvaksymisEsitysToAPI.test.ts
@@ -153,7 +153,8 @@ describe("adaptHyvaksymisEsitysToApi", () => {
       salt: "jotain",
       muokattavaHyvaksymisEsitys: {
         ...TEST_HYVAKSYMISESITYS,
-        tila: API.HyvaksymisTila.HYVAKSYTTY,
+        tila: API.HyvaksymisTila.MUOKKAUS,
+        palautusSyy: "Huono",
       },
       julkaistuHyvaksymisEsitys: {
         ...TEST_HYVAKSYMISESITYS,
@@ -184,7 +185,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           nimi: "hyvaksymisEsitys äöå .png",
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "hyvaksymis-esitys-uuid",
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/hyvaksymisEsitys/hyvaksymisEsitys_aoa_.png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/hyvaksymisEsitys/hyvaksymisEsitys_aoa_.png",
         },
       ],
       suunnitelma: [
@@ -197,7 +198,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "suunnitelma-uuid",
           tuotu: true,
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/suunnitelma/suunnitelma_aoa_.png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/suunnitelma/suunnitelma_aoa_.png",
         },
       ],
       muistutukset: [
@@ -208,7 +209,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "muistutukset-uuid",
           kunta: 1,
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/muistutukset/muistutukset äöå .png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/muistutukset/muistutukset äöå .png",
         },
       ],
       lausunnot: [
@@ -218,7 +219,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           nimi: "lausunnot äöå .png",
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "lausunnot-uuid",
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/lausunnot/lausunnot_aoa_.png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/lausunnot/lausunnot_aoa_.png",
         },
       ],
       kuulutuksetJaKutsu: [
@@ -228,7 +229,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           nimi: "kuulutuksetJaKutsu äöå .png",
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "kuulutuksetJaKutsu-uuid",
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/kuulutuksenJaKutsu/kuulutuksetJaKutsu_aoa_.png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/kuulutuksenJaKutsu/kuulutuksetJaKutsu_aoa_.png",
         },
       ],
       muuAineistoVelhosta: [
@@ -241,7 +242,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "muuAineistoVelhosta-uuid",
           tuotu: true,
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/muuAineistoVelhosta/muuAineistoVelhosta_aoa_.png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/muuAineistoVelhosta/muuAineistoVelhosta_aoa_.png",
         },
       ],
       muuAineistoKoneelta: [
@@ -251,7 +252,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           nimi: "muuAineistoKoneelta äöå .png",
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "muuAineistoKoneelta-uuid",
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/muuAineistoKoneelta/muuAineistoKoneelta_aoa_.png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/muuAineistoKoneelta/muuAineistoKoneelta_aoa_.png",
         },
       ],
       maanomistajaluettelo: [
@@ -261,7 +262,7 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           nimi: "maanomistajaluettelo äöå .png",
           lisatty: "2022-01-02T02:00:00+02:00",
           uuid: "maanomistajaluettelo-uuid",
-          tiedosto: "yllapito/tiedostot/projekti/1/hyvaksymisesitys/maanomistajaluettelo/maanomistajaluettelo_aoa_.png",
+          tiedosto: "yllapito/tiedostot/projekti/1/muokattava_hyvaksymisesitys/maanomistajaluettelo/maanomistajaluettelo_aoa_.png",
         },
       ],
       vastaanottajat: [
@@ -270,7 +271,8 @@ describe("adaptHyvaksymisEsitysToApi", () => {
           sahkoposti: "vastaanottaja@sahkoposti.fi",
         },
       ],
-      tila: "HYVAKSYTTY",
+      tila: "MUOKKAUS",
+      palautusSyy: "Huono",
       hash: "f67cde5bf0977767e610740d0196732784a101160024d848d8c0a894d267d2c276c08b06e5076972480e98cf12a431676b36bf30b7a221415f91f14a9e1186a8",
     });
   });

--- a/backend/integrationtest/HyvaksymisEsitys/haeTiedot.test.ts
+++ b/backend/integrationtest/HyvaksymisEsitys/haeTiedot.test.ts
@@ -1,0 +1,58 @@
+import sinon from "sinon";
+import { userService } from "../../src/user";
+import { UserFixture } from "../../test/fixture/userFixture";
+import { insertProjektiToDB, removeProjektiFromDB, setupLocalDatabase } from "../util/databaseUtil";
+import * as API from "hassu-common/graphql/apiModel";
+import TEST_HYVAKSYMISESITYS from "./TEST_HYVAKSYMISESITYS";
+import { haeHyvaksymisEsityksenTiedot } from "../../src/HyvaksymisEsitys/actions";
+import { expect } from "chai";
+
+describe("HaeHyvaksymisRsityksenTiedot", () => {
+  const userFixture = new UserFixture(userService);
+  setupLocalDatabase();
+  const oid = "Testi1";
+
+  afterEach(async () => {
+    // Poista projekti joka testin päätteeksi
+    await removeProjektiFromDB(oid);
+    userFixture.logout();
+  });
+
+  after(() => {
+    sinon.reset();
+    sinon.restore();
+  });
+
+  it("antaa muokkauksenVoiAvata=true, kun hyväksymisesitys on hyväksytty ja hyväksymispäätösvaihetta ei vielä ole", async () => {
+    userFixture.loginAsAdmin();
+    const muokattavaHyvaksymisEsitys = { ...TEST_HYVAKSYMISESITYS, tila: API.HyvaksymisTila.HYVAKSYTTY };
+    const julkaistuHyvaksymisEsitys = { ...TEST_HYVAKSYMISESITYS, hyvaksymisPaiva: "2022-01-01", hyvaksyja: "oid" };
+    const projektiBefore = {
+      oid,
+      versio: 2,
+      muokattavaHyvaksymisEsitys,
+      julkaistuHyvaksymisEsitys,
+      salt: "salt",
+    };
+    await insertProjektiToDB(projektiBefore);
+    const tiedot = await haeHyvaksymisEsityksenTiedot(oid);
+    expect(tiedot.muokkauksenVoiAvata).to.be.true;
+  });
+
+  it("antaa muokkauksenVoiAvata=false, kun hyväksymisesitys on hyväksytty ja hyväksymispäätösvaihetta on olemassa", async () => {
+    userFixture.loginAsAdmin();
+    const muokattavaHyvaksymisEsitys = { ...TEST_HYVAKSYMISESITYS, tila: API.HyvaksymisTila.HYVAKSYTTY };
+    const julkaistuHyvaksymisEsitys = { ...TEST_HYVAKSYMISESITYS, hyvaksymisPaiva: "2022-01-01", hyvaksyja: "oid" };
+    const projektiBefore = {
+      oid,
+      versio: 2,
+      muokattavaHyvaksymisEsitys,
+      julkaistuHyvaksymisEsitys,
+      hyvaksymisPaatosVaihe: { id: 1 },
+      salt: "salt",
+    };
+    await insertProjektiToDB(projektiBefore);
+    const tiedot = await haeHyvaksymisEsityksenTiedot(oid);
+    expect(tiedot.muokkauksenVoiAvata).to.be.false;
+  });
+});

--- a/backend/src/HyvaksymisEsitys/actions/haeTiedot.ts
+++ b/backend/src/HyvaksymisEsitys/actions/haeTiedot.ts
@@ -13,6 +13,6 @@ export default async function haeHyvaksymisEsityksenTiedot(oid: string): Promise
     oid,
     versio,
     hyvaksymisEsitys,
-    muokkauksenVoiAvata: !!hyvaksymisPaatosVaihe && hyvaksymisEsitys?.tila == API.HyvaksymisTila.HYVAKSYTTY,
+    muokkauksenVoiAvata: !hyvaksymisPaatosVaihe && hyvaksymisEsitys?.tila == API.HyvaksymisTila.HYVAKSYTTY,
   };
 }

--- a/backend/src/HyvaksymisEsitys/actions/tallennaJaLahetaHyvaksyttavaksi.ts
+++ b/backend/src/HyvaksymisEsitys/actions/tallennaJaLahetaHyvaksyttavaksi.ts
@@ -92,7 +92,7 @@ function validateUpcoming(muokattavaHyvaksymisEsitys: MuokattavaHyvaksymisEsitys
     throw new IllegalArgumentError("Hyväksymisesityksellä ei ole hyväksymisesitys-tiedostoa");
   }
   if (!muokattavaHyvaksymisEsitys.suunnitelma?.length) {
-    throw new IllegalArgumentError("Hyväksymisesityksellä ei ole hyväksymisesitys-tiedostoa");
+    throw new IllegalArgumentError("Hyväksymisesityksellä ei ole suunnitelmaa");
   }
   if (!muokattavaHyvaksymisEsitys.muistutukset?.length) {
     throw new IllegalArgumentError("Hyväksymisesityksellä ei ole muistutuksia");

--- a/backend/src/HyvaksymisEsitys/adaptToApi/adaptHyvaksymisEsitysToAPI.ts
+++ b/backend/src/HyvaksymisEsitys/adaptToApi/adaptHyvaksymisEsitysToAPI.ts
@@ -75,5 +75,6 @@ export function adaptHyvaksymisEsitysToAPI(
     vastaanottajat: adaptSahkopostiVastaanottajatToAPI(hyvaksymisEsitys.vastaanottajat),
     tila: muokattavaHyvaksymisEsitys?.tila ?? API.HyvaksymisTila.MUOKKAUS,
     hash: createHyvaksymisEsitysHash(oid, hyvaksymisEsitys.versio, salt),
+    palautusSyy: muokattavaHyvaksymisEsitys?.palautusSyy,
   };
 }

--- a/backend/src/HyvaksymisEsitys/s3Calls/persistFile.ts
+++ b/backend/src/HyvaksymisEsitys/s3Calls/persistFile.ts
@@ -4,6 +4,7 @@ import { getS3Client } from "../../aws/client";
 import { CopyObjectCommand } from "@aws-sdk/client-s3";
 import { config } from "../../config";
 import { log } from "../../logger";
+import { assertIsDefined } from "../../util/assertions";
 
 /**
  * Persistoi yksittäisen tiedoston, joka on tallennettu uploads-kansioon, annetun vaiheen alle ylläpito-bucketiin
@@ -22,10 +23,11 @@ export async function persistFile({
   vaihePrefix,
 }: {
   oid: string;
-  ladattuTiedosto: { tiedosto: string; nimi: string; avain: string };
+  ladattuTiedosto: { tiedosto?: string | null; nimi: string; avain: string };
   vaihePrefix: string;
 }): Promise<void> {
   const { tiedosto, nimi, avain } = ladattuTiedosto;
+  assertIsDefined(tiedosto, "Tiedoston on oltava  määritelty");
   const sourceFileProperties = await getUploadedSourceFileInformation(tiedosto);
   const targetPath = joinPath(getYllapitoPathForProjekti(oid), vaihePrefix, avain, adaptFileName(nimi));
   try {

--- a/src/components/HyvaksymisEsitys/Dialogs/HyvaksyDialog.tsx
+++ b/src/components/HyvaksymisEsitys/Dialogs/HyvaksyDialog.tsx
@@ -1,0 +1,71 @@
+import HassuDialog from "@components/HassuDialog";
+import Button from "@components/button/Button";
+import { DialogActions, DialogContent } from "@mui/material";
+import log from "loglevel";
+import React, { useCallback } from "react";
+import useApi from "src/hooks/useApi";
+import useSnackbars from "src/hooks/useSnackbars";
+import useLoadingSpinner from "src/hooks/useLoadingSpinner";
+import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
+import { SahkopostiVastaanottaja } from "@services/api";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  oid: string;
+  versio: number;
+  vastaanottajat: SahkopostiVastaanottaja[];
+};
+
+export default function HyvaksyDialog({ open, onClose, oid, versio, vastaanottajat }: Props) {
+  const api = useApi();
+  const { mutate: reloadProjekti } = useHyvaksymisEsitys();
+  const { showSuccessMessage } = useSnackbars();
+
+  const { withLoadingSpinner } = useLoadingSpinner();
+
+  const hyvaksyKuulutus = useCallback(
+    () =>
+      withLoadingSpinner(
+        (async () => {
+          try {
+            await api.hyvaksyHyvaksymisEsitys({ oid, versio });
+            await reloadProjekti();
+            showSuccessMessage(`Hyväksyminen onnistui`);
+          } catch (error) {
+            log.error(error);
+          }
+          onClose();
+          log.debug("hyväksy kuulutus");
+        })()
+      ),
+    [api, oid, onClose, reloadProjekti, showSuccessMessage, versio, withLoadingSpinner]
+  );
+
+  return (
+    <HassuDialog title={"Hyväksymisesityksen hyväksyminen"} hideCloseButton open={open} onClose={onClose} maxWidth={"sm"}>
+      <form style={{ display: "contents" }}>
+        <DialogContent>
+          <p>Olet hyväksymässä hyväksymisesityksen seuraaville tahoille</p>
+
+          <ul className="vayla-dialog-list">
+            {vastaanottajat?.map(({ sahkoposti }) => (
+              <li key={sahkoposti}>{sahkoposti}</li>
+            ))}
+          </ul>
+          <p>Hyväksymisesitystä pystyy vapaasti päivittämään lähetyksen jälkeen.</p>
+          <p>Klikkaamalla Hyväksy ja lähetä -painiketta vahvistat hyväksymisesityksen tarkistetuksi ja lähetät vastaanottajille.</p>
+        </DialogContent>
+
+        <DialogActions>
+          <Button id="accept_kuulutus" primary type="button" onClick={hyvaksyKuulutus}>
+            Hyväksy ja lähetä
+          </Button>
+          <Button type="button" onClick={onClose}>
+            Peruuta
+          </Button>
+        </DialogActions>
+      </form>
+    </HassuDialog>
+  );
+}

--- a/src/components/HyvaksymisEsitys/Dialogs/HyvaksyDialog.tsx
+++ b/src/components/HyvaksymisEsitys/Dialogs/HyvaksyDialog.tsx
@@ -1,13 +1,11 @@
 import HassuDialog from "@components/HassuDialog";
 import Button from "@components/button/Button";
 import { DialogActions, DialogContent } from "@mui/material";
-import log from "loglevel";
-import React, { useCallback } from "react";
+import React from "react";
 import useApi from "src/hooks/useApi";
-import useSnackbars from "src/hooks/useSnackbars";
-import useLoadingSpinner from "src/hooks/useLoadingSpinner";
 import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
 import { SahkopostiVastaanottaja } from "@services/api";
+import useSpinnerAndSuccessMessage from "src/hooks/useSpinnerAndSuccessMessage";
 
 type Props = {
   open: boolean;
@@ -19,28 +17,13 @@ type Props = {
 
 export default function HyvaksyDialog({ open, onClose, oid, versio, vastaanottajat }: Props) {
   const api = useApi();
-  const { mutate: reloadProjekti } = useHyvaksymisEsitys();
-  const { showSuccessMessage } = useSnackbars();
+  const { mutate: reloadData } = useHyvaksymisEsitys();
 
-  const { withLoadingSpinner } = useLoadingSpinner();
-
-  const hyvaksyKuulutus = useCallback(
-    () =>
-      withLoadingSpinner(
-        (async () => {
-          try {
-            await api.hyvaksyHyvaksymisEsitys({ oid, versio });
-            await reloadProjekti();
-            showSuccessMessage(`Hyväksyminen onnistui`);
-          } catch (error) {
-            log.error(error);
-          }
-          onClose();
-          log.debug("hyväksy kuulutus");
-        })()
-      ),
-    [api, oid, onClose, reloadProjekti, showSuccessMessage, versio, withLoadingSpinner]
-  );
+  const hyvaksyKuulutus = useSpinnerAndSuccessMessage(async () => {
+    await api.hyvaksyHyvaksymisEsitys({ oid, versio });
+    onClose();
+    await reloadData();
+  }, "Hyväksyminen onnistui");
 
   return (
     <HassuDialog title={"Hyväksymisesityksen hyväksyminen"} hideCloseButton open={open} onClose={onClose} maxWidth={"sm"}>

--- a/src/components/HyvaksymisEsitys/Dialogs/PalautaDialog.tsx
+++ b/src/components/HyvaksymisEsitys/Dialogs/PalautaDialog.tsx
@@ -1,0 +1,105 @@
+import HassuDialog from "@components/HassuDialog";
+import Button from "@components/button/Button";
+import Textarea from "@components/form/Textarea";
+import HassuStack from "@components/layout/HassuStack";
+import log from "loglevel";
+import { useRouter } from "next/router";
+import React, { useCallback } from "react";
+import { useForm } from "react-hook-form";
+import useApi from "src/hooks/useApi";
+import useSnackbars from "src/hooks/useSnackbars";
+import useLoadingSpinner from "src/hooks/useLoadingSpinner";
+import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
+
+type PalautusValues = {
+  syy: string;
+};
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  oid: string;
+  versio: number;
+};
+
+export default function PalautaDialog({ open, onClose, oid, versio }: Props) {
+  const api = useApi();
+  const { mutate: reloadData } = useHyvaksymisEsitys();
+  const { showSuccessMessage } = useSnackbars();
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<PalautusValues>({ defaultValues: { syy: "" } });
+
+  const { withLoadingSpinner } = useLoadingSpinner();
+
+  const palautaMuokattavaksi = useCallback(
+    (data: PalautusValues) =>
+      withLoadingSpinner(
+        (async () => {
+          try {
+            await api.palautaHyvaksymisEsitys({ oid, versio, syy: data.syy });
+            await reloadData();
+            showSuccessMessage(`Kuulutuksen palautus onnistui`);
+          } catch (error) {
+            log.error(error);
+          }
+          onClose();
+        })()
+      ),
+    [withLoadingSpinner, onClose, api, oid, versio, reloadData, showSuccessMessage]
+  );
+
+  const palautaMuokattavaksiJaPoistu = useCallback(
+    (data: PalautusValues) =>
+      withLoadingSpinner(
+        (async () => {
+          await palautaMuokattavaksi(data);
+          const siirtymaTimer = setTimeout(() => {
+            router.push(`/yllapito/projekti/${oid}`);
+          }, 1000);
+          return () => {
+            clearTimeout(siirtymaTimer);
+          };
+        })()
+      ),
+    [withLoadingSpinner, palautaMuokattavaksi, router, oid]
+  );
+
+  return (
+    <div>
+      <HassuDialog open={open} title={"Hyväksymisesityksen palauttaminen"} onClose={onClose}>
+        <form>
+          <HassuStack>
+            <p>
+              Olet palauttamassa hyväksymisesityksen korjattavaksi. Hyväksymisesityksen tekijä saa tiedon palautuksesta ja sen syystä. Saat
+              ilmoituksen, kun hyväksymisesitys on taas valmis hyväksyttäväksi. Jos haluat itse muokata kuulutusta ja hyväksyä sen tehtyjen
+              muutoksien jälkeen, valitse Palauta ja siirry muokkaamaan.
+            </p>
+            <Textarea
+              label="Syy palautukselle *"
+              {...register("syy", { required: "Palautuksen syy täytyy antaa" })}
+              error={errors.syy}
+              maxLength={200}
+              hideLengthCounter={false}
+            ></Textarea>
+          </HassuStack>
+          <HassuStack direction={["column", "column", "row"]} justifyContent={[undefined, undefined, "flex-end"]} paddingTop={"1rem"}>
+            <Button primary onClick={handleSubmit(palautaMuokattavaksiJaPoistu)}>
+              Palauta ja poistu
+            </Button>
+            <Button id="reject_and_edit" onClick={handleSubmit(palautaMuokattavaksi)}>
+              Siirry muokkaamaan
+            </Button>
+            <Button type="button" onClick={onClose}>
+              Peruuta
+            </Button>
+          </HassuStack>
+        </form>
+      </HassuDialog>
+    </div>
+  );
+}

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -1,4 +1,4 @@
-import { HyvaksymisEsityksenTiedot, TallennaHyvaksymisEsitysInput } from "@services/api";
+import { HyvaksymisEsityksenTiedot, TallennaHyvaksymisEsitysInput, Vaihe } from "@services/api";
 import { useEffect, useMemo } from "react";
 import { FormProvider, UseFormProps, useForm } from "react-hook-form";
 import getDefaultValuesForForm from "./getDefaultValuesForForm";
@@ -22,6 +22,7 @@ import Lausunnot from "./LomakeComponents/Lausunnot";
 import Maanomistajaluettelo from "./LomakeComponents/MaanomistajaLuettelo";
 import KuulutuksetJaKutsu from "./LomakeComponents/KuulutuksetJaKutsu";
 import Notification, { NotificationType } from "@components/notification/Notification";
+import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
 
 export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const defaultValues: TallennaHyvaksymisEsitysInput = useMemo(
@@ -58,63 +59,66 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
   }, [useFormReturn, defaultValues]);
 
   return (
-    <FormProvider {...useFormReturn}>
-      <form>
-        <div>
-          <h2 className="vayla-title">Hyväksymisesityksen sisältö</h2>
-          {hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.palautusSyy && (
-            <Section noDivider>
-              <Notification type={NotificationType.WARN}>
-                {"Hyväksymisesitys on palautettu korjattavaksi. Palautuksen syy: " + hyvaksymisEsityksenTiedot.hyvaksymisEsitys.palautusSyy}
-              </Notification>
+    <ProjektiPageLayout title="Hyväksymisesitys" vaihe={Vaihe.HYVAKSYMISPAATOS} showInfo={true}>
+      <FormProvider {...useFormReturn}>
+        <form>
+          <div>
+            <h2 className="vayla-title">Hyväksymisesityksen sisältö</h2>
+            {hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.palautusSyy && (
+              <Section noDivider>
+                <Notification type={NotificationType.WARN}>
+                  {"Hyväksymisesitys on palautettu korjattavaksi. Palautuksen syy: " +
+                    hyvaksymisEsityksenTiedot.hyvaksymisEsitys.palautusSyy}
+                </Notification>
+              </Section>
+            )}
+            <LinkinVoimassaoloaika />
+            <ViestiVastaanottajalle />
+            <Laskutustiedot />
+          </div>
+          <div>
+            <h2 className="vayla-title">Hyväksymisesitykseen liitettävä aineisto</h2>
+            <LinkkiHyvEsAineistoon hash={hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.hash} oid={hyvaksymisEsityksenTiedot.oid} />
+            <HyvaksymisEsitysTiedosto />
+            <h3 className="vayla-subtitle">Suunnitelma</h3>
+            <Section>
+              <h3 className="vayla-subtitle">Vuorovaikutus</h3>
+              <SectionContent>
+                <Muistutukset kunnat={[50, 43]} />
+                <Lausunnot />
+                <Maanomistajaluettelo />
+                <KuulutuksetJaKutsu />
+              </SectionContent>
             </Section>
-          )}
-          <LinkinVoimassaoloaika />
-          <ViestiVastaanottajalle />
-          <Laskutustiedot />
-        </div>
-        <div>
-          <h2 className="vayla-title">Hyväksymisesitykseen liitettävä aineisto</h2>
-          <LinkkiHyvEsAineistoon hash={hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.hash} oid={hyvaksymisEsityksenTiedot.oid} />
-          <HyvaksymisEsitysTiedosto />
-          <h3 className="vayla-subtitle">Suunnitelma</h3>
+            <Section>
+              <h3 className="vayla-subtitle">Muu tekninen aineisto</h3>
+              <p>Voit halutessasi liittää...</p>
+              <MuuAineistoVelhosta />
+              <MuuAineistoKoneelta />
+            </Section>
+          </div>
+          <div>
+            <Vastaanottajat />
+            <h3 className="vayla-subtitle">Hyväksymisesityksen sisällön esikatselu</h3>
+          </div>
           <Section>
-            <h3 className="vayla-subtitle">Vuorovaikutus</h3>
-            <SectionContent>
-              <Muistutukset kunnat={[50, 43]} />
-              <Lausunnot />
-              <Maanomistajaluettelo />
-              <KuulutuksetJaKutsu />
-            </SectionContent>
+            <Stack justifyContent={{ md: "flex-end" }} direction={{ xs: "column", md: "row" }}>
+              <Button primary id="save" onClick={useFormReturn.handleSubmit(save)}>
+                Tallenna luonnos
+              </Button>
+              <Button
+                type="button"
+                disabled={tallennaHyvaksyttavaksiDisabled}
+                id="save_and_send_for_acceptance"
+                primary
+                onClick={useFormReturn.handleSubmit(sendForApproval)}
+              >
+                Lähetä Hyväksyttäväksi
+              </Button>
+            </Stack>
           </Section>
-          <Section>
-            <h3 className="vayla-subtitle">Muu tekninen aineisto</h3>
-            <p>Voit halutessasi liittää...</p>
-            <MuuAineistoVelhosta />
-            <MuuAineistoKoneelta />
-          </Section>
-        </div>
-        <div>
-          <Vastaanottajat />
-          <h3 className="vayla-subtitle">Hyväksymisesityksen sisällön esikatselu</h3>
-        </div>
-        <Section>
-          <Stack justifyContent={{ md: "flex-end" }} direction={{ xs: "column", md: "row" }}>
-            <Button primary id="save" onClick={useFormReturn.handleSubmit(save)}>
-              Tallenna luonnos
-            </Button>
-            <Button
-              type="button"
-              disabled={tallennaHyvaksyttavaksiDisabled}
-              id="save_and_send_for_acceptance"
-              primary
-              onClick={useFormReturn.handleSubmit(sendForApproval)}
-            >
-              Lähetä Hyväksyttäväksi
-            </Button>
-          </Stack>
-        </Section>
-      </form>
-    </FormProvider>
+        </form>
+      </FormProvider>
+    </ProjektiPageLayout>
   );
 }

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -45,6 +45,13 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
     await reloadData();
   }, "Tallennus onnistui");
 
+  const sendForApproval = useSpinnerAndSuccessMessage(async (formData: TallennaHyvaksymisEsitysInput) => {
+    await api.tallennaHyvaksymisEsitysJaLahetaHyvaksyttavaksi(formData);
+    await reloadData();
+  }, "Tallennus ja hyväksyttäväksi lähettäminen onnistui");
+
+  const tallennaHyvaksyttavaksiDisabled = false; // TODO: muuta
+
   useEffect(() => {
     useFormReturn.reset(defaultValues);
   }, [useFormReturn, defaultValues]);
@@ -83,10 +90,19 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
           <Vastaanottajat />
           <h3 className="vayla-subtitle">Hyväksymisesityksen sisällön esikatselu</h3>
         </div>
-        <Section noDivider>
+        <Section>
           <Stack justifyContent={{ md: "flex-end" }} direction={{ xs: "column", md: "row" }}>
             <Button primary id="save" onClick={useFormReturn.handleSubmit(save)}>
-              Tallenna
+              Tallenna luonnos
+            </Button>
+            <Button
+              type="button"
+              disabled={tallennaHyvaksyttavaksiDisabled}
+              id="save_and_send_for_acceptance"
+              primary
+              onClick={useFormReturn.handleSubmit(sendForApproval)}
+            >
+              Lähetä Hyväksyttäväksi
             </Button>
           </Stack>
         </Section>

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -19,6 +19,8 @@ import Vastaanottajat from "./LomakeComponents/Vastaanottajat";
 import MuuAineistoKoneelta from "./LomakeComponents/MuuAineistoKoneelta";
 import MuuAineistoVelhosta from "./LomakeComponents/MuuAineistoVelhosta";
 import Lausunnot from "./LomakeComponents/Lausunnot";
+import Maanomistajaluettelo from "./LomakeComponents/MaanomistajaLuettelo";
+import KuulutuksetJaKutsu from "./LomakeComponents/KuulutuksetJaKutsu";
 
 export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const defaultValues: TallennaHyvaksymisEsitysInput = useMemo(
@@ -66,6 +68,8 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
             <SectionContent>
               <Muistutukset kunnat={[50, 43]} />
               <Lausunnot />
+              <Maanomistajaluettelo />
+              <KuulutuksetJaKutsu />
             </SectionContent>
           </Section>
           <Section>

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -21,6 +21,7 @@ import MuuAineistoVelhosta from "./LomakeComponents/MuuAineistoVelhosta";
 import Lausunnot from "./LomakeComponents/Lausunnot";
 import Maanomistajaluettelo from "./LomakeComponents/MaanomistajaLuettelo";
 import KuulutuksetJaKutsu from "./LomakeComponents/KuulutuksetJaKutsu";
+import Notification, { NotificationType } from "@components/notification/Notification";
 
 export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const defaultValues: TallennaHyvaksymisEsitysInput = useMemo(
@@ -61,6 +62,13 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: { 
       <form>
         <div>
           <h2 className="vayla-title">Hyväksymisesityksen sisältö</h2>
+          {hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.palautusSyy && (
+            <Section noDivider>
+              <Notification type={NotificationType.WARN}>
+                {"Hyväksymisesitys on palautettu korjattavaksi. Palautuksen syy: " + hyvaksymisEsityksenTiedot.hyvaksymisEsitys.palautusSyy}
+              </Notification>
+            </Section>
+          )}
           <LinkinVoimassaoloaika />
           <ViestiVastaanottajalle />
           <Laskutustiedot />

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
@@ -1,6 +1,8 @@
 import { HyvaksymisEsityksenTiedot, HyvaksymisTila } from "@services/api";
 import HyvaksyTaiPalautaPainikkeet from "./LomakeComponents/HyvaksyTaiPalautaPainikkeet";
 import useKayttoOikeudet from "src/hooks/useKayttoOikeudet";
+import Section from "@components/layout/Section2";
+import Notification, { NotificationType } from "@components/notification/Notification";
 
 export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const { oid, versio, hyvaksymisEsitys } = hyvaksymisEsityksenTiedot;
@@ -12,6 +14,21 @@ export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: 
   }
   return (
     <div>
+      {odottaaHyvaksyntaa && nykyinenKayttaja?.onProjektipaallikkoTaiVarahenkilo && (
+        <Section noDivider>
+          <Notification type={NotificationType.WARN}>
+            Hyväksymisesitys odottaa hyväksyntää. Tarkista hyväksymisesitys ja a) hyväksy tai b) palauta hyväksymisesitys korjattavaksi, jos
+            havaitset puutteita tai virheen.
+          </Notification>
+        </Section>
+      )}
+      {odottaaHyvaksyntaa && nykyinenKayttaja?.omaaMuokkausOikeuden && !nykyinenKayttaja.onProjektipaallikkoTaiVarahenkilo && (
+        <Section noDivider>
+          <Notification type={NotificationType.WARN}>
+            Hyväksymisesitys on hyväksyttävänä projektipäälliköllä. Jos hyväksymisesitystä tarvitsee muokata, ota yhteysprojektipäällikköön.
+          </Notification>
+        </Section>
+      )}
       {JSON.stringify(hyvaksymisEsityksenTiedot)}
       {odottaaHyvaksyntaa && nykyinenKayttaja?.onProjektipaallikkoTaiVarahenkilo && (
         <HyvaksyTaiPalautaPainikkeet oid={oid} versio={versio} vastaanottajat={hyvaksymisEsitys.vastaanottajat!} />

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
@@ -1,19 +1,35 @@
-import { HyvaksymisEsityksenTiedot, HyvaksymisTila } from "@services/api";
+import { HyvaksymisEsityksenTiedot, HyvaksymisTila, Vaihe } from "@services/api";
 import HyvaksyTaiPalautaPainikkeet from "./LomakeComponents/HyvaksyTaiPalautaPainikkeet";
 import useKayttoOikeudet from "src/hooks/useKayttoOikeudet";
 import Section from "@components/layout/Section2";
 import Notification, { NotificationType } from "@components/notification/Notification";
+import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
+import useApi from "src/hooks/useApi";
+import Button from "@components/button/Button";
 
 export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
-  const { oid, versio, hyvaksymisEsitys } = hyvaksymisEsityksenTiedot;
+  const { oid, versio, hyvaksymisEsitys, muokkauksenVoiAvata } = hyvaksymisEsityksenTiedot;
   const odottaaHyvaksyntaa = hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.tila == HyvaksymisTila.ODOTTAA_HYVAKSYNTAA;
   const { data: nykyinenKayttaja } = useKayttoOikeudet();
+  const api = useApi();
 
   if (!hyvaksymisEsitys) {
     return null;
   }
   return (
-    <div>
+    <ProjektiPageLayout
+      title="Hyväksymisesitys"
+      vaihe={Vaihe.HYVAKSYMISPAATOS}
+      contentAsideTitle={
+        muokkauksenVoiAvata ? (
+          <Button onClick={() => api.avaaHyvaksymisEsityksenMuokkaus({ oid, versio })} id="avaa_hyvaksymisesityksen_muokkaus_button">
+            Muokkaa
+          </Button>
+        ) : (
+          <></>
+        )
+      }
+    >
       {odottaaHyvaksyntaa && nykyinenKayttaja?.onProjektipaallikkoTaiVarahenkilo && (
         <Section noDivider>
           <Notification type={NotificationType.WARN}>
@@ -33,6 +49,6 @@ export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: 
       {odottaaHyvaksyntaa && nykyinenKayttaja?.onProjektipaallikkoTaiVarahenkilo && (
         <HyvaksyTaiPalautaPainikkeet oid={oid} versio={versio} vastaanottajat={hyvaksymisEsitys.vastaanottajat!} />
       )}
-    </div>
+    </ProjektiPageLayout>
   );
 }

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
@@ -1,5 +1,20 @@
-import { HyvaksymisEsityksenTiedot } from "@services/api";
+import { HyvaksymisEsityksenTiedot, HyvaksymisTila } from "@services/api";
+import HyvaksyTaiPalautaPainikkeet from "./LomakeComponents/HyvaksyTaiPalautaPainikkeet";
 
 export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
-  return <>{JSON.stringify(hyvaksymisEsityksenTiedot)}</>;
+  const { oid, versio, hyvaksymisEsitys } = hyvaksymisEsityksenTiedot;
+  const odottaaHyvaksyntaa = hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.tila == HyvaksymisTila.ODOTTAA_HYVAKSYNTAA;
+  const kayttajaOnProjari = true; // TODO: muuta
+
+  if (!hyvaksymisEsitys) {
+    return null;
+  }
+  return (
+    <div>
+      {JSON.stringify(hyvaksymisEsityksenTiedot)}
+      {odottaaHyvaksyntaa && kayttajaOnProjari && (
+        <HyvaksyTaiPalautaPainikkeet oid={oid} versio={versio} vastaanottajat={hyvaksymisEsitys.vastaanottajat!} />
+      )}
+    </div>
+  );
 }

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
@@ -1,10 +1,11 @@
 import { HyvaksymisEsityksenTiedot, HyvaksymisTila } from "@services/api";
 import HyvaksyTaiPalautaPainikkeet from "./LomakeComponents/HyvaksyTaiPalautaPainikkeet";
+import useKayttoOikeudet from "src/hooks/useKayttoOikeudet";
 
 export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
   const { oid, versio, hyvaksymisEsitys } = hyvaksymisEsityksenTiedot;
   const odottaaHyvaksyntaa = hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.tila == HyvaksymisTila.ODOTTAA_HYVAKSYNTAA;
-  const kayttajaOnProjari = true; // TODO: muuta
+  const { data: nykyinenKayttaja } = useKayttoOikeudet();
 
   if (!hyvaksymisEsitys) {
     return null;
@@ -12,7 +13,7 @@ export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: 
   return (
     <div>
       {JSON.stringify(hyvaksymisEsityksenTiedot)}
-      {odottaaHyvaksyntaa && kayttajaOnProjari && (
+      {odottaaHyvaksyntaa && nykyinenKayttaja?.onProjektipaallikkoTaiVarahenkilo && (
         <HyvaksyTaiPalautaPainikkeet oid={oid} versio={versio} vastaanottajat={hyvaksymisEsitys.vastaanottajat!} />
       )}
     </div>

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
@@ -6,12 +6,20 @@ import Notification, { NotificationType } from "@components/notification/Notific
 import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
 import useApi from "src/hooks/useApi";
 import Button from "@components/button/Button";
+import useSpinnerAndSuccessMessage from "src/hooks/useSpinnerAndSuccessMessage";
+import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
 
 export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: { hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot }) {
+  const { mutate: reloadData } = useHyvaksymisEsitys();
   const { oid, versio, hyvaksymisEsitys, muokkauksenVoiAvata } = hyvaksymisEsityksenTiedot;
   const odottaaHyvaksyntaa = hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.tila == HyvaksymisTila.ODOTTAA_HYVAKSYNTAA;
   const { data: nykyinenKayttaja } = useKayttoOikeudet();
   const api = useApi();
+
+  const avaaMuokkaus = useSpinnerAndSuccessMessage(async () => {
+    await api.avaaHyvaksymisEsityksenMuokkaus({ oid, versio });
+    await reloadData();
+  }, "Muokkauksen avaaminen onnistui");
 
   if (!hyvaksymisEsitys) {
     return null;
@@ -22,7 +30,7 @@ export default function HyvaksymisEsitysLukutila({ hyvaksymisEsityksenTiedot }: 
       vaihe={Vaihe.HYVAKSYMISPAATOS}
       contentAsideTitle={
         muokkauksenVoiAvata ? (
-          <Button onClick={() => api.avaaHyvaksymisEsityksenMuokkaus({ oid, versio })} id="avaa_hyvaksymisesityksen_muokkaus_button">
+          <Button onClick={avaaMuokkaus} id="avaa_hyvaksymisesityksen_muokkaus_button">
             Muokkaa
           </Button>
         ) : (

--- a/src/components/HyvaksymisEsitys/LomakeComponents/HyvaksyTaiPalautaPainikkeet.tsx
+++ b/src/components/HyvaksymisEsitys/LomakeComponents/HyvaksyTaiPalautaPainikkeet.tsx
@@ -1,0 +1,41 @@
+import Button from "@components/button/Button";
+import Section from "@components/layout/Section2";
+import { Stack } from "@mui/system";
+import React, { useState } from "react";
+import PalautaDialog from "../Dialogs/PalautaDialog";
+import HyvaksyDialog from "../Dialogs/HyvaksyDialog";
+import { SahkopostiVastaanottaja } from "@services/api";
+
+type Props = {
+  versio: number;
+  oid: string;
+  vastaanottajat: SahkopostiVastaanottaja[];
+};
+
+export default function HyvaksyTaiPalautaPainikkeet({ versio, oid, vastaanottajat }: Props) {
+  const [isOpenPalauta, setIsOpenPalauta] = useState(false);
+  const [isOpenHyvaksy, setIsOpenHyvaksy] = useState(false);
+
+  return (
+    <>
+      <Section noDivider>
+        <Stack direction={["column", "column", "row"]} justifyContent={[undefined, undefined, "flex-end"]}>
+          <Button type="button" id="button_reject" onClick={() => setIsOpenPalauta(true)}>
+            Palauta
+          </Button>
+          <Button type="button" id="button_open_acceptance_dialog" primary onClick={() => setIsOpenHyvaksy(true)}>
+            Hyväksy ja lähetä
+          </Button>
+        </Stack>
+      </Section>
+      <PalautaDialog open={isOpenPalauta} onClose={() => setIsOpenPalauta(false)} versio={versio} oid={oid} />
+      <HyvaksyDialog
+        open={isOpenHyvaksy}
+        onClose={() => setIsOpenHyvaksy(false)}
+        versio={versio}
+        oid={oid}
+        vastaanottajat={vastaanottajat}
+      />
+    </>
+  );
+}

--- a/src/components/HyvaksymisEsitys/LomakeComponents/KuulutuksetJaKutsu.tsx
+++ b/src/components/HyvaksymisEsitys/LomakeComponents/KuulutuksetJaKutsu.tsx
@@ -1,0 +1,57 @@
+import Section from "@components/layout/Section2";
+import { ReactElement, useRef } from "react";
+import { allowedFileTypes } from "hassu-common/fileValidationSettings";
+import Button from "@components/button/Button";
+import useHandleUploadedFiles from "src/hooks/useHandleUploadedFiles";
+import { TallennaHyvaksymisEsitysInput } from "@services/api";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import IconButton from "@components/button/IconButton";
+
+export default function KuulutuksetJaKutsu(): ReactElement {
+  const hiddenInputRef = useRef<HTMLInputElement | null>();
+  const { control } = useFormContext<TallennaHyvaksymisEsitysInput>();
+  const { fields, remove } = useFieldArray({ name: `muokattavaHyvaksymisEsitys.kuulutuksetJaKutsu`, control });
+  const handleUploadedFiles = useHandleUploadedFiles(`muokattavaHyvaksymisEsitys.kuulutuksetJaKutsu`);
+
+  const onButtonClick = () => {
+    if (hiddenInputRef.current) {
+      hiddenInputRef.current.click();
+    }
+  };
+
+  return (
+    <Section>
+      <h4 className="vayla-small-title">Kuulutukset ja kutsu vuorovaikutukseen</h4>
+      {fields.map((aineisto) => (
+        <div key={aineisto.id}>
+          {aineisto.nimi}
+          <IconButton
+            type="button"
+            onClick={() => {
+              remove(fields.indexOf(aineisto));
+            }}
+            icon="trash"
+          />
+        </div>
+      ))}
+      <input
+        type="file"
+        multiple
+        accept={allowedFileTypes.join(", ")}
+        style={{ display: "none" }}
+        id={`kuulutuksetJaKutsu-input`}
+        onChange={handleUploadedFiles}
+        ref={(e) => {
+          if (hiddenInputRef) {
+            hiddenInputRef.current = e;
+          }
+        }}
+      />
+      <label htmlFor={`kuulutuksetJaKutsu-input`}>
+        <Button className="mt-4" type="button" id={`tuo_kuulutuksetJaKutsu_button`} onClick={onButtonClick}>
+          Tuo tiedostot
+        </Button>
+      </label>
+    </Section>
+  );
+}

--- a/src/components/HyvaksymisEsitys/LomakeComponents/MaanomistajaLuettelo.tsx
+++ b/src/components/HyvaksymisEsitys/LomakeComponents/MaanomistajaLuettelo.tsx
@@ -1,0 +1,57 @@
+import Section from "@components/layout/Section2";
+import { ReactElement, useRef } from "react";
+import { allowedFileTypes } from "hassu-common/fileValidationSettings";
+import Button from "@components/button/Button";
+import useHandleUploadedFiles from "src/hooks/useHandleUploadedFiles";
+import { TallennaHyvaksymisEsitysInput } from "@services/api";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import IconButton from "@components/button/IconButton";
+
+export default function Maanomistajaluettelo(): ReactElement {
+  const hiddenInputRef = useRef<HTMLInputElement | null>();
+  const { control } = useFormContext<TallennaHyvaksymisEsitysInput>();
+  const { fields, remove } = useFieldArray({ name: `muokattavaHyvaksymisEsitys.maanomistajaluettelo`, control });
+  const handleUploadedFiles = useHandleUploadedFiles(`muokattavaHyvaksymisEsitys.maanomistajaluettelo`);
+
+  const onButtonClick = () => {
+    if (hiddenInputRef.current) {
+      hiddenInputRef.current.click();
+    }
+  };
+
+  return (
+    <Section>
+      <h4 className="vayla-small-title">Maanomistajaluettelo</h4>
+      {fields.map((aineisto) => (
+        <div key={aineisto.id}>
+          {aineisto.nimi}
+          <IconButton
+            type="button"
+            onClick={() => {
+              remove(fields.indexOf(aineisto));
+            }}
+            icon="trash"
+          />
+        </div>
+      ))}
+      <input
+        type="file"
+        multiple
+        accept={allowedFileTypes.join(", ")}
+        style={{ display: "none" }}
+        id={`maanomistajaluettelo-input`}
+        onChange={handleUploadedFiles}
+        ref={(e) => {
+          if (hiddenInputRef) {
+            hiddenInputRef.current = e;
+          }
+        }}
+      />
+      <label htmlFor={`maanomistajaluettelo-input`}>
+        <Button className="mt-4" type="button" id={`tuo_maanomistajaluettelo_button`} onClick={onButtonClick}>
+          Tuo tiedostot
+        </Button>
+      </label>
+    </Section>
+  );
+}

--- a/src/pages/yllapito/projekti/[oid]/hyvaksymisesitys.tsx
+++ b/src/pages/yllapito/projekti/[oid]/hyvaksymisesitys.tsx
@@ -1,31 +1,27 @@
 import HyvaksymisEsitysLomake from "@components/HyvaksymisEsitys/HyvaksymisEsitysLomake";
 import HyvaksymisEsitysLukutila from "@components/HyvaksymisEsitys/HyvaksymisEsitysLukutila";
-import ProjektiPageLayout from "@components/projekti/ProjektiPageLayout";
-import { HyvaksymisTila, Vaihe } from "@services/api";
+import { HyvaksymisTila } from "@services/api";
 import { ReactElement } from "react";
 import useHyvaksymisEsitys from "src/hooks/useHyvaksymisEsitys";
 import useKayttoOikeudet from "src/hooks/useKayttoOikeudet";
 
 export default function HyvaksymisEsitysPage(): ReactElement {
   const { data: hyvaksymisEsityksenTiedot } = useHyvaksymisEsitys();
+  const { oid, versio, hyvaksymisEsitys } = hyvaksymisEsityksenTiedot ?? {};
   const { data: nykyinenKayttaja } = useKayttoOikeudet();
 
-  const muokkaustila =
-    nykyinenKayttaja?.omaaMuokkausOikeuden &&
-    (!hyvaksymisEsityksenTiedot?.hyvaksymisEsitys || hyvaksymisEsityksenTiedot?.hyvaksymisEsitys?.tila == HyvaksymisTila.MUOKKAUS);
+  const muokkaustila = nykyinenKayttaja?.omaaMuokkausOikeuden && (!hyvaksymisEsitys || hyvaksymisEsitys?.tila == HyvaksymisTila.MUOKKAUS);
 
   return (
     <>
-      {hyvaksymisEsityksenTiedot && (
-        // TODO: Uusi oma vaihe Hyväksymisesitykselle(?), ja vaihda alta vaihe vastaavaksi
-        <ProjektiPageLayout title="Hyväksymisesitys" vaihe={Vaihe.HYVAKSYMISPAATOS} showInfo={muokkaustila}>
-          {muokkaustila ? (
-            <HyvaksymisEsitysLomake hyvaksymisEsityksenTiedot={hyvaksymisEsityksenTiedot} />
-          ) : (
-            <HyvaksymisEsitysLukutila hyvaksymisEsityksenTiedot={hyvaksymisEsityksenTiedot} />
-          )}
-        </ProjektiPageLayout>
-      )}
+      {hyvaksymisEsityksenTiedot &&
+        oid &&
+        versio &&
+        (muokkaustila ? (
+          <HyvaksymisEsitysLomake hyvaksymisEsityksenTiedot={hyvaksymisEsityksenTiedot} />
+        ) : (
+          <HyvaksymisEsitysLukutila hyvaksymisEsityksenTiedot={hyvaksymisEsityksenTiedot} />
+        ))}
     </>
   );
 }


### PR DESCRIPTION
Toteutettu "lähetä hyväksyttäväksi", "hyväksy", "palauta" ja "muokkaa" napit + dialogit, eli kaikki mikä liityy hyväksymisesityksen tilasiirtymiin. Mikä nappi näkyy kellekin ja milloin pitäisi olla kunnossa. Napit toimivat. Nappien ulkonäön ei ole tarkoitus olla vielä lopullinen. Koodin jäsentelyn ja nappien toimivuuden on tarkoitus olla kunnossa. Dialogien pitäisi olla speksin mukaisia (sisältö ja miten ne käyttäytyvät, ulkonäkö ei välttämättä).

Koodia jäsennelty. Korjattu yksi BE-logiikkavirhe ja tehty sille pienet testit.

Testaamisessa huomioitavaa:

Ei ole mahdollista lähettää hyväksyttäväksi projektia, jolla ei ole suunnitelmaa. Suunnitelmaa ei voi kuitenkaan vielä UI:n kautta lisätä. Lisää "muu aineisto velhosta" ja aws:ssä käy kopioimassa aineistotieto suunnitelmatiedoksi.

Ei ole mahdollista lähettää hyväksyttäväksi projektia, jonka aineistot eivät ole valmiita. Feikkaa aineistot valmiiksi laittamalla projektiin DynamoDB:ssä aineistoHandledAt-aikaleima projektin juuritasolle. Laita esim. tuleva päivä, tyyliin "2024-05-22".

Ei ole mahdollista hyväksyä hyväksymisesitystä, koska aineistot, jotka ovat dynamoDB:ssä, eivät oikeasti ole s3:ssä. Ennen hyväksymistä poista suunnitelma ja muu aineisto velhossa.