### PR TITLE
fix: HASSUYP-837 - Suomi.fi-tiedottaminen epäonnistuu jaetun suunnitelman projektille

### DIFF
--- a/backend/src/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.ts
+++ b/backend/src/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.ts
@@ -13,6 +13,10 @@ export async function haeKuulutettuYhdessaSuunnitelmanimi(
   if (!jaetunProjektinOid) {
     return undefined;
   }
+  // Haetaan nimi suoraan tietokannasta eikä haeLiittyvanProjektinTiedot-funktion kautta,
+  // koska se kutsuu projektiAdapterJulkinen.adaptProjekti:a joka tuo transitiivisen
+  // riippuvuuden s3Cache:en (calculateEndDate → getBankHolidays → s3Cache).
+  // Tässä tarvitaan vain projektin nimi, ei julkisuusstatusta.
   const projekti = await projektiDatabase.loadProjektiByOid(jaetunProjektinOid, true, false);
   if (!projekti?.velho?.nimi) {
     return undefined;

--- a/backend/src/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.ts
+++ b/backend/src/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.ts
@@ -1,8 +1,9 @@
+// Contains code generated or recommended by Amazon Q
 import { Kieli } from "hassu-common/graphql/apiModel";
 import { KaannettavaKieli } from "hassu-common/kaannettavatKielet";
 import { ProjektinJakautuminen } from "../database/model";
 import { haeJaetunProjektinOid } from "../projekti/haeJaetunProjektinOid";
-import { haeLiittyvanProjektinTiedot } from "../projekti/haeLiittyvanProjektinTiedot";
+import { projektiDatabase } from "../database/projektiDatabase";
 
 export async function haeKuulutettuYhdessaSuunnitelmanimi(
   projektinJakautuminen: ProjektinJakautuminen | undefined,
@@ -12,9 +13,16 @@ export async function haeKuulutettuYhdessaSuunnitelmanimi(
   if (!jaetunProjektinOid) {
     return undefined;
   }
-  const liittyvanProjektinTiedot = (await haeLiittyvanProjektinTiedot(jaetunProjektinOid))?.nimi;
-  if (!liittyvanProjektinTiedot) {
+  const projekti = await projektiDatabase.loadProjektiByOid(jaetunProjektinOid, true, false);
+  if (!projekti?.velho?.nimi) {
     return undefined;
   }
-  return kieli === Kieli.RUOTSI && liittyvanProjektinTiedot.RUOTSI ? liittyvanProjektinTiedot.RUOTSI : liittyvanProjektinTiedot.SUOMI;
+  if (
+    kieli === Kieli.RUOTSI &&
+    projekti.kielitiedot?.projektinNimiVieraskielella &&
+    [projekti.kielitiedot.ensisijainenKieli, projekti.kielitiedot.toissijainenKieli].includes(Kieli.RUOTSI)
+  ) {
+    return projekti.kielitiedot.projektinNimiVieraskielella;
+  }
+  return projekti.velho.nimi;
 }

--- a/backend/test/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.test.ts
+++ b/backend/test/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.test.ts
@@ -3,74 +3,59 @@ import { describe, it } from "mocha";
 import * as sinon from "sinon";
 import { expect } from "chai";
 import { Kieli } from "hassu-common/graphql/apiModel";
-import { GetCommand, QueryCommand, DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
-import { mockClient } from "aws-sdk-client-mock";
-import { config } from "../../src/config";
 import { haeKuulutettuYhdessaSuunnitelmanimi } from "../../src/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi";
-import { ProjektinJakautuminen } from "../../src/database/model";
+import { DBProjekti, ProjektinJakautuminen } from "../../src/database/model";
+import { projektiDatabase } from "../../src/database/projektiDatabase";
 
 describe("haeKuulutettuYhdessaSuunnitelmanimi", () => {
-  const tableName = "Projekti-localstack";
-  const tableDataName = "ProjektiData-localstack";
-  let mock: ReturnType<typeof mockClient>;
+  let loadProjektiStub: sinon.SinonStub;
 
   beforeEach(() => {
-    sinon.stub(config, "projektiTableName").returns(tableName);
-    sinon.stub(config, "projektiDataTableName").returns(tableDataName);
+    loadProjektiStub = sinon.stub(projektiDatabase, "loadProjektiByOid");
   });
 
   afterEach(() => {
-    mock?.restore();
     sinon.restore();
   });
 
   it("should return undefined if projektinJakautuminen is undefined", async () => {
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(undefined, Kieli.SUOMI);
     expect(result).to.be.undefined;
+    expect(loadProjektiStub.called).to.be.false;
   });
 
   it("should return undefined if no jaettu projekti oid found", async () => {
     const jakautuminen: ProjektinJakautuminen = {};
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
     expect(result).to.be.undefined;
+    expect(loadProjektiStub.called).to.be.false;
   });
 
   it("should return SUOMI name for jaettuProjektista", async () => {
     const oid = "1.2.3";
     const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
-    mock = mockClient(DynamoDBDocumentClient)
-      .on(GetCommand, { TableName: tableName, Key: { oid } })
-      .resolves({
-        Item: {
-          oid,
-          velho: { nimi: "Suomenkielinen nimi" },
-          kielitiedot: { ensisijainenKieli: Kieli.SUOMI },
-        },
-      })
-      .on(QueryCommand)
-      .resolves({ Items: [] });
+    loadProjektiStub.resolves({
+      oid,
+      velho: { nimi: "Suomenkielinen nimi" },
+      kielitiedot: { ensisijainenKieli: Kieli.SUOMI },
+    } as unknown as DBProjekti);
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
     expect(result).to.equal("Suomenkielinen nimi");
+    expect(loadProjektiStub.calledOnceWith(oid, true, false)).to.be.true;
   });
 
   it("should return RUOTSI name when kieli is RUOTSI and project has Swedish name", async () => {
     const oid = "1.2.3";
     const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
-    mock = mockClient(DynamoDBDocumentClient)
-      .on(GetCommand, { TableName: tableName, Key: { oid } })
-      .resolves({
-        Item: {
-          oid,
-          velho: { nimi: "Suomenkielinen nimi" },
-          kielitiedot: {
-            ensisijainenKieli: Kieli.SUOMI,
-            toissijainenKieli: Kieli.RUOTSI,
-            projektinNimiVieraskielella: "Svenskt namn",
-          },
-        },
-      })
-      .on(QueryCommand)
-      .resolves({ Items: [] });
+    loadProjektiStub.resolves({
+      oid,
+      velho: { nimi: "Suomenkielinen nimi" },
+      kielitiedot: {
+        ensisijainenKieli: Kieli.SUOMI,
+        toissijainenKieli: Kieli.RUOTSI,
+        projektinNimiVieraskielella: "Svenskt namn",
+      },
+    } as unknown as DBProjekti);
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.RUOTSI);
     expect(result).to.equal("Svenskt namn");
   });
@@ -78,21 +63,15 @@ describe("haeKuulutettuYhdessaSuunnitelmanimi", () => {
   it("should return SUOMI name when kieli is RUOTSI but project has no Swedish name", async () => {
     const oid = "1.2.3";
     const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
-    mock = mockClient(DynamoDBDocumentClient)
-      .on(GetCommand, { TableName: tableName, Key: { oid } })
-      .resolves({
-        Item: {
-          oid,
-          velho: { nimi: "Suomenkielinen nimi" },
-          kielitiedot: {
-            ensisijainenKieli: Kieli.SUOMI,
-            toissijainenKieli: Kieli.POHJOISSAAME,
-            projektinNimiVieraskielella: "Sámegillii namma",
-          },
-        },
-      })
-      .on(QueryCommand)
-      .resolves({ Items: [] });
+    loadProjektiStub.resolves({
+      oid,
+      velho: { nimi: "Suomenkielinen nimi" },
+      kielitiedot: {
+        ensisijainenKieli: Kieli.SUOMI,
+        toissijainenKieli: Kieli.POHJOISSAAME,
+        projektinNimiVieraskielella: "Sámegillii namma",
+      },
+    } as unknown as DBProjekti);
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.RUOTSI);
     expect(result).to.equal("Suomenkielinen nimi");
   });
@@ -100,16 +79,10 @@ describe("haeKuulutettuYhdessaSuunnitelmanimi", () => {
   it("should return SUOMI name for jaettuProjekteihin", async () => {
     const oid = "1.2.3";
     const jakautuminen: ProjektinJakautuminen = { jaettuProjekteihin: [oid] };
-    mock = mockClient(DynamoDBDocumentClient)
-      .on(GetCommand, { TableName: tableName, Key: { oid } })
-      .resolves({
-        Item: {
-          oid,
-          velho: { nimi: "Jaetun projektin nimi" },
-        },
-      })
-      .on(QueryCommand)
-      .resolves({ Items: [] });
+    loadProjektiStub.resolves({
+      oid,
+      velho: { nimi: "Jaetun projektin nimi" },
+    } as unknown as DBProjekti);
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
     expect(result).to.equal("Jaetun projektin nimi");
   });
@@ -117,11 +90,7 @@ describe("haeKuulutettuYhdessaSuunnitelmanimi", () => {
   it("should return undefined if project not found in database", async () => {
     const oid = "1.2.3";
     const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
-    mock = mockClient(DynamoDBDocumentClient)
-      .on(GetCommand, { TableName: tableName, Key: { oid } })
-      .resolves({ Item: undefined })
-      .on(QueryCommand)
-      .resolves({ Items: [] });
+    loadProjektiStub.resolves(undefined);
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
     expect(result).to.be.undefined;
   });
@@ -129,13 +98,10 @@ describe("haeKuulutettuYhdessaSuunnitelmanimi", () => {
   it("should return undefined if project has no velho.nimi", async () => {
     const oid = "1.2.3";
     const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
-    mock = mockClient(DynamoDBDocumentClient)
-      .on(GetCommand, { TableName: tableName, Key: { oid } })
-      .resolves({
-        Item: { oid, velho: {} },
-      })
-      .on(QueryCommand)
-      .resolves({ Items: [] });
+    loadProjektiStub.resolves({
+      oid,
+      velho: {},
+    } as unknown as DBProjekti);
     const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
     expect(result).to.be.undefined;
   });

--- a/backend/test/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.test.ts
+++ b/backend/test/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi.test.ts
@@ -1,0 +1,142 @@
+// Contains code generated or recommended by Amazon Q
+import { describe, it } from "mocha";
+import * as sinon from "sinon";
+import { expect } from "chai";
+import { Kieli } from "hassu-common/graphql/apiModel";
+import { GetCommand, QueryCommand, DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+import { mockClient } from "aws-sdk-client-mock";
+import { config } from "../../src/config";
+import { haeKuulutettuYhdessaSuunnitelmanimi } from "../../src/asiakirja/haeKuulutettuYhdessaSuunnitelmanimi";
+import { ProjektinJakautuminen } from "../../src/database/model";
+
+describe("haeKuulutettuYhdessaSuunnitelmanimi", () => {
+  const tableName = "Projekti-localstack";
+  const tableDataName = "ProjektiData-localstack";
+  let mock: ReturnType<typeof mockClient>;
+
+  beforeEach(() => {
+    sinon.stub(config, "projektiTableName").returns(tableName);
+    sinon.stub(config, "projektiDataTableName").returns(tableDataName);
+  });
+
+  afterEach(() => {
+    mock?.restore();
+    sinon.restore();
+  });
+
+  it("should return undefined if projektinJakautuminen is undefined", async () => {
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(undefined, Kieli.SUOMI);
+    expect(result).to.be.undefined;
+  });
+
+  it("should return undefined if no jaettu projekti oid found", async () => {
+    const jakautuminen: ProjektinJakautuminen = {};
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
+    expect(result).to.be.undefined;
+  });
+
+  it("should return SUOMI name for jaettuProjektista", async () => {
+    const oid = "1.2.3";
+    const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
+    mock = mockClient(DynamoDBDocumentClient)
+      .on(GetCommand, { TableName: tableName, Key: { oid } })
+      .resolves({
+        Item: {
+          oid,
+          velho: { nimi: "Suomenkielinen nimi" },
+          kielitiedot: { ensisijainenKieli: Kieli.SUOMI },
+        },
+      })
+      .on(QueryCommand)
+      .resolves({ Items: [] });
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
+    expect(result).to.equal("Suomenkielinen nimi");
+  });
+
+  it("should return RUOTSI name when kieli is RUOTSI and project has Swedish name", async () => {
+    const oid = "1.2.3";
+    const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
+    mock = mockClient(DynamoDBDocumentClient)
+      .on(GetCommand, { TableName: tableName, Key: { oid } })
+      .resolves({
+        Item: {
+          oid,
+          velho: { nimi: "Suomenkielinen nimi" },
+          kielitiedot: {
+            ensisijainenKieli: Kieli.SUOMI,
+            toissijainenKieli: Kieli.RUOTSI,
+            projektinNimiVieraskielella: "Svenskt namn",
+          },
+        },
+      })
+      .on(QueryCommand)
+      .resolves({ Items: [] });
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.RUOTSI);
+    expect(result).to.equal("Svenskt namn");
+  });
+
+  it("should return SUOMI name when kieli is RUOTSI but project has no Swedish name", async () => {
+    const oid = "1.2.3";
+    const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
+    mock = mockClient(DynamoDBDocumentClient)
+      .on(GetCommand, { TableName: tableName, Key: { oid } })
+      .resolves({
+        Item: {
+          oid,
+          velho: { nimi: "Suomenkielinen nimi" },
+          kielitiedot: {
+            ensisijainenKieli: Kieli.SUOMI,
+            toissijainenKieli: Kieli.POHJOISSAAME,
+            projektinNimiVieraskielella: "Sámegillii namma",
+          },
+        },
+      })
+      .on(QueryCommand)
+      .resolves({ Items: [] });
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.RUOTSI);
+    expect(result).to.equal("Suomenkielinen nimi");
+  });
+
+  it("should return SUOMI name for jaettuProjekteihin", async () => {
+    const oid = "1.2.3";
+    const jakautuminen: ProjektinJakautuminen = { jaettuProjekteihin: [oid] };
+    mock = mockClient(DynamoDBDocumentClient)
+      .on(GetCommand, { TableName: tableName, Key: { oid } })
+      .resolves({
+        Item: {
+          oid,
+          velho: { nimi: "Jaetun projektin nimi" },
+        },
+      })
+      .on(QueryCommand)
+      .resolves({ Items: [] });
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
+    expect(result).to.equal("Jaetun projektin nimi");
+  });
+
+  it("should return undefined if project not found in database", async () => {
+    const oid = "1.2.3";
+    const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
+    mock = mockClient(DynamoDBDocumentClient)
+      .on(GetCommand, { TableName: tableName, Key: { oid } })
+      .resolves({ Item: undefined })
+      .on(QueryCommand)
+      .resolves({ Items: [] });
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
+    expect(result).to.be.undefined;
+  });
+
+  it("should return undefined if project has no velho.nimi", async () => {
+    const oid = "1.2.3";
+    const jakautuminen: ProjektinJakautuminen = { jaettuProjektista: oid };
+    mock = mockClient(DynamoDBDocumentClient)
+      .on(GetCommand, { TableName: tableName, Key: { oid } })
+      .resolves({
+        Item: { oid, velho: {} },
+      })
+      .on(QueryCommand)
+      .resolves({ Items: [] });
+    const result = await haeKuulutettuYhdessaSuunnitelmanimi(jakautuminen, Kieli.SUOMI);
+    expect(result).to.be.undefined;
+  });
+});


### PR DESCRIPTION
**Muutos**
`haeKuulutettuYhdessaSuunnitelmanimi `hakee liittyvän projektin nimen suoraan tietokannasta sen sijaan, että kutsuisi `haeLiittyvanProjektinTiedot`-funktiota.

**Miksi**
Suomi.fi-tiedottaminen epäonnistui jaetun suunnitelman projektille. Kun tiedotettavalla projektilla oli `projektinJakautuminen`-tieto, `haeKuulutettuYhdessaSuunnitelmanimi` kutsui `haeLiittyvanProjektinTiedot`-funktiota, joka adaptoi koko liittyvän projektin julkiseen muotoon (`projektiAdapterJulkinen.adaptProjekti)`. Tämä laukaisi transitiivisen ketjun: `adaptAloitusKuulutusJulkaisuJulkinen` → `calculateEndDate` → `getBankHolidays` → `s3Cache.get()`, joka yritti lukea S3-bucketia. Suomifi-lambdalta puuttui I`NTERNAL_BUCKET_NAME`-ympäristömuuttuja, joten bucket-nimeksi resolvoitui "`unset`" ja kutsu kaatui `PermanentRedirect`-virheeseen.

**Aiempi toteutus**
`haeKuulutettuYhdessaSuunnitelmanimi` kutsui `haeLiittyvanProjektinTiedot(oid)`-funktiota, joka:

1. Haki projektin tietokannasta (`projektiDatabase.loadProjektiByOid`)

2. Adaptoi koko projektin julkiseen muotoon (`projektiAdapterJulkinen.adaptProjekti`) — tämä kävi läpi kaikki julkaisuvaiheet mukaan lukien aloituskuulutuksen, joka transitiivisesti kutsui `calculateEndDate` → `getBankHolidays` → `s3Cache.get()`

3. Tarkisti adaptoinnin tuloksesta onko projekti julkinen

4. Palautti `ProjektinJakotieto`-objektin jossa oli `oid`, `nimi` ja `julkinen`

Tästä `haeKuulutettuYhdessaSuunnitelmanimi` käytti vain `.nimi`-kenttää. Koko adaptointi ja julkisuusstatuksen selvitys oli turhaa työtä tässä kontekstissa.

`projektiAdapterJulkinen.adaptProjekti` on perusteltu silloin kun tarvitaan projektin julkinen näkymä kokonaisuudessaan — esimerkiksi kansalaispuolen API-vastauksissa tai kun tarvitaan tieto projektin julkisuusstatuksesta. `haeLiittyvanProjektinTiedot`-funktio käyttää sitä edelleen oikeutetusti, koska sen muut kutsupaikat (`lisaaJakotiedotJulkisilleJulkaisuille`, `projektiHandler`) tarvitsevat julkinen-kenttää.

`projektiAdapterJulkinen.adaptProjekti` on melko raskas operaatio: se adaptoi aloituskuulutuksen (joka tekee S3-kutsun arkipyhälistan hakemiseksi), vuorovaikutuskierrokset, nähtävilläolovaiheen, hyväksymispäätösvaiheen kolmeen kertaan (hyväksymispäätös, jatkopäätös 1, jatkopäätös 2), laskee aikatauluja, adaptoi henkilöt ja suunnittelusopimuksen sekä selvittää julkisuusstatuksen.

**Uusi toteutus**
`haeKuulutettuYhdessaSuunnitelmanimi` hakee projektin suoraan tietokannasta samalla `projektiDatabase.loadProjektiByOid`-kutsulla ja poimii nimen suoraan `projekti.velho.nimi `/ `projekti.kielitiedot.projektinNimiVieraskielella` -kentistä. Nimen palautuslogiikka (SUOMI/RUOTSI-valinta) on identtinen aiemman kanssa. Erona on, ettei tulosta ajeta raskaan `projektiAdapterJulkinen.adaptProjekti()`-ketjun läpi, jolloin turha riippuvuus S3-cacheen ja arkipyhälaskentaan poistuu.

Käytännössä aiemmin tehtiin yksi tietokantakutsu + S3-kutsu + koko projektin kaikkien vaiheiden adaptointi, nyt tehdään yksi tietokantakutsu ja poimitaan kaksi kenttää.