### PR TITLE
chore: HASSUYP-787 - Nosta AWS Parameters and Secrets Lambda Extension versio 63 -> 82

### DIFF
--- a/deployment/lib/hassu-account.ts
+++ b/deployment/lib/hassu-account.ts
@@ -97,7 +97,7 @@ export class HassuAccountStack extends Stack {
         LayerVersion.fromLayerVersionArn(
           this,
           "paramLayer",
-          "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:63"
+          "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:82"
         ),
       ],
       logRetention: RetentionDays.SEVEN_YEARS,

--- a/deployment/lib/hassu-backend.ts
+++ b/deployment/lib/hassu-backend.ts
@@ -96,7 +96,7 @@ export class HassuBackendStack extends Stack {
       LayerVersion.fromLayerVersionArn(
         this,
         "paramLayer",
-        "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:63"
+        "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:82"
       ),
     ];
   }

--- a/migration-cli/package-lock.json
+++ b/migration-cli/package-lock.json
@@ -51,7 +51,7 @@
         "@fortawesome/free-regular-svg-icons": "6.5.2",
         "@fortawesome/free-solid-svg-icons": "6.5.2",
         "@fortawesome/react-fontawesome": "0.2.2",
-        "@hassu/asianhallinta": "0.4.8",
+        "@hassu/asianhallinta": "0.4.9",
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "^2.9.11",
         "@mui/icons-material": "~5.10.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@fortawesome/free-regular-svg-icons": "6.5.2",
         "@fortawesome/free-solid-svg-icons": "6.5.2",
         "@fortawesome/react-fontawesome": "0.2.2",
-        "@hassu/asianhallinta": "0.4.8",
+        "@hassu/asianhallinta": "0.4.9",
         "@hookform/error-message": "2.0.1",
         "@hookform/resolvers": "^2.9.11",
         "@mui/icons-material": "~5.10.6",
@@ -5499,9 +5499,9 @@
       }
     },
     "node_modules/@hassu/asianhallinta": {
-      "version": "0.4.8",
-      "resolved": "https://hassu-domain-283563576583.d.codeartifact.eu-west-1.amazonaws.com/npm/hassu-private-npm/@hassu/asianhallinta/-/asianhallinta-0.4.8.tgz",
-      "integrity": "sha512-BWvREZwKg6VGyor6OufvVv4hRZs9u+u05b2c8iN5tKiUQMrlibRewJ78JpV6xORfWFPpwtVHuGOQ4JVJ2RI77Q==",
+      "version": "0.4.9",
+      "resolved": "https://hassu-domain-283563576583.d.codeartifact.eu-west-1.amazonaws.com/npm/hassu-private-npm/@hassu/asianhallinta/-/asianhallinta-0.4.9.tgz",
+      "integrity": "sha512-GwrngjhqPsY5Ikg7DW7LJZdhvNCqnz7mBBnZId+838cuoPxsPyULpPzpFS8+VMyfGRSgGniSE9k0Tioy3rtALA==",
       "dependencies": {
         "typescript": "5.9.3"
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@fortawesome/free-regular-svg-icons": "6.5.2",
     "@fortawesome/free-solid-svg-icons": "6.5.2",
     "@fortawesome/react-fontawesome": "0.2.2",
-    "@hassu/asianhallinta": "0.4.8",
+    "@hassu/asianhallinta": "0.4.9",
     "@hookform/error-message": "2.0.1",
     "@hookform/resolvers": "^2.9.11",
     "@mui/icons-material": "~5.10.6",


### PR DESCRIPTION
Päivitä AWS-Parameters-and-Secrets-Lambda-Extension uusimpaan versioon

TODO: nosta asianhallinta paketin versio uusimpaan kun sen muutokset viety ja julkaistu.

AI-Assisted: Amazon Q developer, none
