### PR TITLE
chore: HASSUYP-829 - Ashan uusi versio käyttöön

### DIFF
--- a/migration-cli/package-lock.json
+++ b/migration-cli/package-lock.json
@@ -51,7 +51,7 @@
         "@fortawesome/free-regular-svg-icons": "6.5.2",
         "@fortawesome/free-solid-svg-icons": "6.5.2",
         "@fortawesome/react-fontawesome": "0.2.2",
-        "@hassu/asianhallinta": "0.4.5",
+        "@hassu/asianhallinta": "0.4.8",
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "^2.9.11",
         "@mui/icons-material": "~5.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@fortawesome/free-regular-svg-icons": "6.5.2",
         "@fortawesome/free-solid-svg-icons": "6.5.2",
         "@fortawesome/react-fontawesome": "0.2.2",
-        "@hassu/asianhallinta": "0.4.5",
+        "@hassu/asianhallinta": "0.4.8",
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "^2.9.11",
         "@mui/icons-material": "~5.10.6",
@@ -5499,15 +5499,28 @@
       }
     },
     "node_modules/@hassu/asianhallinta": {
-      "version": "0.4.5",
-      "resolved": "https://hassu-domain-283563576583.d.codeartifact.eu-west-1.amazonaws.com/npm/hassu-private-npm/@hassu/asianhallinta/-/asianhallinta-0.4.5.tgz",
-      "integrity": "sha512-/ArcCzRhjqyPmlLz8WBLY8lHRH+qn7B/TBk3F1AuO/s1SGbBXJbVN/FiB3th4CNIwAaDZR/RJgWwVptgb+/zpQ==",
+      "version": "0.4.8",
+      "resolved": "https://hassu-domain-283563576583.d.codeartifact.eu-west-1.amazonaws.com/npm/hassu-private-npm/@hassu/asianhallinta/-/asianhallinta-0.4.8.tgz",
+      "integrity": "sha512-BWvREZwKg6VGyor6OufvVv4hRZs9u+u05b2c8iN5tKiUQMrlibRewJ78JpV6xORfWFPpwtVHuGOQ4JVJ2RI77Q==",
       "dependencies": {
-        "typescript": "4.9.5"
+        "typescript": "5.9.3"
       },
       "engines": {
         "node": ">=22.22.1",
         "npm": ">=10.9.4"
+      }
+    },
+    "node_modules/@hassu/asianhallinta/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@hookform/error-message": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@fortawesome/free-regular-svg-icons": "6.5.2",
     "@fortawesome/free-solid-svg-icons": "6.5.2",
     "@fortawesome/react-fontawesome": "0.2.2",
-    "@hassu/asianhallinta": "0.4.5",
+    "@hassu/asianhallinta": "0.4.8",
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "^2.9.11",
     "@mui/icons-material": "~5.10.6",


### PR DESCRIPTION
## Muutokset
- Nostetaan versio uusimpaan
  - väliin jäi kaksi versiota (näissä ei oikeasti päivityksiä, koska liittyivät Github App integraation käyttöönottoon)

## AI-Assisted: Amazon Q developer, none
