### PR TITLE
Projektin tallennus epaonnistuu satunnaisesti

### DIFF
--- a/backend/src/aws/parameters.ts
+++ b/backend/src/aws/parameters.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import fetch from "cross-fetch";
 import { assertIsDefined } from "../util/assertions";
 import { config } from "../config";
@@ -24,7 +25,17 @@ interface ParameterData {
   Version: number;
 }
 
+const PARAMETER_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minuuttia
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 100;
+
+interface CachedParameter {
+  value: string | undefined;
+  timestamp: number;
+}
+
 class Parameters {
+  private cache = new Map<string, CachedParameter>();
   private async getParameterForEnv(paramName: string, envName?: string): Promise<string | undefined> {
     let name;
     if (envName) {
@@ -46,28 +57,51 @@ class Parameters {
       }
     } else {
       assertIsDefined(process.env.AWS_SESSION_TOKEN, "process.env.AWS_SESSION_TOKEN puuttuu!");
-      const response = await fetch(
-        `http://localhost:2773/systemsmanager/parameters/get/?name=${encodeURIComponent(name)}&withDecryption=true`,
-        {
-          headers: {
-            "X-Aws-Parameters-Secrets-Token": process.env.AWS_SESSION_TOKEN,
-          },
+      const url = `http://localhost:2773/systemsmanager/parameters/get/?name=${encodeURIComponent(name)}&withDecryption=true`;
+      const headers = { "X-Aws-Parameters-Secrets-Token": process.env.AWS_SESSION_TOKEN };
+      for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        try {
+          const response = await fetch(url, { headers });
+          if (response.ok) {
+            const data = (await response.json()) as ParameterStoreResponse;
+            return data.Parameter.Value;
+          } else if (!envName) {
+            log.error("getParameter(" + name + ") failed", { response });
+          } else {
+            log.info("getParameter(" + name + ") failed", { response });
+          }
+          break;
+        } catch (e) {
+          if (attempt < MAX_RETRIES) {
+            log.warn(`SSM Lambda Extension -kutsu epäonnistui (yritys ${attempt + 1}/${MAX_RETRIES + 1}), yritetään uudelleen`, {
+              name,
+              error: e instanceof Error ? e.message : String(e),
+            });
+            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * (attempt + 1)));
+          } else {
+            log.error(`SSM Lambda Extension -kutsu epäonnistui kaikkien yritysten jälkeen`, {
+              name,
+              error: e instanceof Error ? e.message : String(e),
+            });
+            throw e;
+          }
         }
-      );
-      if (response.ok) {
-        const data = (await response.json()) as ParameterStoreResponse;
-        return data.Parameter.Value;
-      } else if (!envName) {
-        log.error("getParameter(" + name + ") failed", { response });
-      } else {
-        // ei lokiteta virhettä kun ympäristökohtaista parametria ei välttämättä löydy
-        log.info("getParameter(" + name + ") failed", { response });
       }
     }
     return undefined;
   }
 
   async getParameter(paramName: string): Promise<string | undefined> {
+    const cached = this.cache.get(paramName);
+    if (cached && Date.now() - cached.timestamp < PARAMETER_CACHE_TTL_MS) {
+      return cached.value;
+    }
+    const value = await this.getParameterUncached(paramName);
+    this.cache.set(paramName, { value, timestamp: Date.now() });
+    return value;
+  }
+
+  private async getParameterUncached(paramName: string): Promise<string | undefined> {
     let value: string | undefined;
     if (process.env.ENVIRONMENT) {
       value = await this.getParameterForEnv(paramName, process.env.ENVIRONMENT);

--- a/backend/test/db-migration-tool/migrateTable.test.ts
+++ b/backend/test/db-migration-tool/migrateTable.test.ts
@@ -115,7 +115,10 @@ describe("migrateTable", () => {
 
     const cfg: TableConfig = {
       name: "TestTable",
-      migrations: [{ versionId: 3, plan }, { versionId: 5, plan }],
+      migrations: [
+        { versionId: 3, plan },
+        { versionId: 5, plan },
+      ],
     };
 
     await migrateTable(cfg, makeOptions());
@@ -127,8 +130,14 @@ describe("migrateTable", () => {
   it("should run pending migrations in order", async () => {
     getVersionStub.resolves(1);
 
-    const plan2 = makePlan({ updateInput: [{ TableName: "T", Key: { id: "a" }, UpdateExpression: "SET x = :v" }], lastEvaluatedKey: undefined });
-    const plan3 = makePlan({ updateInput: [{ TableName: "T", Key: { id: "b" }, UpdateExpression: "SET x = :v" }], lastEvaluatedKey: undefined });
+    const plan2 = makePlan({
+      updateInput: [{ TableName: "T", Key: { id: "a" }, UpdateExpression: "SET x = :v" }],
+      lastEvaluatedKey: undefined,
+    });
+    const plan3 = makePlan({
+      updateInput: [{ TableName: "T", Key: { id: "b" }, UpdateExpression: "SET x = :v" }],
+      lastEvaluatedKey: undefined,
+    });
 
     const cfg: TableConfig = {
       name: "TestTable",
@@ -148,12 +157,15 @@ describe("migrateTable", () => {
   it("should handle pagination across multiple pages", async () => {
     getVersionStub.resolves(0);
 
-    const plan: PagedMigrationRunPlan = sinon.stub()
-      .onFirstCall().resolves({
+    const plan: PagedMigrationRunPlan = sinon
+      .stub()
+      .onFirstCall()
+      .resolves({
         updateInput: [{ TableName: "T", Key: { id: "1" }, UpdateExpression: "SET x = :v" }],
         lastEvaluatedKey: { id: "1" },
       })
-      .onSecondCall().resolves({
+      .onSecondCall()
+      .resolves({
         updateInput: [{ TableName: "T", Key: { id: "2" }, UpdateExpression: "SET x = :v" }],
         lastEvaluatedKey: undefined,
       });
@@ -171,12 +183,15 @@ describe("migrateTable", () => {
   it("should continue to next page when a page has 0 writes", async () => {
     getVersionStub.resolves(0);
 
-    const plan: PagedMigrationRunPlan = sinon.stub()
-      .onFirstCall().resolves({
+    const plan: PagedMigrationRunPlan = sinon
+      .stub()
+      .onFirstCall()
+      .resolves({
         updateInput: [],
         lastEvaluatedKey: { id: "cursor" },
       })
-      .onSecondCall().resolves({
+      .onSecondCall()
+      .resolves({
         updateInput: [{ TableName: "T", Key: { id: "1" }, UpdateExpression: "SET x = :v" }],
         lastEvaluatedKey: undefined,
       });
@@ -229,7 +244,10 @@ describe("migrateTable", () => {
 
     const cfg: TableConfig = {
       name: "TestTable",
-      migrations: [{ versionId: 2, plan }, { versionId: 3, plan }],
+      migrations: [
+        { versionId: 2, plan },
+        { versionId: 3, plan },
+      ],
     };
 
     await migrateTable(cfg, makeDryRunOptions({ forcedTableVersions: { TestTable: 2 } }));

--- a/src/components/projekti/AineistoSivunPainikkeet.tsx
+++ b/src/components/projekti/AineistoSivunPainikkeet.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import Button from "@components/button/Button";
 import Section from "@components/layout/Section";
 import { DialogActions, DialogContent, Stack } from "@mui/material";
@@ -127,7 +128,10 @@ export default function AineistoSivunPainikkeet({
           showSuccessMessage("Aineistojen muokkaustila suljettu");
           await reloadProjekti();
           close();
-        } catch {}
+        } catch {
+          // Ladataan projekti uudelleen, koska backend on saattanut jo päivittää versiota.
+          await reloadProjekti();
+        }
       })()
     );
   }, [withLoadingSpinner, projekti.oid, api, siirtymaTyyppi, showSuccessMessage, reloadProjekti, close]);
@@ -177,6 +181,8 @@ export default function AineistoSivunPainikkeet({
               showSuccessMessage("Aineistot lähetetty hyväksyttäväksi");
             } catch (e) {
               log.error(e);
+              // Ladataan projekti uudelleen, koska backend on saattanut jo päivittää versiota.
+              await reloadProjekti();
             }
           };
           try {
@@ -208,6 +214,8 @@ export default function AineistoSivunPainikkeet({
             await sendForApproval();
           } catch (e) {
             log.error(e);
+            // Ladataan projekti uudelleen, koska tallennus on saattanut onnistua ja kasvattaa versiota.
+            await reloadProjekti();
           }
         })()
       ),

--- a/src/components/projekti/TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx
+++ b/src/components/projekti/TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import Button from "@components/button/Button";
 import Section from "@components/layout/Section2";
 import { Stack } from "@mui/system";
@@ -128,6 +129,9 @@ export default function TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet<TFieldValu
             reloadProjekti();
           } catch (e) {
             log.error("Virhe hyväksyntään lähetyksessä", e);
+            // tallennaJaSiirraTilaa on ei-atominen: tallennus voi onnistua (versio kasvaa) vaikka tilasiirtymä epäonnistuu.
+            // Ladataan projekti uudelleen, jotta lomakkeen versio pysyy synkronissa tietokannan kanssa.
+            await reloadProjekti();
           }
         })()
       ),

--- a/src/components/projekti/UudelleenkuulutaButton.tsx
+++ b/src/components/projekti/UudelleenkuulutaButton.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import Button from "@components/button/Button";
 import HassuDialog from "@components/HassuDialog";
 import { DialogActions, DialogContent, DialogProps } from "@mui/material";
@@ -66,6 +67,8 @@ export const UudelleenkuulutaModal: FunctionComponent<DialogProps & Uudelleenkuu
           } catch (error) {
             log.log("Uudelleenkuulutus Error", error);
             showErrorMessage("Kuulutuksen avaaminen uudelleenkuulutettavaksi epäonnistui");
+            // Ladataan projekti uudelleen, koska backend on saattanut jo päivittää versiota.
+            await reloadProjekti();
           }
           closeDialog(event);
         })()


### PR DESCRIPTION
Yhteenveto: 2. jatkopäätöksen uudelleenkuulutuksen virhe
Havainnot
Kahdella eri projektilla on havaittu sama ongelma: 2. jatkopäätöksen uudelleenkuulutuksen yhteydessä "Lähetä hyväksyttäväksi" -toiminto epäonnistuu, minkä jälkeen myöskään tallennus ei onnistu. Käyttäjälle näytetään dialogi "Tallennus epäonnistui — Toinen käyttäjä on muokannut sivun sisältöä". Ongelma ei toistu joka kerta — toisella projektilla uudelleenkuulutus onnistui ongelmitta, mikä viittaa satunnaiseen infrastruktuuriongelmaan.

Juurisyy
Testin lokeilta löytyi kolmen virheen "ketju", jossa kaksi samalla correlationId:llä (1-69e08d13-7c38296334bdc9100cb39495) projektille 1.2.246.578.5.1.2358066325.616252332.

Virhe 1 — SSM Lambda Extension socket hang up:
PDF-generaattori-Lambda (hassu-pdf-generator-test) yrittää hakea SuomiFiViestitIntegrationEnabled-parametria AWS Parameters and Secrets Lambda Extensionilta (http://localhost:2773/systemsmanager/parameters/get/?name=%2Ftest%2FSuomiFiViestitIntegrationEnabled). Yhteys katkeaa: FetchError: request to http://localhost:2773/... failed, reason: socket hang up. Tämä on tunnettu ongelma Lambda Extensionissa, joka tapahtuu erityisesti cold start -tilanteissa tai Extensionin sisäisten yhteyksien satunnaisesti katketessa. Parametria tarvitaan PDF-generoinnissa sen määrittämiseksi, mikä asiakirjapohja valitaan (Suomi.fi-viestit vaikuttaa mm. kiinteistönomistajille lähetettävän ilmoituksen muotoon).

Virhe 2 — PDF-generointi epäonnistuu:
Koska SSM-kutsu epäonnistuu, asiakirjaService.createHyvaksymisPaatosKuulutusPdf ei pysty generoimaan PDF:ää asiakirjatyypille ILMOITUS_JATKOPAATOSKUULUTUKSESTA2. Virhe propagoituu pdfGeneratorClient.generatePDF:stä takaisin kutsuvaan sendForApproval-metodiin jatkoPaatos2VaiheTilaManager:ssa. Lokissa näkyy "msg":"PDF-generointi ei onnistunut" ja virheen tiedot.

Virhe 3 — Versiokonfliktista johtuva SimultaneousUpdateError:
Tämä on seurausvirhe, joka tapahtuu käyttäjän seuraavalla tallennusyrityksellä. Taustalla on se, että "Lähetä hyväksyttäväksi" -painike kutsuu backendin tallennaJaSiirraTilaa-operaatiota, joka on ei-atominen — se koostuu kahdesta peräkkäisestä vaiheesta:

createOrUpdateProjekti(projekti) — tallentaa lomakkeen tiedot tietokantaan ja kasvattaa projektin version N → N+1. Tämä vaihe onnistuu.

tilaHandler.siirraTila(tilasiirtyma) — lataa projektin uudelleen tietokannasta (versio N+1), kutsuu sendForApproval-metodia, joka yrittää generoida PDF:t. Tämä vaihe epäonnistuu PDF-virheen takia.

Koska vaihe 1 on jo onnistunut, projektin versio tietokannassa on N+1. Virhe propagoituu frontendille, jossa TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet-komponentin lahetaHyvaksyttavaksi-handlerin catch-lohko logittaa virheen mutta ei kutsu reloadProjekti()-funktiota. Tämän seurauksena React Hook Form -lomakkeen versio-kenttä jää arvoon N (alkuperäinen arvo, joka asetettiin defaultValues:ssa projekti.versio:sta).

Kun käyttäjä yrittää seuraavaksi tallentaa (tai lähettää uudelleen hyväksyttäväksi), frontend lähettää tallennaProjekti({ versio: N, ... }). Backend vertaa tätä tietokannan versioon N+1 DynamoDB:n ConditionExpression:lla (attribute_not_exists(#versio) OR #versio = :versioFromInput), ehto ei täyty, ja DynamoDB heittää ConditionalCheckFailedException:n, joka muunnetaan SimultaneousUpdateError:ksi viestillä "Projektia on päivitetty tietokannassa. Lataa projekti uudelleen." Tämä käsitellään globaalisti ApiProvider-komponentissa, joka tunnistaa SimultaneousUpdateError:n ja avaa SivuaOnMuokattuDialog:n: "Tallennus epäonnistui — Toinen käyttäjä on muokannut sivun sisältöä."

Miksi virhe ei toistu joka kerta
SSM Lambda Extension socket hang up on satunnainen infrastruktuuriongelma. Kun Extension toimii normaalisti, PDF-generointi onnistuu ja koko tallennaJaSiirraTilaa-ketju menee läpi ilman ongelmia. Toisella projektilla uudelleenkuulutus onnistui todennäköisesti siksi, että Lambda-instanssi oli jo "lämmin" (warm) eikä Extension-yhteydessä ollut ongelmaa.

Korjaustoimenpiteet
1. Frontend: reloadProjekti() virhetilanteissa

Estetään vanhentuneen version jääminen lomakkeeseen lisäämällä await reloadProjekti() catch-lohkoihin. Tämä varmistaa, että lomakkeen versio-kenttä päivittyy vastaamaan tietokannan tilaa myös silloin, kun ei-atominen operaatio epäonnistuu osittain (tallennus onnistui, tilasiirtymä ei).

Muutetut tiedostot:

[TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx](vscode-webview://080n45ro9mi4gndb1th4gl0dgc1ns8t4k89ncmcfjfs82674o60t/src/components/projekti/TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx) — lahetaHyvaksyttavaksi-handlerin catch-lohko. Tämä on kriittisin korjaus, koska tallennaJaSiirraTilaa on ainoa frontend-operaatio joka tekee ensin tallennuksen (versio kasvaa) ja sitten tilasiirtymän (voi epäonnistua).

[UudelleenkuulutaButton.tsx](vscode-webview://080n45ro9mi4gndb1th4gl0dgc1ns8t4k89ncmcfjfs82674o60t/src/components/projekti/UudelleenkuulutaButton.tsx) — avaaUudelleenkuulutettavaksi-handlerin catch-lohko. siirraTila-kutsu voi sisäisesti tehdä saveVaihe-kutsun joka kasvattaa versiota, ja jos myöhempi vaihe (esim. updateJulkaisu) epäonnistuu, versio on jo muuttunut.

[AineistoSivunPainikkeet.tsx](vscode-webview://080n45ro9mi4gndb1th4gl0dgc1ns8t4k89ncmcfjfs82674o60t/src/components/projekti/AineistoSivunPainikkeet.tsx) — cancelAineistoMuokkaus, sisempi sendForApproval ja ulompi catch-lohko sendForApprovalAineistoMuokkaus-handlerissa. Ulompi catch on tärkeä, koska savePaatosAineisto kutsuu tallennaProjekti:a (versio kasvaa) ja sen jälkeen sendForApproval voi epäonnistua.

2. Backend: SSM-kutsujen retry-logiikka ja välimuisti

Estetään alkuperäinen socket hang up -virhe tekemällä SSM Lambda Extension -kutsut vikasietoisemmiksi.

Muutettu tiedosto: [parameters.ts](vscode-webview://080n45ro9mi4gndb1th4gl0dgc1ns8t4k89ncmcfjfs82674o60t/backend/src/aws/parameters.ts)

Retry-logiikka: Lambda Extension -kutsuille (localhost:2773) lisätty enintään 3 yritystä (alkuperäinen + 2 uudelleenyritystä) kasvavalla viiveellä (100ms, 200ms). Uudelleenyritykset lokitetaan warn-tasolla, ja jos kaikki yritykset epäonnistuvat, lokitetaan error-tasolla ja heitetään alkuperäinen virhe. Tämä kattaa tyypillisen socket hang up -tilanteen, jossa Extension palautuu nopeasti.

In-memory välimuisti: getParameter-metodiin lisätty 5 minuutin TTL-välimuisti. Parametrit kuten SuomiFiViestitIntegrationEnabled muuttuvat harvoin, mutta niitä haetaan toistuvasti — esimerkiksi jokainen PDF-generointi-Lambda-invokointikerta kutsuu isSuomiFiViestitIntegrationEnabled():a. Välimuisti on Lambda-instanssin tasolla ja nollautuu automaattisesti cold startissa, joten parametrimuutokset tulevat voimaan viimeistään 5 minuutin kuluessa tai seuraavassa cold startissa.