### PR TITLE
fix: HASSUYP-490: Päätöksen kuulutusaika päätynyt viesti myös projektipäällikölle ja HASSUYP-491: Päätöksen kuulutusaika päättynyt viesti myös jatkopäätöksistä

### DIFF
--- a/backend/src/sqsEvents/projektiScheduleManager.ts
+++ b/backend/src/sqsEvents/projektiScheduleManager.ts
@@ -261,7 +261,8 @@ abstract class AbstractHyvaksymisPaatosVaiheScheduleManager extends VaiheSchedul
 }
 
 const HYVAKSYMISPAATOS_VAIHE = "HyvaksymisPaatosVaihe";
-
+const JATKOPAATOS1_VAIHE = "JatkoPaatos1Vaihe";
+const JATKOPAATOS2_VAIHE = "JatkoPaatos2Vaihe";
 export class HyvaksymisPaatosVaiheScheduleManager extends AbstractHyvaksymisPaatosVaiheScheduleManager {
   getSchedule(): PublishOrExpireEvent[] {
     const julkaisut = findJulkaisutWithTila(this.julkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
@@ -272,19 +273,21 @@ export class HyvaksymisPaatosVaiheScheduleManager extends AbstractHyvaksymisPaat
 export class JatkoPaatos1VaiheScheduleManager extends AbstractHyvaksymisPaatosVaiheScheduleManager {
   getSchedule(): PublishOrExpireEvent[] {
     const julkaisut = findJulkaisutWithTila(this.julkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
-    return getPublishExpireScheduleForVaiheJulkaisut(julkaisut, "JatkoPaatos1Vaihe", "JATKOPAATOS1VAIHE", JATKOPAATOS_DURATION);
+    return getPublishExpireScheduleForVaiheJulkaisut(julkaisut, JATKOPAATOS1_VAIHE, "JATKOPAATOS1VAIHE", JATKOPAATOS_DURATION);
   }
 }
 
 export class JatkoPaatos2VaiheScheduleManager extends AbstractHyvaksymisPaatosVaiheScheduleManager {
   getSchedule(): PublishOrExpireEvent[] {
     const julkaisut = findJulkaisutWithTila(this.julkaisut, KuulutusJulkaisuTila.HYVAKSYTTY);
-    return getPublishExpireScheduleForVaiheJulkaisut(julkaisut, "JatkoPaatos2Vaihe", "JATKOPAATOS2VAIHE", JATKOPAATOS_DURATION);
+    return getPublishExpireScheduleForVaiheJulkaisut(julkaisut, JATKOPAATOS2_VAIHE, "JATKOPAATOS2VAIHE", JATKOPAATOS_DURATION);
   }
 }
 
 const KUULUTUSVAIHE_PAATTYY = " kuulutusvaihe päättyy";
 export const HYVAKSYMISPAATOS_VAIHE_PAATTYY = HYVAKSYMISPAATOS_VAIHE + KUULUTUSVAIHE_PAATTYY;
+export const JATKOPAATOS1_VAIHE_PAATTYY = JATKOPAATOS1_VAIHE + KUULUTUSVAIHE_PAATTYY;
+export const JATKOPAATOS2_VAIHE_PAATTYY = JATKOPAATOS2_VAIHE + KUULUTUSVAIHE_PAATTYY;
 
 function getPublishExpireScheduleForVaiheJulkaisut(
   julkaisut: Pick<NahtavillaoloVaiheJulkaisu & HyvaksymisPaatosVaiheJulkaisu, "kuulutusPaiva" | "kuulutusVaihePaattyyPaiva">[] | undefined,

--- a/backend/src/util/lausuntoPyyntoUtil.ts
+++ b/backend/src/util/lausuntoPyyntoUtil.ts
@@ -19,12 +19,34 @@ export function findLatestHyvaksyttyNahtavillaoloVaiheJulkaisu(
   );
 }
 
+type PaatosVaihe = HyvaksymisPaatosVaiheJulkaisu | HyvaksymisPaatosVaihe | undefined;
+
 export function findLatestHyvaksyttyHyvaksymispaatosVaiheJulkaisu(
   projekti: Pick<DBProjekti, "hyvaksymisPaatosVaiheJulkaisut" | "hyvaksymisPaatosVaihe">
-): HyvaksymisPaatosVaiheJulkaisu | HyvaksymisPaatosVaihe | undefined {
+): PaatosVaihe {
   return (
     projekti.hyvaksymisPaatosVaiheJulkaisut?.filter((julkaisu) => julkaisu.tila === KuulutusJulkaisuTila.HYVAKSYTTY).pop() ??
     projekti.hyvaksymisPaatosVaihe ??
+    undefined
+  );
+}
+
+export function findLatestJatko1paatosVaiheJulkaisu(
+  projekti: Pick<DBProjekti, "jatkoPaatos1VaiheJulkaisut" | "jatkoPaatos1Vaihe">
+): PaatosVaihe {
+  return (
+    projekti.jatkoPaatos1VaiheJulkaisut?.filter((julkaisu) => julkaisu.tila === KuulutusJulkaisuTila.HYVAKSYTTY).pop() ??
+    projekti.jatkoPaatos1Vaihe ??
+    undefined
+  );
+}
+
+export function findLatestJatko2paatosVaiheJulkaisu(
+  projekti: Pick<DBProjekti, "jatkoPaatos2VaiheJulkaisut" | "jatkoPaatos2Vaihe">
+): PaatosVaihe {
+  return (
+    projekti.jatkoPaatos2VaiheJulkaisut?.filter((julkaisu) => julkaisu.tila === KuulutusJulkaisuTila.HYVAKSYTTY).pop() ??
+    projekti.jatkoPaatos2Vaihe ??
     undefined
   );
 }

--- a/src/pages/yllapito/projekti/[oid]/testikomento.dev.tsx
+++ b/src/pages/yllapito/projekti/[oid]/testikomento.dev.tsx
@@ -1,180 +1,131 @@
-import { TestiKomento, TestiKomentoVaihe } from "@services/api";
-import { api } from "@services/api/permanentApi";
-
+import { apiConfig, TestiKomento, TestiKomentoVaihe } from "@services/api";
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useEffect, useMemo, useState } from "react";
 import useApi from "src/hooks/useApi";
 import { ProjektiTestCommandExecutor, TestAction } from "../../../../../common/testUtil.dev";
+import { API } from "@services/api/commonApi";
+import useSWR from "swr";
 
 export default function Testikomento(): ReactElement {
   const [result, setResult] = useState<string>("");
-  const router = useRouter();
   const api = useApi();
-
+  const router = useRouter();
+  const commandLoader = useMemo(() => testCommandExecutor(api), [api]);
+  const { data } = useSWR([apiConfig.suoritaTestiKomento.graphql, router.query], commandLoader);
   useEffect(() => {
-    runTestCommand(router.query)
-      .then((action) => {
-        setResult("OK");
-        if (TestAction.MIGROI !== action) {
-          setTimeout(() => {
-            window.history.back();
-          }, 2000);
-        }
-      })
-      .catch((e) => {
-        console.error(e);
-        setResult(e.message);
-      });
-  }, [api, router.query]);
+    setResult(data?.result ?? "Komentoa suoritetaan...");
+    if (data?.action && TestAction.MIGROI !== data.action) {
+      setTimeout(() => {
+        window.history.back();
+      }, 2000);
+    }
+  }, [data]);
   return <p id="result">{result}</p>;
 }
 
-async function runTestCommand(query: ParsedUrlQuery) {
-  let executor = new ProjektiTestCommandExecutor(query);
-
-  await executor.onAjansiirto(async (_oid: string, days: string) => {
-    console.log("onAjansiirto", days);
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      ajansiirtoPaivina: Number(days),
-    });
-  });
-
-  await executor.onVuorovaikutusKierrosMenneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      ajansiirtoPaivina: 1,
-      vaihe: TestiKomentoVaihe.VUOROVAIKUTUKSET,
-    });
-  });
-
-  await executor.onNahtavillaoloMenneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      ajansiirtoPaivina: 1,
-      vaihe: TestiKomentoVaihe.NAHTAVILLAOLO,
-    });
-  });
-
-  await executor.onHyvaksymispaatosMenneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      ajansiirtoPaivina: 1,
-      vaihe: TestiKomentoVaihe.HYVAKSYMISVAIHE,
-    });
-  });
-
-  await executor.onHyvaksymispaatosVuosiMenneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      vaihe: TestiKomentoVaihe.HYVAKSYMISVAIHE,
-      ajansiirtoPaivina: 367,
-    });
-  });
-
-  await executor.onJatkopaatos1Menneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      ajansiirtoPaivina: 1,
-      vaihe: TestiKomentoVaihe.JATKOPAATOS1VAIHE,
-    });
-  });
-
-  await executor.onJatkopaatos1VuosiMenneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      vaihe: TestiKomentoVaihe.JATKOPAATOS1VAIHE,
-      ajansiirtoPaivina: 367,
-    });
-  });
-
-  await executor.onJatkopaatos2Menneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      ajansiirtoPaivina: 1,
-      vaihe: TestiKomentoVaihe.JATKOPAATOS2VAIHE,
-    });
-  });
-
-  await executor.onJatkopaatos2VuosiMenneisyyteen(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.AJANSIIRTO,
-      vaihe: TestiKomentoVaihe.JATKOPAATOS2VAIHE,
-      ajansiirtoPaivina: 367,
-    });
-  });
-
-  await executor.onResetAloituskuulutus(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.RESET,
-      vaihe: TestiKomentoVaihe.ALOITUSKUULUTUS,
-    });
-  });
-
-  await executor.onResetSuunnittelu(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.RESET,
-      vaihe: TestiKomentoVaihe.SUUNNITTELU,
-    });
-  });
-
-  await executor.onResetVuorovaikutukset(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.RESET,
-      vaihe: TestiKomentoVaihe.VUOROVAIKUTUKSET,
-    });
-  });
-
-  await executor.onResetNahtavillaolo(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.RESET,
-      vaihe: TestiKomentoVaihe.NAHTAVILLAOLO,
-    });
-  });
-
-  await executor.onResetHyvaksymisvaihe(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.RESET,
-      vaihe: TestiKomentoVaihe.HYVAKSYMISVAIHE,
-    });
-  });
-
-  await executor.onResetJatkopaatos1vaihe(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.RESET,
-      vaihe: TestiKomentoVaihe.JATKOPAATOS1VAIHE,
-    });
-  });
-
-  await executor.onMigraatio(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.MIGRAATIO,
-      migraatioTargetStatus: executor._targetStatus,
-    });
-  });
-
-  await executor.onKaynnistaAsianhallintaSynkronointi(async () => {
-    await api.suoritaTestiKomento({
-      oid: executor.getOid(),
-      tyyppi: TestiKomento.VIE_ASIANHALLINTAAN,
-    });
-  });
-  return executor._action;
-}
+const testCommandExecutor = (api: API) => async (_query: string, routerQuery: ParsedUrlQuery) => {
+  let executor = new ProjektiTestCommandExecutor(routerQuery);
+  if (!executor.getOid()) {
+    return null;
+  }
+  let tyyppi: TestiKomento | undefined;
+  let vaihe: TestiKomentoVaihe | undefined;
+  let ajansiirtoPaivina: number | undefined;
+  let migraatioTargetStatus: string | undefined;
+  switch (executor._action) {
+    case TestAction.MIGROI:
+      tyyppi = TestiKomento.MIGRAATIO;
+      migraatioTargetStatus = executor._targetStatus;
+      break;
+    case TestAction.RESET_ALOITUSKUULUTUS:
+      tyyppi = TestiKomento.RESET;
+      vaihe = TestiKomentoVaihe.ALOITUSKUULUTUS;
+      break;
+    case TestAction.RESET_SUUNNITTELU:
+      tyyppi = TestiKomento.RESET;
+      vaihe = TestiKomentoVaihe.SUUNNITTELU;
+      break;
+    case TestAction.RESET_NAHTAVILLAOLO:
+      tyyppi = TestiKomento.RESET;
+      vaihe = TestiKomentoVaihe.NAHTAVILLAOLO;
+      break;
+    case TestAction.RESET_VUOROVAIKUTUKSET:
+      tyyppi = TestiKomento.RESET;
+      vaihe = TestiKomentoVaihe.VUOROVAIKUTUKSET;
+      break;
+    case TestAction.RESET_JATKOPAATOS1VAIHE:
+      tyyppi = TestiKomento.RESET;
+      vaihe = TestiKomentoVaihe.JATKOPAATOS1VAIHE;
+      break;
+    case TestAction.RESET_HYVAKSYMISVAIHE:
+      tyyppi = TestiKomento.RESET;
+      vaihe = TestiKomentoVaihe.HYVAKSYMISVAIHE;
+      break;
+    case TestAction.KAYNNISTA_ASIANHALLINTA_SYNKRONOINTI:
+      tyyppi = TestiKomento.VIE_ASIANHALLINTAAN;
+      break;
+    case TestAction.AJANSIIRTO:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      ajansiirtoPaivina = Number(executor._days);
+      break;
+    case TestAction.VUOROVAIKUTUSKIERROS_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.VUOROVAIKUTUKSET;
+      ajansiirtoPaivina = 1;
+      break;
+    case TestAction.NAHTAVILLAOLO_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.NAHTAVILLAOLO;
+      ajansiirtoPaivina = 1;
+      break;
+    case TestAction.HYVAKSYMISPAATOS_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.HYVAKSYMISVAIHE;
+      ajansiirtoPaivina = 1;
+      break;
+    case TestAction.JATKOPAATOS1_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.JATKOPAATOS1VAIHE;
+      ajansiirtoPaivina = 1;
+      break;
+    case TestAction.JATKOPAATOS2_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.JATKOPAATOS2VAIHE;
+      ajansiirtoPaivina = 1;
+      break;
+    case TestAction.HYVAKSYMISPAATOS_VUOSI_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.HYVAKSYMISVAIHE;
+      ajansiirtoPaivina = 367;
+      break;
+    case TestAction.JATKOPAATOS1_VUOSI_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.JATKOPAATOS1VAIHE;
+      ajansiirtoPaivina = 367;
+      break;
+    case TestAction.JATKOPAATOS2_VUOSI_MENNEISYYTEEN:
+      tyyppi = TestiKomento.AJANSIIRTO;
+      vaihe = TestiKomentoVaihe.JATKOPAATOS2VAIHE;
+      ajansiirtoPaivina = 367;
+      break;
+  }
+  let result;
+  try {
+    if (tyyppi) {
+      await api.suoritaTestiKomento({
+        oid: executor.getOid(),
+        tyyppi,
+        ajansiirtoPaivina,
+        migraatioTargetStatus,
+        vaihe,
+      });
+      result = "OK";
+    } else {
+      result = "Tuntematon komento";
+    }
+  } catch (e) {
+    result = e instanceof Error ? e.message : "Tuntematon virhe";
+  }
+  return { result, action: executor._action };
+};


### PR DESCRIPTION
Testikomentojen suoritus myös korjattu, koska developer modessa useEffect suoritetaan kahdesti ja joskus saattoi ehtiä suorittamaan komennon kahteen kertaan.