### PR TITLE
feat: HASSUYP-864 - Suodatustoiminto kiinteistönomistajien muokkaussivulle

### DIFF
--- a/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
+++ b/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
@@ -889,7 +889,7 @@ const SuodatusKentta: FunctionComponent<{ onSuodata: (query: string) => void; su
     <Section noDivider>
       <Stack direction="row" alignItems="end" spacing={2}>
         <TextField
-          sx={{ flexGrow: 1 }}
+          sx={{ flexGrow: 1, label: { fontWeight: 700, fontSize: "1.25rem" } }}
           label="Suodata kiinteistönomistajia"
           autoComplete="off"
           value={query}

--- a/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
+++ b/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
@@ -1,5 +1,5 @@
 // Contains code generated or recommended by Amazon Q
-import React, { useCallback, useState, useMemo, useRef, FunctionComponent } from "react";
+import React, { useCallback, useState, useMemo, useRef, useContext, createContext, FunctionComponent } from "react";
 import { Autocomplete, DialogActions, DialogContent, Stack, styled, TextField } from "@mui/material";
 import Button from "@components/button/Button";
 import Section from "@components/layout/Section2";
@@ -23,7 +23,7 @@ import { ColumnDef, getCoreRowModel, useReactTable } from "@tanstack/react-table
 import { formatKiinteistotunnusForDatabase } from "common/util/formatKiinteistotunnus";
 import { RectangleButton } from "@components/button/RectangleButton";
 import { TextFieldWithController } from "@components/form/TextFieldWithController";
-import { ButtonFlatWithIcon } from "@components/button/ButtonFlat";
+import { ButtonFlat, ButtonFlatWithIcon } from "@components/button/ButtonFlat";
 import HassuTable from "@components/table/HassuTable";
 import useSnackbars from "src/hooks/useSnackbars";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -37,6 +37,8 @@ import useLeaveConfirm from "src/hooks/useLeaveConfirm";
 import HassuDialog from "@components/HassuDialog";
 import readXlsxFile, { readSheetNames } from "read-excel-file/browser";
 import { findColumnIndices, matchExcelRowsToOmistajat, getSheetIndexToRead } from "src/util/excelImport";
+
+const SuodatusContext = createContext<string>("");
 
 type OmistajaRow = Omit<OmistajaInput, "maakoodi"> & {
   toBeDeleted: boolean;
@@ -497,15 +499,36 @@ export const FormContents: FunctionComponent<{
   );
 
   const loadAllMuutRef = useRef<(() => Promise<void>) | undefined>(undefined);
+  const loadAllSuomifiRef = useRef<(() => Promise<void>) | undefined>(undefined);
+  const [suodatus, setSuodatus] = useState("");
+
+  const handleSuodata = useCallback(
+    (query: string) => {
+      if (query) {
+        withLoadingSpinner(
+          (async () => {
+            await loadAllSuomifiRef.current?.();
+            await loadAllMuutRef.current?.();
+            setSuodatus(query);
+          })()
+        );
+      } else {
+        setSuodatus("");
+      }
+    },
+    [withLoadingSpinner]
+  );
 
   const resetAndClose = useCallback(async () => {
     await router.push({ pathname: "/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat", query: { oid: projekti.oid } });
   }, [router, projekti.oid]);
 
   return (
+    <SuodatusContext.Provider value={suodatus}>
     <FormProvider {...useFormReturn}>
       <DialogForm>
         <DialogContent>
+          <SuodatusKentta onSuodata={handleSuodata} suodatusAktiivinen={!!suodatus} />
           <Section noDivider>
             <H3>Kiinteistönomistajien tiedotus Suomi.fi -palvelulla</H3>
             <p>
@@ -518,6 +541,7 @@ export const FormContents: FunctionComponent<{
                 initialHakutulosMaara={initialSearchResponses.suomifi.hakutulosMaara}
                 columns={suomifiColumns}
                 fieldArrayName="suomifiOmistajat"
+                loadAllRef={loadAllSuomifiRef}
               />
             ) : (
               <GrayBackgroundText>
@@ -582,6 +606,7 @@ export const FormContents: FunctionComponent<{
         </DialogActions>
       </HassuDialog>
     </FormProvider>
+    </SuodatusContext.Provider>
   );
 };
 
@@ -608,7 +633,16 @@ const PaginatedTaulukko = ({
   const [hakutulosMaara, setHakutulosMaara] = useState<number>(initialHakutulosMaara);
   const [sliceAt, setSliceAt] = useState(PAGE_SIZE);
   const { append: appendMuut, fields } = useFieldArray({ control, name: fieldArrayName, keyName: "fieldId" });
-  const slicedFields = useMemo(() => fields.slice(0, sliceAt), [fields, sliceAt]);
+  const suodatus = useContext(SuodatusContext);
+  const filteredFields = useMemo(() => {
+    if (!suodatus) return fields;
+    const lower = suodatus.toLowerCase();
+    return fields.filter((o) =>
+      [o.nimi, o.kiinteistotunnus, o.jakeluosoite, o.postinumero, o.paikkakunta, o.maa]
+        .some((val) => val?.toLowerCase().includes(lower))
+    );
+  }, [fields, suodatus]);
+  const slicedFields = useMemo(() => (suodatus ? filteredFields : filteredFields.slice(0, sliceAt)), [filteredFields, sliceAt, suodatus]);
 
   const api = useApi();
   const { withLoadingSpinner } = useLoadingSpinner();
@@ -681,30 +715,32 @@ const PaginatedTaulukko = ({
   return (
     <>
       <HassuTable table={table} />
-      <Stack direction="row" alignItems="flex-start">
-        <Stack alignItems="center" flex={1}>
-          {slicedFields.length > PAGE_SIZE && (
-            <RectangleButton type="button" onClick={showLess}>
-              Näytä vähemmän kiinteistönomistajia
-            </RectangleButton>
-          )}
-          {hakutulosMaara > slicedFields.length && (
-            <RectangleButton type="button" onClick={getNextPage}>
-              Näytä enemmän kiinteistönomistajia
-            </RectangleButton>
-          )}
-          {hakutulosMaara > PAGE_SIZE && (
-            <ButtonFlatWithIcon
-              type="button"
-              icon={hakutulosMaara <= slicedFields.length ? "chevron-up" : "chevron-down"}
-              onClick={toggleShowHideAll}
-            >
-              {hakutulosMaara <= slicedFields.length ? "Piilota kaikki" : "Näytä kaikki"}
-            </ButtonFlatWithIcon>
-          )}
+      {!suodatus && (
+        <Stack direction="row" alignItems="flex-start">
+          <Stack alignItems="center" flex={1}>
+            {slicedFields.length > PAGE_SIZE && (
+              <RectangleButton type="button" onClick={showLess}>
+                Näytä vähemmän kiinteistönomistajia
+              </RectangleButton>
+            )}
+            {hakutulosMaara > slicedFields.length && (
+              <RectangleButton type="button" onClick={getNextPage}>
+                Näytä enemmän kiinteistönomistajia
+              </RectangleButton>
+            )}
+            {hakutulosMaara > PAGE_SIZE && (
+              <ButtonFlatWithIcon
+                type="button"
+                icon={hakutulosMaara <= slicedFields.length ? "chevron-up" : "chevron-down"}
+                onClick={toggleShowHideAll}
+              >
+                {hakutulosMaara <= slicedFields.length ? "Piilota kaikki" : "Näytä kaikki"}
+              </ButtonFlatWithIcon>
+            )}
+          </Stack>
+          {extraActions}
         </Stack>
-        {extraActions}
-      </Stack>
+      )}
     </>
   );
 };
@@ -712,11 +748,20 @@ const PaginatedTaulukko = ({
 const LisatytTaulukko = () => {
   const { control } = useFormContext<KiinteistonOmistajatFormFields>();
   const { append, fields } = useFieldArray({ control, name: "lisatytOmistajat", keyName: "fieldId" });
+  const suodatus = useContext(SuodatusContext);
+  const filteredFields = useMemo(() => {
+    if (!suodatus) return fields;
+    const lower = suodatus.toLowerCase();
+    return fields.filter((o) =>
+      [o.nimi, o.kiinteistotunnus, o.jakeluosoite, o.postinumero, o.paikkakunta, o.maa]
+        .some((val) => val?.toLowerCase().includes(lower))
+    );
+  }, [fields, suodatus]);
 
   const table = useReactTable({
     columns: lisatytColumns,
     getCoreRowModel: getCoreRowModel(),
-    data: fields,
+    data: filteredFields,
     enableSorting: false,
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
     state: { pagination: undefined },
@@ -826,5 +871,41 @@ const TuoExcelistaButton: FunctionComponent<{ loadAllRef: React.MutableRefObject
         Tuo Excelistä
       </Button>
     </>
+  );
+};
+
+const SuodatusKentta: FunctionComponent<{ onSuodata: (query: string) => void; suodatusAktiivinen: boolean }> = ({
+  onSuodata,
+  suodatusAktiivinen,
+}) => {
+  const [query, setQuery] = useState("");
+
+  const handleReset = useCallback(() => {
+    setQuery("");
+    onSuodata("");
+  }, [onSuodata]);
+
+  return (
+    <Section noDivider>
+      <Stack direction="row" alignItems="end" spacing={2}>
+        <TextField
+          sx={{ flexGrow: 1 }}
+          label="Suodata kiinteistönomistajia"
+          autoComplete="off"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onSuodata(query); } }}
+          size="small"
+        />
+        <Button primary type="button" onClick={() => onSuodata(query)} endIcon="search">
+          Suodata
+        </Button>
+      </Stack>
+      {suodatusAktiivinen && (
+        <ButtonFlat onClick={handleReset} type="button">
+          Nollaa suodatus
+        </ButtonFlat>
+      )}
+    </Section>
   );
 };


### PR DESCRIPTION
## HASSUYP-864: Suodatustoiminto kiinteistönomistajien muokkaussivulle

### Toteutus

Paikallinen suodatus (ei backend-hakua) koska lomakedata voi olla
tallentamatonta (dirty). Suodatus kohdistuu react-hook-formin field-arrayhin.

**Toiminta:**
1. Käyttäjä kirjoittaa hakutermin ja painaa "Suodata" (tai Enter)
2. Kaikki rivit ladataan backendistä (jos ei jo ladattu) — spinner näkyy
3. Kaikki kolme listaa suodatetaan samanaikaisesti
4. Paginointipainikkeet piilotetaan, kaikki osumat näytetään
5. "Nollaa suodatus" palauttaa alkuperäisen näkymän

**Haettavat kentät:** nimi, kiinteistötunnus, jakeluosoite, postinumero,
paikkakunta, maa

**Suunnitteluperiaatteet:**
- Yhdenmukainen TiedotettavaHaitari-komponentin kanssa (ButtonFlat "Nollaa
  suodatus", sama visuaalinen ilme)
- Hyödyntää HASSUYP-855:ssä toteutettua loadAllRef-mekanismia ja
  virtualisointia — ei turhia API-kutsuja eikä UI:n jäätymistä


## AI-Assisted: Amazon Q developer, generated
