### PR TITLE
fix: Korjaa tuotannon sso logout

### DIFF
--- a/src/pages/api/slo.ts
+++ b/src/pages/api/slo.ts
@@ -1,23 +1,9 @@
-import { SSM } from "@aws-sdk/client-ssm";
 import { NextApiRequest, NextApiResponse } from "next";
-
-const ssm = new SSM({ region: "eu-west-1" });
-
-async function getParameter(name: string, envVariable: string): Promise<string> {
-  if (process.env[envVariable]) {
-    return process.env[envVariable] as string;
-  }
-  const value = (await ssm.getParameter({ Name: name, WithDecryption: true })).Parameter?.Value;
-  if (value) {
-    return value;
-  }
-  throw new Error("Getting parameter " + name + " failed");
-}
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const currenturl = new URL(req.headers.referer!);
   const keycloakClientId = process.env.KEYCLOAK_CLIENT_ID!;
-  const redirect_uri = new URL(await getParameter("KeycloakDomain", "KEYCLOAK_DOMAIN"));
+  const redirect_uri = new URL(process.env.KEYCLOAK_DOMAIN!);
   redirect_uri.pathname = "/keycloak/auth/realms/suomifi/protocol/openid-connect/logout";
   redirect_uri.searchParams.set("client_id", keycloakClientId);
   redirect_uri.searchParams.set("post_logout_redirect_uri", currenturl.toString());


### PR DESCRIPTION
Tuotannossa ohjaa logoutin aina https://vayliensuunnittelu.fi osoitteeseen vaikka KeycloakDomain on www.vayliensuunnittelu.fi. Koodissa ei sinänsä mitään vikaa, vaan pakko sen OnPrem proxyn muuttaa se Location header. Tähän auttaa se että muutetaan FRONTEND_DOMAIN_NAME tuotannossa käyttämään www.vayliensuunnittelu.fi arvoa.