### PR TITLE
fix: HASSUYP-332: Otetaan virtualisointi pois käytöstä

### DIFF
--- a/src/components/HyvaksymisEsitys/LomakeComponents/TiedostoInputNewTable.tsx
+++ b/src/components/HyvaksymisEsitys/LomakeComponents/TiedostoInputNewTable.tsx
@@ -166,7 +166,7 @@ export default function TiedostoInputNewTable<S extends GenTiedosto>({
     },
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
     getRowId: (row) => row.uuid,
-    meta: { tableId: id, findRowIndex, onDragAndDrop, virtualization: { type: "window" } },
+    meta: { tableId: id, findRowIndex, onDragAndDrop },
   });
 
   return <HassuTable table={table} />;

--- a/src/components/projekti/common/AineistojenValitseminenDialog.tsx
+++ b/src/components/projekti/common/AineistojenValitseminenDialog.tsx
@@ -178,7 +178,7 @@ const columns: ColumnDef<VelhoAineisto>[] = [
       widthFractions: 2,
     },
   },
-  { header: "Dokumenttityyppi", accessorKey: "dokumenttiTyyppi", meta: { widthFractions: 2 } },
+  { header: "Dokumenttityyppi", accessorKey: "dokumenttiTyyppi", meta: { widthFractions: 2, minWidth: 160 } },
   {
     header: "Koko (kB)",
     accessorKey: "koko",
@@ -198,7 +198,6 @@ const AineistoTable = ({ data, rowSelection = {}, onRowSelectionChange, scrollEl
     state: { pagination: undefined, rowSelection },
     enableRowSelection: true,
     enableSorting: false,
-    meta: { virtualization: { type: "scrollElement", getScrollElement: () => scrollElement.current } },
   });
 
   return <HassuTable table={table} />;

--- a/src/components/projekti/common/AineistojenValitseminenDialog.tsx
+++ b/src/components/projekti/common/AineistojenValitseminenDialog.tsx
@@ -1,12 +1,11 @@
 import { RefObject, useEffect, useMemo, useRef, useState } from "react";
 import Button from "@components/button/Button";
 import HassuDialog from "@components/HassuDialog";
-import { DialogActions, DialogContent, Divider, Stack, styled } from "@mui/material";
+import { DialogProps, DialogActions, DialogContent, Divider, Stack, styled } from "@mui/material";
 import HassuAccordion from "@components/HassuAccordion";
 import { VelhoAineisto, VelhoToimeksianto } from "@services/api";
 import { useProjekti } from "src/hooks/useProjekti";
 import { formatDateTime } from "hassu-common/util/dateUtils";
-import { DialogProps } from "@mui/material";
 import HassuTable, { selectColumnDef } from "@components/table/HassuTable";
 import VelhoAineistoNimiExtLink from "../VelhoAineistoNimiExtLink";
 import useApi from "src/hooks/useApi";
@@ -188,7 +187,7 @@ const columns: ColumnDef<VelhoAineisto>[] = [
   selectColumnDef(),
 ];
 
-const AineistoTable = ({ data, rowSelection = {}, onRowSelectionChange, scrollElement }: AineistoTableProps) => {
+const AineistoTable = ({ data, rowSelection = {}, onRowSelectionChange }: AineistoTableProps) => {
   const table = useReactTable({
     columns,
     data,

--- a/src/components/projekti/common/Aineistot/AineistoNewTable/AineistoTable.tsx
+++ b/src/components/projekti/common/Aineistot/AineistoNewTable/AineistoTable.tsx
@@ -110,7 +110,7 @@ export function AineistoTable(props: AineistoTableProps) {
     },
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
     getRowId: (row) => row.uuid,
-    meta: { tableId: `${props.kategoriaId}_table`, findRowIndex, onDragAndDrop, virtualization: { type: "window" } },
+    meta: { tableId: `${props.kategoriaId}_table`, findRowIndex, onDragAndDrop },
   });
 
   return <HassuTable table={table} />;

--- a/src/components/projekti/common/Aineistot/AineistoTable/AineistoTable.tsx
+++ b/src/components/projekti/common/Aineistot/AineistoTable/AineistoTable.tsx
@@ -167,7 +167,7 @@ export function AineistoTable(props: Readonly<AineistoTableProps>) {
     },
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
     getRowId: (row) => row.id,
-    meta: { tableId: `${props.kategoriaId}_table`, findRowIndex, onDragAndDrop, virtualization: { type: "window" } },
+    meta: { tableId: `${props.kategoriaId}_table`, findRowIndex, onDragAndDrop },
   });
   return <HassuTable table={table} />;
 }

--- a/src/components/projekti/lausuntopyynnot/LausuntoPyynnonTaydennysForm/Muistutukset/Table.tsx
+++ b/src/components/projekti/lausuntopyynnot/LausuntoPyynnonTaydennysForm/Muistutukset/Table.tsx
@@ -100,7 +100,7 @@ export default function AineistoTable({
     },
     getRowId: (row) => row.id,
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
-    meta: { findRowIndex, onDragAndDrop, virtualization: { type: "window" } },
+    meta: { findRowIndex, onDragAndDrop },
   });
   return <HassuTable table={tableProps} />;
 }

--- a/src/components/projekti/lausuntopyynnot/LausuntoPyynnonTaydennysForm/MuuAineisto/Table.tsx
+++ b/src/components/projekti/lausuntopyynnot/LausuntoPyynnonTaydennysForm/MuuAineisto/Table.tsx
@@ -100,7 +100,7 @@ export default function AineistoTable({
     },
     getRowId: (row) => row.id,
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
-    meta: { findRowIndex, onDragAndDrop, virtualization: { type: "window" } },
+    meta: { findRowIndex, onDragAndDrop },
   });
   return <HassuTable table={tableProps} />;
 }

--- a/src/components/projekti/lausuntopyynnot/LausuntoPyyntoForm/LisaAineistot/Table.tsx
+++ b/src/components/projekti/lausuntopyynnot/LausuntoPyyntoForm/LisaAineistot/Table.tsx
@@ -99,7 +99,7 @@ export default function AineistoTable({
     },
     getRowId: (row) => row.id,
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
-    meta: { findRowIndex, onDragAndDrop, virtualization: { type: "window" } },
+    meta: { findRowIndex, onDragAndDrop },
   });
   return <HassuTable table={tableProps} />;
 }

--- a/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
+++ b/src/components/projekti/nahtavillaolo/nahtavilleAsetettavatAineistot/Lukunakyma.tsx
@@ -43,7 +43,7 @@ export default function Lukunakyma() {
         {nahtavillaoloMenneisyydessa ? (
           <p>
             Aineistot ovat olleet nähtävillä palvelun julkisella puolella {formatDate(julkaisu.kuulutusPaiva)}—
-            {formatDate(julkaisu.kuulutusVaihePaattyyPaiva)} välisen ajan. Nähtävilleasetetut aineistot löytyvät
+            {formatDate(julkaisu.kuulutusVaihePaattyyPaiva)} välisen ajan. Nähtävilleasetetut aineistot löytyvät{" "}
             <ExtLink href={velhoURL}>Projektivelhosta</ExtLink>.
           </p>
         ) : (

--- a/src/components/projekti/paatos/aineistot/Lukunakyma.tsx
+++ b/src/components/projekti/paatos/aineistot/Lukunakyma.tsx
@@ -51,7 +51,7 @@ export default function Lukunakyma({ projekti, paatosTyyppi }: Readonly<Props>) 
         {paatosJulkaisuMenneisyydessa ? (
           <p>
             Aineistot ovat olleet nähtävillä palvelun julkisella puolella {formatDate(julkaisu.kuulutusPaiva)}—
-            {formatDate(julkaisu.kuulutusVaihePaattyyPaiva)} välisen ajan. Nähtävilleasetetut aineistot löytyvät
+            {formatDate(julkaisu.kuulutusVaihePaattyyPaiva)} välisen ajan. Nähtävilleasetetut aineistot löytyvät{" "}
             <ExtLink style={{ marginLeft: "5px" }} href={velhoURL}>
               Projektivelhosta
             </ExtLink>

--- a/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/HyvaksymisPaatosTiedostotTaulu.tsx
+++ b/src/components/projekti/paatos/aineistot/MuokkausNakyma/TiedostoLomake/HyvaksymisPaatosTiedostotTaulu.tsx
@@ -95,7 +95,7 @@ export default function AineistoTable({ vaihe }: { vaihe: HyvaksymisPaatosVaihe 
     },
     getRowId: (row) => row.id,
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
-    meta: { findRowIndex, onDragAndDrop, virtualization: { type: "window" } },
+    meta: { findRowIndex, onDragAndDrop },
   });
   return <HassuTable table={tableProps} />;
 }

--- a/src/components/projekti/suunnitteluvaihe/komponentit/AineistoTable.tsx
+++ b/src/components/projekti/suunnitteluvaihe/komponentit/AineistoTable.tsx
@@ -187,7 +187,7 @@ const AineistoTable = ({
     getRowId: (row) => row.id,
     state: { pagination: undefined },
     enableSorting: false,
-    meta: { onDragAndDrop, findRowIndex, virtualization: { type: "window" } },
+    meta: { onDragAndDrop, findRowIndex },
   });
 
   return <HassuTable table={table} />;

--- a/src/components/table/HassuTable.tsx
+++ b/src/components/table/HassuTable.tsx
@@ -64,7 +64,7 @@ export const selectColumnDef: <T>() => ColumnDef<T> = () => ({
       />
     </Span>
   ),
-  meta: { minWidth: 100, widthFractions: 1 },
+  meta: { minWidth: 60, widthFractions: 1 },
 });
 
 function SelectHeader<T>(props: HeaderContext<T, unknown>) {
@@ -175,11 +175,10 @@ const BodyContentVirElement = dynamic(() => import("./BodyContentVirtualElement"
 
 function TableBody<T>({ gridTemplateColumns, table }: HassuTableProps<T> & { gridTemplateColumns: string }) {
   const virtualizationOptions = table.options.meta?.virtualization;
-  const useVirtualization = table.getRowModel().rows.length > 400;
-  if (useVirtualization && virtualizationOptions?.type === "window") {
+  if (virtualizationOptions?.type === "window") {
     const BodyContentVirtualWindow = BodyContentVirWindow as React.ComponentType<BodyContentVirtualWindowProps<T>>;
     return <BodyContentVirtualWindow table={table} gridTemplateColumns={gridTemplateColumns} />;
-  } else if (useVirtualization && virtualizationOptions?.type === "scrollElement" && virtualizationOptions?.getScrollElement) {
+  } else if (virtualizationOptions?.type === "scrollElement" && virtualizationOptions?.getScrollElement) {
     const BodyContentVirtualWindow = BodyContentVirElement as React.ComponentType<BodyContentVirtualElementProps<T>>;
     return (
       <BodyContentVirtualWindow

--- a/src/components/table/HassuTable.tsx
+++ b/src/components/table/HassuTable.tsx
@@ -175,7 +175,7 @@ const BodyContentVirElement = dynamic(() => import("./BodyContentVirtualElement"
 
 function TableBody<T>({ gridTemplateColumns, table }: HassuTableProps<T> & { gridTemplateColumns: string }) {
   const virtualizationOptions = table.options.meta?.virtualization;
-  const useVirtualization = table.getRowModel().rows.length > 100;
+  const useVirtualization = table.getRowModel().rows.length > 400;
   if (useVirtualization && virtualizationOptions?.type === "window") {
     const BodyContentVirtualWindow = BodyContentVirWindow as React.ComponentType<BodyContentVirtualWindowProps<T>>;
     return <BodyContentVirtualWindow table={table} gridTemplateColumns={gridTemplateColumns} />;

--- a/src/components/table/HassuTable.tsx
+++ b/src/components/table/HassuTable.tsx
@@ -175,11 +175,11 @@ const BodyContentVirElement = dynamic(() => import("./BodyContentVirtualElement"
 
 function TableBody<T>({ gridTemplateColumns, table }: HassuTableProps<T> & { gridTemplateColumns: string }) {
   const virtualizationOptions = table.options.meta?.virtualization;
-
-  if (virtualizationOptions?.type === "window") {
+  const useVirtualization = table.getRowModel().rows.length > 100;
+  if (useVirtualization && virtualizationOptions?.type === "window") {
     const BodyContentVirtualWindow = BodyContentVirWindow as React.ComponentType<BodyContentVirtualWindowProps<T>>;
     return <BodyContentVirtualWindow table={table} gridTemplateColumns={gridTemplateColumns} />;
-  } else if (virtualizationOptions?.type === "scrollElement" && virtualizationOptions?.getScrollElement) {
+  } else if (useVirtualization && virtualizationOptions?.type === "scrollElement" && virtualizationOptions?.getScrollElement) {
     const BodyContentVirtualWindow = BodyContentVirElement as React.ComponentType<BodyContentVirtualElementProps<T>>;
     return (
       <BodyContentVirtualWindow


### PR DESCRIPTION
Projektissa VLS-TESTI Peten projekti 2 on valmiiksi aineistoja vajaa 900. Ei niitä tosin noin montaa voi valita, kun dynamodb:ssä tila loppuu kesken viimeistään siinä vaiheessa kun yrittää hyväksyä.