### PR TITLE
feat: HASSUYP-862 Tarkista viestin lähetystapa lähetyksen yhteydessä

### DIFF
--- a/backend/src/database/muistuttajaDatabase.ts
+++ b/backend/src/database/muistuttajaDatabase.ts
@@ -11,7 +11,7 @@ import { getMuistuttajaTableName } from "../util/environment";
 import { log } from "../logger";
 import { config } from "../config";
 import { chunkArray } from "./chunkArray";
-import { TiedotettavanLahetyksenTila } from "hassu-common/graphql/apiModel";
+import { LahetysTapa, TiedotettavanLahetyksenTila } from "hassu-common/graphql/apiModel";
 import { uuid } from "hassu-common/util/uuid";
 
 export type DBMuistuttaja = {
@@ -33,7 +33,7 @@ export type DBMuistuttaja = {
   vastaanotettu?: string | null;
   muistutus?: string | null;
   oid: string;
-  lahetykset?: { tila: TiedotettavanLahetyksenTila; lahetysaika: string }[];
+  lahetykset?: { tila: TiedotettavanLahetyksenTila; lahetysaika: string; lahetysTapa?: LahetysTapa }[];
   liitteet?: string[] | null;
   maakoodi?: string | null;
   suomifiLahetys?: boolean;

--- a/backend/src/database/omistajaDatabase.ts
+++ b/backend/src/database/omistajaDatabase.ts
@@ -13,7 +13,7 @@ import {
   TransactWriteCommandInput,
 } from "@aws-sdk/lib-dynamodb";
 import { chunkArray } from "./chunkArray";
-import { TiedotettavanLahetyksenTila } from "hassu-common/graphql/apiModel";
+import { LahetysTapa, TiedotettavanLahetyksenTila } from "hassu-common/graphql/apiModel";
 
 export type OmistajaKey = {
   oid: string;
@@ -40,7 +40,7 @@ export type DBOmistaja = {
   kaytossa: boolean;
   suomifiLahetys?: boolean;
   osoitetiedotSaatu?: boolean;
-  lahetykset?: { tila: TiedotettavanLahetyksenTila; lahetysaika: string }[];
+  lahetykset?: { tila: TiedotettavanLahetyksenTila; lahetysaika: string; lahetysTapa?: LahetysTapa }[];
   userCreated?: boolean;
 };
 

--- a/backend/src/projektiSearch/omistajaSearch/kiinteistonomistajaSearchAdapter.ts
+++ b/backend/src/projektiSearch/omistajaSearch/kiinteistonomistajaSearchAdapter.ts
@@ -20,7 +20,13 @@ export type OmistajaDocument = Pick<
   | "kaytossa"
   | "userCreated"
   | "osoitetiedotSaatu"
-> & { maa: string | null; viimeisinLahetysaika: string | null; viimeisinTila: API.TiedotettavanLahetyksenTila | null };
+> & {
+  maa: string | null;
+  hasHetu: boolean;
+  viimeisinLahetysaika: string | null;
+  viimeisinTila: API.TiedotettavanLahetyksenTila | null;
+  viimeisinLahetysTapa: API.LahetysTapa | null;
+};
 
 export function adaptOmistajaToIndex({
   etunimet,
@@ -39,6 +45,7 @@ export function adaptOmistajaToIndex({
   userCreated,
   osoitetiedotSaatu,
   lahetykset,
+  henkilotunnus,
 }: DBOmistaja): OmistajaDocument {
   const viimeisinLahetys = lahetykset?.sort((a, b) => b.lahetysaika.localeCompare(a.lahetysaika))[0];
   return {
@@ -56,8 +63,10 @@ export function adaptOmistajaToIndex({
     kaytossa,
     userCreated,
     osoitetiedotSaatu,
+    hasHetu: !!henkilotunnus,
     viimeisinLahetysaika: viimeisinLahetys?.lahetysaika ?? null,
     viimeisinTila: viimeisinLahetys?.tila ?? null,
+    viimeisinLahetysTapa: viimeisinLahetys?.lahetysTapa ?? null,
   };
 }
 
@@ -98,8 +107,10 @@ function mapHitToApiOmistaja(hit: OmistajaDocumentHit) {
     maa,
     maakoodi,
     osoitetiedotSaatu,
+    hasHetu,
     viimeisinLahetysaika,
     viimeisinTila,
+    viimeisinLahetysTapa,
   } = hit._source;
 
   const dokumentti: API.Omistaja = {
@@ -116,8 +127,10 @@ function mapHitToApiOmistaja(hit: OmistajaDocumentHit) {
     osoitetiedotSaatu,
     paivitetty,
     postinumero,
+    hasHetu,
     viimeisinLahetysaika,
     viimeisinTila,
+    viimeisinLahetysTapa,
   };
   return dokumentti;
 }

--- a/backend/src/suomifi/suomifiHandler.ts
+++ b/backend/src/suomifi/suomifiHandler.ts
@@ -12,7 +12,7 @@ import { muistutusEmailService } from "../muistutus/muistutusEmailService";
 import { projektiDatabase } from "../database/projektiDatabase";
 import { isValidEmail } from "../email/emailUtil";
 import { createKuittausMuistuttajalleEmail } from "../email/emailTemplates";
-import { AsiakirjaTyyppi, Kieli, TiedotettavanLahetyksenTila } from "hassu-common/graphql/apiModel";
+import { AsiakirjaTyyppi, Kieli, LahetysTapa, TiedotettavanLahetyksenTila } from "hassu-common/graphql/apiModel";
 import { DBProjekti, KasittelynTila, Muistutus, SuunnitteluSopimus } from "../database/model";
 import { getSQS } from "../aws/clients/getSQS";
 import { SendMessageBatchRequestEntry } from "@aws-sdk/client-sqs";
@@ -222,12 +222,13 @@ type PaivitaLahetysStatusParameters = {
   traceId?: string;
   muistuttajaIdsForLahetystilaUpdate: string[] | undefined;
   omistajaIdsForLahetystilaUpdate: string[] | undefined;
+  lahetysTapa?: LahetysTapa;
 };
 
 async function paivitaTiedotettavanLahetysStatukset(params: PaivitaLahetysStatusParameters) {
-  const { muistuttajaIdsForLahetystilaUpdate, omistajaIdsForLahetystilaUpdate, tila, id, omistaja, ...commonParams } = params;
+  const { muistuttajaIdsForLahetystilaUpdate, omistajaIdsForLahetystilaUpdate, tila, id, omistaja, lahetysTapa, ...commonParams } = params;
   const lahetysaika = nyt().format(FULL_DATE_TIME_FORMAT_WITH_TZ);
-  await paivitaLahetysStatus({ ...commonParams, id, omistaja, lahetysaika, tila });
+  await paivitaLahetysStatus({ ...commonParams, id, omistaja, lahetysaika, tila, lahetysTapa });
   const tilaForOtherEntities =
     tila === "OK" ? TiedotettavanLahetyksenTila.OK_ERI_KIINTEISTO_MUISTUTUS : TiedotettavanLahetyksenTila.VIRHE_ERI_KIINTEISTO_MUISTUTUS;
   if (muistuttajaIdsForLahetystilaUpdate) {
@@ -239,6 +240,7 @@ async function paivitaTiedotettavanLahetysStatukset(params: PaivitaLahetysStatus
           tila: tilaForOtherEntities,
           id: muistuttajaId,
           lahetysaika,
+          lahetysTapa,
         })
       )
     );
@@ -252,6 +254,7 @@ async function paivitaTiedotettavanLahetysStatukset(params: PaivitaLahetysStatus
           tila: tilaForOtherEntities,
           id: omistajaId,
           lahetysaika,
+          lahetysTapa,
         })
       )
     );
@@ -266,9 +269,10 @@ type PaivitaLahetysStatusParameter = {
   approvalType: PublishOrExpireEventType;
   lahetysaika: string;
   traceId?: string;
+  lahetysTapa?: LahetysTapa;
 };
 
-async function paivitaLahetysStatus({ oid, id, omistaja, tila, approvalType, traceId, lahetysaika }: PaivitaLahetysStatusParameter) {
+async function paivitaLahetysStatus({ oid, id, omistaja, tila, approvalType, traceId, lahetysaika, lahetysTapa }: PaivitaLahetysStatusParameter) {
   const params = new UpdateCommand({
     TableName: omistaja ? getKiinteistonomistajaTableName() : getMuistuttajaTableName(),
     Key: {
@@ -278,7 +282,7 @@ async function paivitaLahetysStatus({ oid, id, omistaja, tila, approvalType, tra
     UpdateExpression: "SET #l = list_append(if_not_exists(#l, :tyhjalista), :status)",
     ExpressionAttributeNames: { "#l": "lahetykset" },
     ExpressionAttributeValues: {
-      ":status": [{ tila, lahetysaika, tyyppi: approvalType, traceId }],
+      ":status": [{ tila, lahetysaika, tyyppi: approvalType, traceId, lahetysTapa }],
       ":tyhjalista": [],
     },
   });
@@ -540,6 +544,7 @@ type LahetaPdfViestiParameters = {
   tyyppi: PublishOrExpireEventType;
   muistuttajaIdsForLahetystilaUpdate: string[] | undefined;
   omistajaIdsForLahetystilaUpdate: string[] | undefined;
+  lahetysTapa: LahetysTapa;
 };
 
 async function lahetaPdfViesti({
@@ -549,6 +554,7 @@ async function lahetaPdfViesti({
   tyyppi,
   muistuttajaIdsForLahetystilaUpdate,
   omistajaIdsForLahetystilaUpdate,
+  lahetysTapa,
 }: LahetaPdfViestiParameters) {
   try {
     const pdf = await generatePdf(projektiFromDB, tyyppi, kohde);
@@ -594,6 +600,7 @@ async function lahetaPdfViesti({
         traceId,
         muistuttajaIdsForLahetystilaUpdate,
         omistajaIdsForLahetystilaUpdate,
+        lahetysTapa,
       });
     } else {
       const traceId = parseTraceId(resp.LahetaViestiResult?.TilaKoodi?.TilaKoodiKuvaus);
@@ -616,6 +623,7 @@ async function lahetaPdfViesti({
       approvalType: tyyppi,
       muistuttajaIdsForLahetystilaUpdate,
       omistajaIdsForLahetystilaUpdate,
+      lahetysTapa,
     });
     throw e;
   }
@@ -699,6 +707,12 @@ async function handleMuistuttaja({
   if (tyyppi === undefined) {
     await lahetaViesti(muistuttaja, kohde.projekti);
   } else if (isMuistuttujanTiedotOk(muistuttaja)) {
+    const client = await getClient();
+    const asiakasResponse = await client.haeAsiakas(muistuttaja.henkilotunnus!, "SSN");
+    const asiakas = asiakasResponse.HaeAsiakkaitaResult?.Asiakkaat?.Asiakas?.find(
+      (a) => a.attributes.AsiakasTunnus === muistuttaja.henkilotunnus
+    );
+    const lahetysTapa = asiakas?.Tila === 300 ? LahetysTapa.VIESTI : LahetysTapa.KIRJE;
     await lahetaPdfViesti({
       projektiFromDB: kohde.projekti,
       kohde: {
@@ -714,6 +728,7 @@ async function handleMuistuttaja({
       tyyppi,
       muistuttajaIdsForLahetystilaUpdate,
       omistajaIdsForLahetystilaUpdate,
+      lahetysTapa,
     });
   } else {
     auditLog.info("Muistuttajalta puuttuu pakollisia tietoja", { muistuttajaId: muistuttaja.id });
@@ -750,6 +765,16 @@ async function handleOmistaja({
   }
   const omistaja = kohde.kohde as DBOmistaja;
   if (isOmistajanTiedotOk(omistaja)) {
+    const tunnus = omistaja.henkilotunnus ?? omistaja.ytunnus;
+    let lahetysTapa: LahetysTapa;
+    if (tunnus) {
+      const client = await getClient();
+      const asiakasResponse = await client.haeAsiakas(tunnus, omistaja.henkilotunnus ? "SSN" : "CRN");
+      const asiakas = asiakasResponse.HaeAsiakkaitaResult?.Asiakkaat?.Asiakas?.find((a) => a.attributes.AsiakasTunnus === tunnus);
+      lahetysTapa = asiakas?.Tila === 300 ? LahetysTapa.VIESTI : LahetysTapa.KIRJE;
+    } else {
+      lahetysTapa = LahetysTapa.KIRJE;
+    }
     await lahetaPdfViesti({
       projektiFromDB: kohde.projekti,
       kohde: {
@@ -766,6 +791,7 @@ async function handleOmistaja({
       tyyppi,
       muistuttajaIdsForLahetystilaUpdate,
       omistajaIdsForLahetystilaUpdate,
+      lahetysTapa,
     });
   } else {
     auditLog.info("Omistajalta puuttuu pakollisia tietoja", { omistajaId: omistaja.id });

--- a/backend/src/suomifi/suomifiHandler.ts
+++ b/backend/src/suomifi/suomifiHandler.ts
@@ -624,23 +624,12 @@ async function lahetaPdfViesti({
 // REST-rajapinta tukee pelkän paperikirjeen lähettämistä pelkällä osoitteella ilman hetua/y-tunnusta
 function isOmistajanTiedotOk(kohde: DBOmistaja): boolean {
   return (
-    (!!kohde.henkilotunnus || !!kohde.ytunnus) &&
     (!!kohde.nimi || (!!kohde.etunimet && !!kohde.sukunimi)) &&
     !!kohde.jakeluosoite &&
     !!kohde.paikkakunta &&
     !!kohde.postinumero
   );
 }
-
-// TODO: Ota käyttöön kun pelkkä paperikirje ilman hetua/y-tunnusta halutaan sallia
-// function isOmistajanTiedotOk(kohde: DBOmistaja): boolean {
-//   return (
-//     (!!kohde.nimi || (!!kohde.etunimet && !!kohde.sukunimi)) &&
-//     !!kohde.jakeluosoite &&
-//     !!kohde.paikkakunta &&
-//     !!kohde.postinumero
-//   );
-// }
 
 function isMuistuttujanTiedotOk(kohde: DBMuistuttaja): boolean {
   return (
@@ -769,12 +758,9 @@ async function handleOmistaja({
         lahiosoite: omistaja.jakeluosoite!,
         postinumero: omistaja.postinumero!,
         postitoimipaikka: omistaja.paikkakunta!,
-        hetu: omistaja.henkilotunnus,
-        ytunnus: omistaja.ytunnus,
+        hetu: omistaja.henkilotunnus ?? undefined,
+        ytunnus: omistaja.ytunnus ?? undefined,
         maakoodi: omistaja.maakoodi ? omistaja.maakoodi : "FI",
-        // TODO: Ota käyttöön kun pelkkä paperikirje ilman hetua/y-tunnusta halutaan sallia
-        // hetu: omistaja.henkilotunnus ?? undefined,
-        // ytunnus: omistaja.ytunnus ?? undefined,
       },
       omistaja: true,
       tyyppi,
@@ -885,25 +871,15 @@ async function paivitaMapKiinteistonOmistajilla(projektiFromDB: DBProjekti, tied
     .filter((o) => o.suomifiLahetys)
     .forEach((omistaja) => {
       const tunnus = omistaja.henkilotunnus ?? omistaja.ytunnus;
+      // Ilman tunnusta olevat omistajat eivät voi olla duplikaatteja, joten käytetään id:tä avaimena
       if (!tunnus) {
-        log.warn("Suomi.fi tiedotettavalla ei ole henkilötunnusta tai y-tunnusta tiedottamiseen. Tiedotusta ei pystytä tekemään.", {
+        log.info("Suomi.fi tiedotettavalla ei ole henkilötunnusta tai y-tunnusta, lähetetään pelkkä paperikirje", {
           id: omistaja.id,
         });
-        return;
       }
-      // TODO: Ota käyttöön kun pelkkä paperikirje ilman hetua/y-tunnusta halutaan sallia
-      // Ilman tunnusta olevat omistajat eivät voi olla duplikaatteja, joten käytetään id:tä avaimena
-      // if (!tunnus) {
-      //   log.info("Suomi.fi tiedotettavalla ei ole henkilötunnusta tai y-tunnusta, lähetetään pelkkä paperikirje", {
-      //     id: omistaja.id,
-      //   });
-      // }
+      const avain = tunnus ?? omistaja.id;
       const tiedotettavanRivit =
-        tiedotettavaMap.get(tunnus) ?? tiedotettavaMap.set(tunnus, { kiinteistonOmistajaIds: [], muistuttajaIds: [] }).get(tunnus)!;
-      // TODO: Ota käyttöön kun pelkkä paperikirje ilman hetua/y-tunnusta halutaan sallia
-      // const avain = tunnus ?? omistaja.id;
-      // const tiedotettavanRivit =
-      //   tiedotettavaMap.get(avain) ?? tiedotettavaMap.set(avain, { kiinteistonOmistajaIds: [], muistuttajaIds: [] }).get(avain)!;
+        tiedotettavaMap.get(avain) ?? tiedotettavaMap.set(avain, { kiinteistonOmistajaIds: [], muistuttajaIds: [] }).get(avain)!;
       tiedotettavanRivit.kiinteistonOmistajaIds.push(omistaja.id);
     });
 }

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -1593,8 +1593,10 @@ type Omistaja {
   paikkakunta: String
   maakoodi: String
   maa: String
+  hasHetu: Boolean
   viimeisinLahetysaika: String
   viimeisinTila: TiedotettavanLahetyksenTila
+  viimeisinLahetysTapa: LahetysTapa
 }
 
 enum TiedotettavanLahetyksenTila {
@@ -1602,6 +1604,11 @@ enum TiedotettavanLahetyksenTila {
   VIRHE
   OK_ERI_KIINTEISTO_MUISTUTUS
   VIRHE_ERI_KIINTEISTO_MUISTUTUS
+}
+
+enum LahetysTapa {
+  VIESTI
+  KIRJE
 }
 
 type TallennaKiinteistonOmistajaResponse {
@@ -1626,8 +1633,10 @@ type Muistuttaja {
   tiedotustapa: String
   sahkoposti: String
   paivitetty: String
+  hasHetu: Boolean
   viimeisinLahetysaika: String
   viimeisinTila: TiedotettavanLahetyksenTila
+  viimeisinLahetysTapa: LahetysTapa
 }
 
 type Muistuttajat {


### PR DESCRIPTION
## Muutokset

- Lisätty LahetysTapa-enumit KIRJE ja VIESTI, joiden perusteella voidaan näyttää, kummalla tavalla viesti lähetettiin
- Lähetystapa eli vastaanottajan postilaatikon tila tarkistetaan viestin lähettämisen yhteydessä.

## AI-Assisted: Amazon Q developer, generated
