### PR TITLE
fix: Poistetaan automaattinen omistajien ja muistuttajien indeksointi

### DIFF
--- a/deployment/lib/buildspec/buildspec-dev.yml
+++ b/deployment/lib/buildspec/buildspec-dev.yml
@@ -39,10 +39,6 @@ phases:
       - npm run deploy:stackpolicies
       - npm run opensearch:delete-index
       - npm run opensearch:index
-      - npm run opensearch:delete-omistajaindex
-      - npm run opensearch:omistajaindex
-      - npm run opensearch:delete-muistuttajaindex
-      - npm run opensearch:muistuttajaindex
       - aws codebuild start-build --project-name Hassu-build-e2e-$ENVIRONMENT --source-version $CODEBUILD_SOURCE_VERSION
   post_build:
     on-failure: ABORT

--- a/deployment/lib/buildspec/buildspec-prod.yml
+++ b/deployment/lib/buildspec/buildspec-prod.yml
@@ -29,8 +29,6 @@ phases:
       - npm run deploy:stackpolicies
       - npm run release
       - npm run opensearch:index
-      - npm run opensearch:omistajaindex
-      - npm run opensearch:muistuttajaindex
   post_build:
     on-failure: ABORT
     commands:

--- a/deployment/lib/buildspec/buildspec-test.yml
+++ b/deployment/lib/buildspec/buildspec-test.yml
@@ -39,10 +39,6 @@ phases:
       - npm run release
       - npm run opensearch:delete-index
       - npm run opensearch:index
-      - npm run opensearch:delete-omistajaindex
-      - npm run opensearch:omistajaindex
-      - npm run opensearch:delete-muistuttajaindex
-      - npm run opensearch:muistuttajaindex
       - aws codebuild start-build --project-name Hassu-build-e2e-$ENVIRONMENT --source-version $CODEBUILD_SOURCE_VERSION
   post_build:
     on-failure: ABORT

--- a/deployment/lib/buildspec/buildspec-training.yml
+++ b/deployment/lib/buildspec/buildspec-training.yml
@@ -40,10 +40,6 @@ phases:
       - npm run release
       - npm run opensearch:delete-index
       - npm run opensearch:index
-      - npm run opensearch:delete-omistajaindex
-      - npm run opensearch:omistajaindex
-      - npm run opensearch:delete-muistuttajaindex
-      - npm run opensearch:muistuttajaindex
   post_build:
     on-failure: ABORT
     commands:


### PR DESCRIPTION
Tulee timeout jos omistajia paljon. Luotetaan että indeksi pysyy ajan tasalla stream eventtien välityksellä. Jos päivitetään asetuksia ja mappauksia pitää muistaa deletoida ja indeksoida indeksit uudestaan.