### PR TITLE
fix: HASSUYP-838 - Suomi.fi-tokenien käsittelyn ja NykyinenSuomifiKayttaja-virhekäsittelyn korjaus

### DIFF
--- a/backend/src/user/userService.ts
+++ b/backend/src/user/userService.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { AppSyncResolverEvent } from "aws-lambda/trigger/appsync-resolver";
 import { validateJwtToken } from "./validatejwttoken";
 import { config } from "../config";
@@ -96,7 +97,7 @@ const identifyLoggedInKansalainen = async (event: AppSyncResolverEvent<unknown>)
   });
   if (response.status === 200) {
     const body = await response.json();
-    const user: SuomiFiCognitoKayttaja = {
+    return {
       "custom:hetu": body.hetu,
       "custom:lahiosoite": body.lahiosoite,
       "custom:postinumero": body.postinumero,
@@ -111,7 +112,6 @@ const identifyLoggedInKansalainen = async (event: AppSyncResolverEvent<unknown>)
       sub: body.sub,
       username: body.preferred_username,
     };
-    setCurrentSuomifiUserToGlobal(user);
   } else {
     log.error("Suomi.fi tietojen haku epäonnistui", {
       statusText: response.statusText,
@@ -192,7 +192,12 @@ if (process.env.USER_IDENTIFIER_FUNCTIONS) {
 }
 
 async function haeSuomifiKayttajaViestitEnabled(cognitoKayttaja: SuomiFiCognitoKayttaja): Promise<boolean> {
-  return !!(await invokeLambda("hassu-suomifi-" + config.env, true, JSON.stringify({ hetu: cognitoKayttaja["custom:hetu"] })));
+  try {
+    return !!(await invokeLambda("hassu-suomifi-" + config.env, true, JSON.stringify({ hetu: cognitoKayttaja["custom:hetu"] })));
+  } catch (e) {
+    log.error("haeSuomifiKayttajaViestitEnabled epäonnistui", { error: e });
+    return false;
+  }
 }
 
 /**

--- a/backend/test/user/userService.test.ts
+++ b/backend/test/user/userService.test.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { describe, it } from "mocha";
 import * as sinon from "sinon";
 import { userService } from "../../src/user";
@@ -8,6 +9,8 @@ import { GetParameterCommand, SSM } from "@aws-sdk/client-ssm";
 import { AppSyncResolverEvent } from "aws-lambda/trigger/appsync-resolver";
 import { defaultUnitTestMocks } from "../mocks";
 import { mockClient } from "aws-sdk-client-mock";
+import * as lambdaModule from "../../src/aws/lambda";
+import { parameters } from "../../src/aws/parameters";
 
 import { expect } from "chai";
 
@@ -78,5 +81,77 @@ describe("userService", () => {
     } as unknown as AppSyncResolverEvent<unknown>);
     const user = userService.requireVaylaUser();
     expect(user.roolit).to.eql(["hassu_admin", "hassu_kayttaja", "HassuAdmin"]);
+  });
+
+  describe("Suomi.fi user identification", () => {
+    let suomifiEnabledStub: sinon.SinonStub;
+    let suomifiViestitEnabledStub: sinon.SinonStub;
+    let invokeLambdaStub: sinon.SinonStub;
+
+    before(() => {
+      suomifiEnabledStub = sinon.stub(parameters, "isSuomiFiIntegrationEnabled");
+      suomifiViestitEnabledStub = sinon.stub(parameters, "isSuomiFiViestitIntegrationEnabled");
+      invokeLambdaStub = sinon.stub(lambdaModule, "invokeLambda");
+    });
+
+    beforeEach(() => {
+      validateTokenStub.returns(undefined);
+      suomifiEnabledStub.resolves(true);
+      suomifiViestitEnabledStub.resolves(false);
+      invokeLambdaStub.resolves("");
+    });
+
+    after(() => {
+      suomifiEnabledStub.restore();
+      suomifiViestitEnabledStub.restore();
+      invokeLambdaStub.restore();
+    });
+
+    it("should return user with kayttajaSuomifiViestitEnabled false when invokeLambda fails", async () => {
+      suomifiViestitEnabledStub.resolves(true);
+      invokeLambdaStub.rejects(new Error("Lambda timeout"));
+
+      // Simulate an identified Suomi.fi user by setting it directly
+      (globalThis as any).currentSuomifiUser = {
+        sub: "test-sub",
+        email: "test@example.com",
+        email_verified: "true",
+        given_name: "Testi",
+        family_name: "Kayttaja",
+        username: "testikayttaja",
+        "custom:hetu": "010101-123A",
+        "custom:lahiosoite": "Testikatu 1",
+        "custom:postinumero": "00100",
+        "custom:postitoimipaikka": "Helsinki",
+        "custom:ulkomainenkunta": "",
+        "custom:ulkomainenlahiosoite": "",
+        "custom:maakoodi": "FI",
+      };
+
+      const kayttaja = await userService.getSuomiFiKayttaja();
+      expect(kayttaja).to.not.be.undefined;
+      expect(kayttaja?.tunnistautunut).to.equal(true);
+      expect(kayttaja?.kayttajaSuomifiViestitEnabled).to.equal(false);
+      expect(kayttaja?.etunimi).to.equal("Testi");
+    });
+
+    it("should return tunnistautunut false when no Suomi.fi user is identified", async () => {
+      (globalThis as any).currentSuomifiUser = undefined;
+
+      const kayttaja = await userService.getSuomiFiKayttaja();
+      expect(kayttaja).to.not.be.undefined;
+      expect(kayttaja?.tunnistautunut).to.equal(false);
+      expect(kayttaja?.suomifiEnabled).to.equal(true);
+    });
+
+    it("should return tunnistautunut false when Suomi.fi integration is disabled", async () => {
+      suomifiEnabledStub.resolves(false);
+      (globalThis as any).currentSuomifiUser = undefined;
+
+      const kayttaja = await userService.getSuomiFiKayttaja();
+      expect(kayttaja).to.not.be.undefined;
+      expect(kayttaja?.tunnistautunut).to.equal(false);
+      expect(kayttaja?.suomifiEnabled).to.equal(false);
+    });
   });
 });

--- a/src/__tests__/util/errorMessageUtil.test.tsx
+++ b/src/__tests__/util/errorMessageUtil.test.tsx
@@ -20,10 +20,10 @@ const createMockErrorResponse = (operationName: string): ErrorResponse => ({
 const mockTranslate = ((key: string) => key) as any;
 
 describe("generateErrorMessage", () => {
-  it("should return specific message for NykyinenSuomifiKayttaja", () => {
+  it("should return generic translated message for kansalainen on NykyinenSuomifiKayttaja error", () => {
     const errorResponse = createMockErrorResponse("NykyinenSuomifiKayttaja");
     const message = generateErrorMessage({ errorResponse, isYllapito: false, t: mockTranslate });
-    expect(message).toBe("Käyttäjätietojen haku epäonnistui. Kokeile päivittää sivu.");
+    expect(message).toBe("error:yleinen");
   });
 
   it("should return specific message for LataaProjekti", () => {

--- a/src/__tests__/util/errorMessageUtil.test.tsx
+++ b/src/__tests__/util/errorMessageUtil.test.tsx
@@ -1,0 +1,46 @@
+// Contains code generated or recommended by Amazon Q
+import { generateErrorMessage } from "../../util/errorMessageUtil";
+import { ErrorResponse } from "@apollo/client/link/error";
+import { Operation } from "@apollo/client";
+
+jest.mock("../../util/env", () => ({
+  getPublicEnv: (key: string) => {
+    if (key === "ENVIRONMENT") return "dev";
+    return undefined;
+  },
+}));
+
+const createMockErrorResponse = (operationName: string): ErrorResponse => ({
+  operation: { operationName, variables: {} } as unknown as Operation,
+  response: { errors: undefined },
+  graphQLErrors: [],
+  forward: jest.fn(),
+});
+
+const mockTranslate = ((key: string) => key) as any;
+
+describe("generateErrorMessage", () => {
+  it("should return specific message for NykyinenSuomifiKayttaja", () => {
+    const errorResponse = createMockErrorResponse("NykyinenSuomifiKayttaja");
+    const message = generateErrorMessage({ errorResponse, isYllapito: false, t: mockTranslate });
+    expect(message).toBe("Käyttäjätietojen haku epäonnistui. Kokeile päivittää sivu.");
+  });
+
+  it("should return specific message for LataaProjekti", () => {
+    const errorResponse = createMockErrorResponse("LataaProjekti");
+    const message = generateErrorMessage({ errorResponse, isYllapito: false, t: mockTranslate });
+    expect(message).toBe("Projektin lataus epäonnistui.");
+  });
+
+  it("should return generic message with operation name for yllapito user on unknown operation", () => {
+    const errorResponse = createMockErrorResponse("TuntematonOperaatio");
+    const message = generateErrorMessage({ errorResponse, isYllapito: true, t: mockTranslate });
+    expect(message).toContain("Odottamaton virhe toiminnossa 'TuntematonOperaatio'.");
+  });
+
+  it("should return translated generic message for kansalainen on unknown operation", () => {
+    const errorResponse = createMockErrorResponse("TuntematonOperaatio");
+    const message = generateErrorMessage({ errorResponse, isYllapito: false, t: mockTranslate });
+    expect(message).toBe("error:yleinen");
+  });
+});

--- a/src/pages/api/refreshtoken.ts
+++ b/src/pages/api/refreshtoken.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { SSM } from "@aws-sdk/client-ssm";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -58,6 +59,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       res.setHeader("Set-Cookie", cookie);
       status = 401;
     }
+  } else {
+    // No refresh token — clear any stale access/id tokens
+    const cookie = [
+      "x-vls-access-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;",
+      "x-vls-refresh-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;",
+      "x-vls-id-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;",
+    ];
+    res.setHeader("Set-Cookie", cookie);
   }
   res.status(200).send({ status, updated: new Date().toUTCString() });
 }

--- a/src/pages/api/token.ts
+++ b/src/pages/api/token.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { SSM } from "@aws-sdk/client-ssm";
 import { NextApiRequest, NextApiResponse } from "next";
 
@@ -55,6 +56,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       `x-vls-access-token=${access_token};path=/;Secure;SameSite=Strict;HttpOnly `,
       `x-vls-refresh-token=${refresh_token};path=/;Secure;SameSite=Strict;HttpOnly `,
       `x-vls-id-token=${id_token};path=/;Secure;SameSite=Strict;HttpOnly `,
+    ];
+    res.setHeader("Set-Cookie", cookie);
+  } else {
+    // Token exchange failed — clear any stale cookies from previous session
+    const cookie = [
+      "x-vls-access-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;",
+      "x-vls-refresh-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;",
+      "x-vls-id-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;",
     ];
     res.setHeader("Set-Cookie", cookie);
   }

--- a/src/util/errorMessageUtil.ts
+++ b/src/util/errorMessageUtil.ts
@@ -52,12 +52,6 @@ const nonGenericErrorMessages: { validator: NonGenericErrorMessageValidator; err
   },
   {
     validator: ({ errorResponse }) => {
-      return errorResponse.operation.operationName === "NykyinenSuomifiKayttaja";
-    },
-    errorMessage: () => "Käyttäjätietojen haku epäonnistui. Kokeile päivittää sivu.",
-  },
-  {
-    validator: ({ errorResponse }) => {
       return errorResponse.operation.operationName === "TallennaProjekti";
     },
     errorMessage: () => "Projektin tallennus epäonnistui.",

--- a/src/util/errorMessageUtil.ts
+++ b/src/util/errorMessageUtil.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { concatCorrelationIdToErrorMessage } from "@components/ApiProvider";
 import { ErrorResponse } from "@apollo/client/link/error";
 import { Translate } from "next-translate";
@@ -48,6 +49,12 @@ const nonGenericErrorMessages: { validator: NonGenericErrorMessageValidator; err
       return errorResponse.operation.operationName === "LataaProjekti";
     },
     errorMessage: () => "Projektin lataus epäonnistui.",
+  },
+  {
+    validator: ({ errorResponse }) => {
+      return errorResponse.operation.operationName === "NykyinenSuomifiKayttaja";
+    },
+    errorMessage: () => "Käyttäjätietojen haku epäonnistui. Kokeile päivittää sivu.",
   },
   {
     validator: ({ errorResponse }) => {


### PR DESCRIPTION
**Ongelma**
Käyttöliittymässä esiintyy ajoittain virhe "Odottamaton virhe toiminnossa 'NykyinenSuomifiKayttaja'" kun kansalainen on kirjautunut Suomi.fi-palveluun.

**Juurisyy**
Ongelman aiheuttaa usean pienen puutteen yhdistelmä Suomi.fi token-käsittelyketjussa:

1. **haeSuomifiKayttajaViestitEnabled Lambda-kutsu ei ole try-catchissa** (`userService.ts`) — Jos `hassu-suomifi-Lambda` epäonnistuu (timeout, throttle, virhe), koko `getSuomiFiKayttaja`-funktio kaatuu käsittelemättömään poikkeukseen ja GraphQL palauttaa virheen käyttöliittymälle.

2. **identifyLoggedInKansalainen käyttää sivuvaikutusta käyttäjän asettamiseen** (`userService.ts`) — Funktio asettaa tunnistetun Suomi.fi-käyttäjän suoraan `globalThis`:iin mutta palauttaa aina `undefined`. `identifyUser`-loopin `else if`-haara ei koskaan toteudu, joten käyttäjän tunnistus toimii vain sivuvaikutuksen kautta. Tämä on hauras ja vaikeuttaa koodin ymmärtämistä.

3. **Vanhat cookiet jäävät roikkumaan virhetilanteissa** (`refreshtoken.ts, token.ts`) — Kun refresh tokenia ei ole cookieissa mutta access token on vielä jäljellä, vanhentunutta access tokenia lähetetään jokaisessa GraphQL-kutsussa backendille turhaan. Vastaavasti jos kirjautumisen token exchange epäonnistuu, edellisen session cookiet jäävät selaimeen.

**Muutokset**
**Backend (`backend/src/user/userService.ts`)**
* `identifyLoggedInKansalainen` palauttaa nyt `SuomiFiCognitoKayttaja`-olion suoraan. `identifyUser`-looppi hoitaa `globalThis`-asettamisen else if-haarassa kuten oli alun perin tarkoitettu.

* `haeSuomifiKayttajaViestitEnabled`-kutsu on nyt try-catchissa. Lambda-virheen sattuessa palautetaan `false` eikä koko query kaadu.

**Cookie-siivous (`src/pages/api/refreshtoken.ts, src/pages/api/token.ts`)**
* `refreshtoken.ts`: Lisätty cookie-siivous (access, refresh, id token) tilanteeseen jossa refresh tokenia ei ole cookieissa. Estää vanhentuneiden tokenien jäämisen roikkumaan.

* `token.ts`: Lisätty cookie-siivous kun Keycloak token exchange epäonnistuu kirjautumisen yhteydessä. Estää edellisen session cookien jäämisen selaimeen.