### PR TITLE
chore: HASSUYP-537 katselmointikorjauksia

### DIFF
--- a/backend/src/projektiSearch/muistuttajaSearch/muistuttajaSearchAdapter.ts
+++ b/backend/src/projektiSearch/muistuttajaSearch/muistuttajaSearchAdapter.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { getLocalizedCountryName } from "hassu-common/getLocalizedCountryName";
 import * as API from "hassu-common/graphql/apiModel";
 import { DBMuistuttaja } from "../../database/muistuttajaDatabase";
@@ -18,7 +19,13 @@ export type MuistuttajaDocument = Pick<
   | "suomifiLahetys"
   | "sahkoposti"
   | "kaytossa"
-> & { maa: string | null; viimeisinLahetysaika: string | null; viimeisinTila: API.TiedotettavanLahetyksenTila | null };
+> & {
+  maa: string | null;
+  hasHetu: boolean;
+  viimeisinLahetysaika: string | null;
+  viimeisinTila: API.TiedotettavanLahetyksenTila | null;
+  viimeisinLahetysTapa: API.LahetysTapa | null;
+};
 
 export function adaptMuistuttajaToIndex({
   etunimi,
@@ -36,6 +43,7 @@ export function adaptMuistuttajaToIndex({
   suomifiLahetys,
   kaytossa,
   lahetykset,
+  henkilotunnus,
 }: DBMuistuttaja): MuistuttajaDocument {
   const viimeisinLahetys = lahetykset?.sort((a, b) => b.lahetysaika.localeCompare(a.lahetysaika))[0];
   return {
@@ -52,8 +60,10 @@ export function adaptMuistuttajaToIndex({
     sahkoposti,
     suomifiLahetys,
     kaytossa,
+    hasHetu: !!henkilotunnus,
     viimeisinLahetysaika: viimeisinLahetys?.lahetysaika ?? null,
     viimeisinTila: viimeisinLahetys?.tila ?? null,
+    viimeisinLahetysTapa: viimeisinLahetys?.lahetysTapa ?? null,
   };
 }
 
@@ -95,8 +105,10 @@ function mapHitToApiMuistuttaja(hit: MuistuttajaDocumentHit) {
     tiedotustapa: hit._source.tiedotustapa,
     paivitetty: hit._source.paivitetty,
     sahkoposti: hit._source.sahkoposti,
+    hasHetu: hit._source.hasHetu,
     viimeisinLahetysaika: hit._source.viimeisinLahetysaika,
     viimeisinTila: hit._source.viimeisinTila,
+    viimeisinLahetysTapa: hit._source.viimeisinLahetysTapa,
   };
   return dokumentti;
 }

--- a/backend/src/projektiSearch/muistuttajaSearch/muistuttajaSearchAdapter.ts
+++ b/backend/src/projektiSearch/muistuttajaSearch/muistuttajaSearchAdapter.ts
@@ -21,7 +21,7 @@ export type MuistuttajaDocument = Pick<
   | "kaytossa"
 > & {
   maa: string | null;
-  hasHetu: boolean;
+  hasTunnus: boolean;
   viimeisinLahetysaika: string | null;
   viimeisinTila: API.TiedotettavanLahetyksenTila | null;
   viimeisinLahetysTapa: API.LahetysTapa | null;
@@ -60,7 +60,7 @@ export function adaptMuistuttajaToIndex({
     sahkoposti,
     suomifiLahetys,
     kaytossa,
-    hasHetu: !!henkilotunnus,
+    hasTunnus: !!henkilotunnus,
     viimeisinLahetysaika: viimeisinLahetys?.lahetysaika ?? null,
     viimeisinTila: viimeisinLahetys?.tila ?? null,
     viimeisinLahetysTapa: viimeisinLahetys?.lahetysTapa ?? null,
@@ -105,7 +105,7 @@ function mapHitToApiMuistuttaja(hit: MuistuttajaDocumentHit) {
     tiedotustapa: hit._source.tiedotustapa,
     paivitetty: hit._source.paivitetty,
     sahkoposti: hit._source.sahkoposti,
-    hasHetu: hit._source.hasHetu,
+    hasTunnus: hit._source.hasTunnus,
     viimeisinLahetysaika: hit._source.viimeisinLahetysaika,
     viimeisinTila: hit._source.viimeisinTila,
     viimeisinLahetysTapa: hit._source.viimeisinLahetysTapa,

--- a/backend/src/projektiSearch/omistajaSearch/kiinteistonomistajaSearchAdapter.ts
+++ b/backend/src/projektiSearch/omistajaSearch/kiinteistonomistajaSearchAdapter.ts
@@ -22,7 +22,7 @@ export type OmistajaDocument = Pick<
   | "osoitetiedotSaatu"
 > & {
   maa: string | null;
-  hasHetu: boolean;
+  hasTunnus: boolean;
   viimeisinLahetysaika: string | null;
   viimeisinTila: API.TiedotettavanLahetyksenTila | null;
   viimeisinLahetysTapa: API.LahetysTapa | null;
@@ -46,6 +46,7 @@ export function adaptOmistajaToIndex({
   osoitetiedotSaatu,
   lahetykset,
   henkilotunnus,
+  ytunnus,
 }: DBOmistaja): OmistajaDocument {
   const viimeisinLahetys = lahetykset?.sort((a, b) => b.lahetysaika.localeCompare(a.lahetysaika))[0];
   return {
@@ -63,7 +64,7 @@ export function adaptOmistajaToIndex({
     kaytossa,
     userCreated,
     osoitetiedotSaatu,
-    hasHetu: !!henkilotunnus,
+    hasTunnus: !!(henkilotunnus || ytunnus),
     viimeisinLahetysaika: viimeisinLahetys?.lahetysaika ?? null,
     viimeisinTila: viimeisinLahetys?.tila ?? null,
     viimeisinLahetysTapa: viimeisinLahetys?.lahetysTapa ?? null,
@@ -107,7 +108,7 @@ function mapHitToApiOmistaja(hit: OmistajaDocumentHit) {
     maa,
     maakoodi,
     osoitetiedotSaatu,
-    hasHetu,
+    hasTunnus,
     viimeisinLahetysaika,
     viimeisinTila,
     viimeisinLahetysTapa,
@@ -127,7 +128,7 @@ function mapHitToApiOmistaja(hit: OmistajaDocumentHit) {
     osoitetiedotSaatu,
     paivitetty,
     postinumero,
-    hasHetu,
+    hasTunnus,
     viimeisinLahetysaika,
     viimeisinTila,
     viimeisinLahetysTapa,

--- a/backend/src/suomifi/suomifiRest/suomifi.ts
+++ b/backend/src/suomifi/suomifiRest/suomifi.ts
@@ -279,6 +279,17 @@ function buildPaperMail(
 async function lahetaViesti(client: SuomiFiRestClient, options: Options, viesti: PdfViesti): Promise<LahetaViestiResponse> {
   const tunnus = viesti.hetu ?? viesti.ytunnus;
 
+  if (!viesti.lahiosoite || !viesti.postinumero || !viesti.postitoimipaikka) {
+    return {
+      LahetaViestiResult: {
+        TilaKoodi: {
+          TilaKoodi: -1,
+          TilaKoodiKuvaus: "Vastaanottajan osoitetiedot puuttuvat",
+        },
+      },
+    };
+  }
+
   const externalId = `VLS-${uuid.v4()}`;
   const printingAndEnvelopingService = getLaskutus(viesti, options);
   if (!printingAndEnvelopingService) {
@@ -308,7 +319,6 @@ async function lahetaViesti(client: SuomiFiRestClient, options: Options, viesti:
 
   const paperMail = buildPaperMail(viesti, uploadResponse.attachmentId, printingAndEnvelopingService);
 
-  // TODO: tämä on valmiina, mutta ei voi vielä toteutua, koska suomifiHandlerin isOmistajanTiedotOk estää
   if (!tunnus) {
     const message: PaperMailOnlyMessageRequest = {
       externalId,

--- a/backend/test/projektiSearch/omistajaSearch/kiinteistonomistajaSearchAdapter.test.ts
+++ b/backend/test/projektiSearch/omistajaSearch/kiinteistonomistajaSearchAdapter.test.ts
@@ -6,7 +6,7 @@ import { LahetysTapa, TiedotettavanLahetyksenTila } from "hassu-common/graphql/a
 
 describe("kiinteistonomistajaSearchAdapter", () => {
   describe("adaptOmistajaToIndex", () => {
-    it("should set hasHetu true when henkilotunnus exists", () => {
+    it("should set hasTunnus true when henkilotunnus exists", () => {
       const omistaja: DBOmistaja = {
         id: "1",
         oid: "1.2.3",
@@ -22,10 +22,10 @@ describe("kiinteistonomistajaSearchAdapter", () => {
         expires: 0,
       };
       const result = adaptOmistajaToIndex(omistaja);
-      expect(result.hasHetu).to.equal(true);
+      expect(result.hasTunnus).to.equal(true);
     });
 
-    it("should set hasHetu false when henkilotunnus is missing", () => {
+    it("should set hasTunnus false when henkilotunnus is missing", () => {
       const omistaja: DBOmistaja = {
         id: "2",
         oid: "1.2.3",
@@ -40,7 +40,7 @@ describe("kiinteistonomistajaSearchAdapter", () => {
         expires: 0,
       };
       const result = adaptOmistajaToIndex(omistaja);
-      expect(result.hasHetu).to.equal(false);
+      expect(result.hasTunnus).to.equal(false);
     });
 
     it("should set viimeisinLahetysTapa from latest lahetys", () => {
@@ -110,7 +110,7 @@ describe("kiinteistonomistajaSearchAdapter", () => {
   });
 
   describe("adaptSearchResultsToApiOmistaja", () => {
-    it("should map hasHetu and viimeisinLahetysTapa to API model", () => {
+    it("should map hasTunnus and viimeisinLahetysTapa to API model", () => {
       const results = {
         hits: {
           hits: [
@@ -127,7 +127,7 @@ describe("kiinteistonomistajaSearchAdapter", () => {
                 maakoodi: "FI",
                 lisatty: "2024-01-01",
                 paivitetty: null,
-                hasHetu: true,
+                hasTunnus: true,
                 osoitetiedotSaatu: true,
                 viimeisinLahetysaika: "2024-06-01T10:00:00+02:00",
                 viimeisinTila: TiedotettavanLahetyksenTila.OK,
@@ -147,7 +147,7 @@ describe("kiinteistonomistajaSearchAdapter", () => {
                 maakoodi: "FI",
                 lisatty: "2024-01-01",
                 paivitetty: null,
-                hasHetu: false,
+                hasTunnus: false,
                 osoitetiedotSaatu: true,
                 viimeisinLahetysaika: "2024-06-01T10:00:00+02:00",
                 viimeisinTila: TiedotettavanLahetyksenTila.OK,
@@ -159,10 +159,10 @@ describe("kiinteistonomistajaSearchAdapter", () => {
       };
       const apiOmistajat = adaptSearchResultsToApiOmistaja(results);
       expect(apiOmistajat).to.have.length(2);
-      expect(apiOmistajat[0].hasHetu).to.equal(true);
+      expect(apiOmistajat[0].hasTunnus).to.equal(true);
       expect(apiOmistajat[0].viimeisinLahetysTapa).to.equal(LahetysTapa.VIESTI);
       expect(apiOmistajat[0].osoitetiedotSaatu).to.equal(true);
-      expect(apiOmistajat[1].hasHetu).to.equal(false);
+      expect(apiOmistajat[1].hasTunnus).to.equal(false);
       expect(apiOmistajat[1].viimeisinLahetysTapa).to.equal(LahetysTapa.KIRJE);
     });
   });

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -1593,7 +1593,7 @@ type Omistaja {
   paikkakunta: String
   maakoodi: String
   maa: String
-  hasHetu: Boolean
+  hasTunnus: Boolean
   viimeisinLahetysaika: String
   viimeisinTila: TiedotettavanLahetyksenTila
   viimeisinLahetysTapa: LahetysTapa
@@ -1633,7 +1633,7 @@ type Muistuttaja {
   tiedotustapa: String
   sahkoposti: String
   paivitetty: String
-  hasHetu: Boolean
+  hasTunnus: Boolean
   viimeisinLahetysaika: String
   viimeisinTila: TiedotettavanLahetyksenTila
   viimeisinLahetysTapa: LahetysTapa

--- a/src/components/PaivamaaraTila.tsx
+++ b/src/components/PaivamaaraTila.tsx
@@ -10,7 +10,7 @@ import { LahetysTapa, TiedotettavanLahetyksenTila } from "@services/api";
 interface TilaProps {
   pvm?: string | null;
   tila?: TiedotettavanLahetyksenTila | null;
-  hasHetu?: boolean | null;
+  hasTunnus?: boolean | null;
   lahetysTapa?: LahetysTapa | null;
 }
 
@@ -37,8 +37,8 @@ export const tilaTooltipTitles: Record<TiedotettavanLahetyksenTila, string> = {
 
 export function PaivamaaraTila(props: Readonly<TilaProps>) {
   const pvm = props.pvm ? dayjs(props.pvm).format("DD.MM.YYYY HH:mm") : undefined;
-  const hasHetuData = props.hasHetu != null;
-  const vainOsoitetiedot = props.hasHetu === false;
+  const hasTunnusData = props.hasTunnus != null;
+  const vainOsoitetiedot = props.hasTunnus === false;
 
   // Before sending
   if (!props.tila) {
@@ -49,8 +49,8 @@ export function PaivamaaraTila(props: Readonly<TilaProps>) {
   const iconColor = tilaIconColors[props.tila];
   const tooltipTitle = tilaTooltipTitles[props.tila];
 
-  // Fallback: show old simple format when hasHetu/lahetysTapa data is not yet available
-  if (!hasHetuData || !props.lahetysTapa) {
+  // Fallback: show old simple format when hasTunnus/lahetysTapa data is not yet available
+  if (!hasTunnusData || !props.lahetysTapa) {
     return (
       <>
         {pvm ?? "-"}

--- a/src/pages/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat/index.tsx
@@ -229,8 +229,8 @@ const KiinteistonomistajatPage: FunctionComponent<{ projekti: ProjektiLisatiedol
                 },
                 cell: (c) => {
                   const value = c.getValue() as string | null;
-                  const { viimeisinTila, hasHetu, viimeisinLahetysTapa } = c.row.original;
-                  return <PaivamaaraTila pvm={value} tila={viimeisinTila} hasHetu={hasHetu} lahetysTapa={viimeisinLahetysTapa} />;
+                  const { viimeisinTila, hasTunnus, viimeisinLahetysTapa } = c.row.original;
+                  return <PaivamaaraTila pvm={value} tila={viimeisinTila} hasTunnus={hasTunnus} lahetysTapa={viimeisinLahetysTapa} />;
                 },
               },
             ]}

--- a/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
@@ -68,8 +68,8 @@ const columnsSuomifi: ColumnDef<Muistuttaja>[] = [
     },
     cell: (c) => {
       const value = c.getValue() as string | null;
-      const { viimeisinTila, hasHetu, viimeisinLahetysTapa } = c.row.original;
-      return <PaivamaaraTila pvm={value} tila={viimeisinTila} hasHetu={hasHetu} lahetysTapa={viimeisinLahetysTapa} />;
+      const { viimeisinTila, hasTunnus, viimeisinLahetysTapa } = c.row.original;
+      return <PaivamaaraTila pvm={value} tila={viimeisinTila} hasTunnus={hasTunnus} lahetysTapa={viimeisinLahetysTapa} />;
     },
   },
 ];


### PR DESCRIPTION
## Muutokset

- hasHetu muotoon hasTunnus, koska tarkistaa myös y-tunnuksen olemassaolon
- lisää hasTunnus myös muistuttajalle, jotta niidenkin lähetystapa voidaan näyttää
- validoi osoitetiedot vielä ennen rajapintaan lähettämistä

## AI-Assisted: Amazon Q developer, generated
