### PR TITLE
feat: hassuyp 404 muokkauksen sulku

### DIFF
--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -184,10 +184,15 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: Re
                 <AineistonEsikatselu />
               </Section>
               <Section noDivider>
-                <Stack justifyContent="space-between" direction={{ xs: "column", md: "row" }}>
-                  <Button id="save" style={{ float: "left" }} type="button" onClick={suljeMuokkaus}>
-                    Sulje muokkaus
-                  </Button>
+                <Stack
+                  justifyContent={hyvaksymisEsitys.hyvaksymisPaiva ? "space-between" : "flex-end"}
+                  direction={{ xs: "column", md: "row" }}
+                >
+                  {hyvaksymisEsitys.hyvaksymisPaiva && (
+                    <Button id="save" style={{ float: "left" }} type="button" onClick={suljeMuokkaus}>
+                      Sulje muokkaus
+                    </Button>
+                  )}
                   <Stack justifyContent="flex-end" direction={{ xs: "column", md: "row" }}>
                     <Button id="save" type="button" onClick={useFormReturn.handleSubmit(save)}>
                       Tallenna luonnos

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLomake.tsx
@@ -25,6 +25,8 @@ import AineistonEsikatselu from "./LomakeComponents/AineistonEsikatselu";
 import ProjektiPageLayout, { ProjektiPageLayoutContext } from "@components/projekti/ProjektiPageLayout";
 import { OhjelistaNotification } from "@components/projekti/common/OhjelistaNotification";
 import { H3, H4 } from "@components/Headings";
+import ExtLink from "@components/ExtLink";
+import { formatDate } from "common/util/dateUtils";
 
 type Props = {
   hyvaksymisEsityksenTiedot: HyvaksymisEsityksenTiedot;
@@ -64,8 +66,24 @@ export default function HyvaksymisEsitysLomake({ hyvaksymisEsityksenTiedot }: Re
     useFormReturn.reset(defaultValues);
   }, [useFormReturn, defaultValues]);
 
+  const { oid, hyvaksymisEsitys } = hyvaksymisEsityksenTiedot;
+
+  if (!hyvaksymisEsitys) {
+    return null;
+  }
+
+  const url = `${window?.location?.protocol}//${window?.location?.host}/suunnitelma/${oid}/hyvaksymisesitysaineistot?hash=${hyvaksymisEsitys.hash}`;
+
   return (
     <ProjektiPageLayout title="Hyväksymisesitys" vaihe={Vaihe.HYVAKSYMISPAATOS} showInfo>
+      {hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.hyvaksymisPaiva && (
+        <Section noDivider>
+          <Notification type={NotificationType.INFO_GREEN}>
+            Hyväksymisesitys on lähetetty vastaanottajalle {formatDate(hyvaksymisEsitys.hyvaksymisPaiva)}:{" "}
+            <ExtLink href={url}>{url}</ExtLink>
+          </Notification>
+        </Section>
+      )}
       <ProjektiPageLayoutContext.Consumer>
         {({ ohjeetOnClose, ohjeetOpen }) => (
           <FormProvider {...useFormReturn}>

--- a/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
+++ b/src/components/HyvaksymisEsitys/HyvaksymisEsitysLukutila.tsx
@@ -33,7 +33,6 @@ export default function HyvaksymisEsitysLukutila({
   const { mutate: reloadData } = useHyvaksymisEsitys();
   const { oid, versio, hyvaksymisEsitys, muokkauksenVoiAvata, perustiedot, tuodutTiedostot } = hyvaksymisEsityksenTiedot;
   const odottaaHyvaksyntaa = hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.tila == HyvaksymisTila.ODOTTAA_HYVAKSYNTAA;
-  const hyvaksytty = hyvaksymisEsityksenTiedot.hyvaksymisEsitys?.tila == HyvaksymisTila.HYVAKSYTTY;
   const { data: nykyinenKayttaja } = useKayttoOikeudet();
   const [expandedAineisto, setExpandedAineisto] = useState<Key[]>([]);
   const api = useApi();
@@ -81,7 +80,7 @@ export default function HyvaksymisEsitysLukutila({
         )
       }
     >
-      {hyvaksytty && (
+      {hyvaksymisEsitys.hyvaksymisPaiva && (
         <Section noDivider>
           <Notification type={NotificationType.INFO_GREEN}>
             Hyväksymisesitys on lähetetty vastaanottajalle {formatDate(hyvaksymisEsitys.hyvaksymisPaiva)}:{" "}


### PR DESCRIPTION
Toteutettu sulje muokkaus -nappi. Lisätty leaveConfirm hyväksymisesityksen lomakesivulle. Laitettu custom "leave confirm" myös muokkauksen sulkemistoimintoon. Huom! Sketch-kuvista poiketen muokkauksen sulkunapin teksti on "Sulje muokkaus" eikä "Palaa tallentamatta". Tämä on tahallista.

Huom! Muokkaustilan sulkeminen onnistuu vain, jos hyväksymisesitykselle merkityt kaikki tiedostot ovat oikeasti olemassa (eikä esim. feikattu).