### PR TITLE
fix: HASSUYP-855 - Lisää maa-sarakkeen tuki Excel-tuontiin

### DIFF
--- a/src/__tests__/util/excelImport.test.ts
+++ b/src/__tests__/util/excelImport.test.ts
@@ -18,6 +18,7 @@ describe("excelImport", () => {
       expect(result!.postiosoite).toBe(2);
       expect(result!.postinumero).toBe(3);
       expect(result!.postitoimipaikka).toBe(4);
+      expect(result!.maa).toBe(5);
       expect(result!.headerRowIndex).toBe(3);
     });
 
@@ -36,7 +37,7 @@ describe("excelImport", () => {
     });
 
     it("handles columns in different order", () => {
-      const rows = [["Omistajan nimi", "Kiinteistötunnus", "Postitoimipaikka", "Postiosoite", "Postinumero"]];
+      const rows = [["Omistajan nimi", "Kiinteistötunnus", "Postitoimipaikka", "Postiosoite", "Postinumero", "Maa"]];
       const result = findColumnIndices(rows);
       expect(result).not.toBeNull();
       expect(result!.kiinteistotunnus).toBe(1);
@@ -44,6 +45,7 @@ describe("excelImport", () => {
       expect(result!.postiosoite).toBe(3);
       expect(result!.postinumero).toBe(4);
       expect(result!.postitoimipaikka).toBe(2);
+      expect(result!.maa).toBe(5);
     });
 
     it("returns -1 for missing optional columns", () => {
@@ -55,6 +57,7 @@ describe("excelImport", () => {
       expect(result!.postiosoite).toBe(-1);
       expect(result!.postinumero).toBe(-1);
       expect(result!.postitoimipaikka).toBe(-1);
+      expect(result!.maa).toBe(-1);
     });
 
     it("handles whitespace in header cells", () => {
@@ -74,6 +77,7 @@ describe("excelImport", () => {
       postiosoite: 2,
       postinumero: 3,
       postitoimipaikka: 4,
+      maa: -1,
       headerRowIndex: 0,
     };
 
@@ -89,29 +93,35 @@ describe("excelImport", () => {
         { kiinteistotunnus: "123-456-7-8", nimi: "Matti Meikäläinen" },
         { kiinteistotunnus: "234-567-8-9", nimi: "Liisa Virtanen" },
       ];
-      const results = matchExcelRowsToOmistajat(rows, columns, omistajat);
+      const { results } = matchExcelRowsToOmistajat(rows, columns, omistajat);
       expect(results).toHaveLength(2);
-      expect(results[0]).toEqual({ index: 0, jakeluosoite: "Testikatu 1", postinumero: "00100", paikkakunta: "Helsinki" });
-      expect(results[1]).toEqual({ index: 1, jakeluosoite: "Esimerkkitie 5", postinumero: "33100", paikkakunta: "Tampere" });
+      expect(results[0]).toEqual({ index: 0, jakeluosoite: "Testikatu 1", postinumero: "00100", paikkakunta: "Helsinki", maakoodi: null });
+      expect(results[1]).toEqual({
+        index: 1,
+        jakeluosoite: "Esimerkkitie 5",
+        postinumero: "33100",
+        paikkakunta: "Tampere",
+        maakoodi: null,
+      });
     });
 
     it("does not match when kiinteistotunnus differs", () => {
       const omistajat = [{ kiinteistotunnus: "999-999-9-9", nimi: "Matti Meikäläinen" }];
-      const results = matchExcelRowsToOmistajat(rows, columns, omistajat);
+      const { results } = matchExcelRowsToOmistajat(rows, columns, omistajat);
       expect(results).toHaveLength(0);
     });
 
     it("does not match when nimi differs", () => {
       const omistajat = [{ kiinteistotunnus: "123-456-7-8", nimi: "Väärä Nimi" }];
-      const results = matchExcelRowsToOmistajat(rows, columns, omistajat);
+      const { results } = matchExcelRowsToOmistajat(rows, columns, omistajat);
       expect(results).toHaveLength(0);
     });
 
     it("includes rows with empty address data (Excel is source of truth)", () => {
       const omistajat = [{ kiinteistotunnus: "345-678-9-0", nimi: "Yritys Oy" }];
-      const results = matchExcelRowsToOmistajat(rows, columns, omistajat);
+      const { results } = matchExcelRowsToOmistajat(rows, columns, omistajat);
       expect(results).toHaveLength(1);
-      expect(results[0]).toEqual({ index: 0, jakeluosoite: "", postinumero: "", paikkakunta: "" });
+      expect(results[0]).toEqual({ index: 0, jakeluosoite: "", postinumero: "", paikkakunta: "", maakoodi: null });
     });
 
     it("updates existing address data", () => {
@@ -124,11 +134,12 @@ describe("excelImport", () => {
           paikkakunta: "Vanha",
         },
       ];
-      const results = matchExcelRowsToOmistajat(rows, columns, omistajat);
+      const { results } = matchExcelRowsToOmistajat(rows, columns, omistajat);
       expect(results).toHaveLength(1);
       expect(results[0].jakeluosoite).toBe("Testikatu 1");
       expect(results[0].postinumero).toBe("00100");
       expect(results[0].paikkakunta).toBe("Helsinki");
+      expect(results[0].maakoodi).toBeNull();
     });
 
     it("handles null/undefined kiinteistotunnus and nimi in omistajat", () => {
@@ -136,7 +147,7 @@ describe("excelImport", () => {
         { kiinteistotunnus: null, nimi: null },
         { kiinteistotunnus: undefined, nimi: undefined },
       ];
-      const results = matchExcelRowsToOmistajat(rows, columns, omistajat);
+      const { results } = matchExcelRowsToOmistajat(rows, columns, omistajat);
       expect(results).toHaveLength(0);
     });
 
@@ -146,10 +157,58 @@ describe("excelImport", () => {
         { kiinteistotunnus: "234-567-8-9", nimi: "Liisa Virtanen" },
         { kiinteistotunnus: "123-456-7-8", nimi: "Matti Meikäläinen" },
       ];
-      const results = matchExcelRowsToOmistajat(rows, columns, omistajat);
+      const { results } = matchExcelRowsToOmistajat(rows, columns, omistajat);
       expect(results).toHaveLength(2);
       expect(results[0].index).toBe(1);
       expect(results[1].index).toBe(2);
+    });
+
+    it("reads maa column and converts to ISO2 code", () => {
+      const columnsWithMaa = { ...columns, maa: 5 };
+      const rowsWithMaa = [
+        ["Kiinteistötunnus", "Omistajan nimi", "Postiosoite", "Postinumero", "Postitoimipaikka", "Maa"],
+        ["123-456-7-8", "Matti Meikäläinen", "Testikatu 1", "00100", "Helsinki", "Ruotsi"],
+        ["234-567-8-9", "Liisa Virtanen", "Esimerkkitie 5", "33100", "Tampere", "Suomi"],
+      ];
+      const omistajat = [
+        { kiinteistotunnus: "123-456-7-8", nimi: "Matti Meikäläinen" },
+        { kiinteistotunnus: "234-567-8-9", nimi: "Liisa Virtanen" },
+      ];
+      const { results, errors } = matchExcelRowsToOmistajat(rowsWithMaa, columnsWithMaa, omistajat);
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(2);
+      expect(results[0].maakoodi).toBe("SE");
+      expect(results[1].maakoodi).toBe("FI");
+    });
+
+    it("maa column matching is case-insensitive", () => {
+      const columnsWithMaa = { ...columns, maa: 5 };
+      const rowsWithMaa = [
+        ["Kiinteistötunnus", "Omistajan nimi", "Postiosoite", "Postinumero", "Postitoimipaikka", "Maa"],
+        ["123-456-7-8", "Matti Meikäläinen", "Testikatu 1", "00100", "Helsinki", "suomi"],
+        ["234-567-8-9", "Liisa Virtanen", "Esimerkkitie 5", "33100", "Tampere", "RUOTSI"],
+      ];
+      const omistajat = [
+        { kiinteistotunnus: "123-456-7-8", nimi: "Matti Meikäläinen" },
+        { kiinteistotunnus: "234-567-8-9", nimi: "Liisa Virtanen" },
+      ];
+      const { results, errors } = matchExcelRowsToOmistajat(rowsWithMaa, columnsWithMaa, omistajat);
+      expect(errors).toHaveLength(0);
+      expect(results).toHaveLength(2);
+      expect(results[0].maakoodi).toBe("FI");
+      expect(results[1].maakoodi).toBe("SE");
+    });
+
+    it("returns error for unrecognized country name", () => {
+      const columnsWithMaa = { ...columns, maa: 5 };
+      const rowsWithMaa = [
+        ["Kiinteistötunnus", "Omistajan nimi", "Postiosoite", "Postinumero", "Postitoimipaikka", "Maa"],
+        ["123-456-7-8", "Matti Meikäläinen", "Testikatu 1", "00100", "Helsinki", "Ruots"],
+      ];
+      const omistajat = [{ kiinteistotunnus: "123-456-7-8", nimi: "Matti Meikäläinen" }];
+      const { errors } = matchExcelRowsToOmistajat(rowsWithMaa, columnsWithMaa, omistajat);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toEqual({ type: "unknown_country", rowIndex: 2, omistajaIndex: 0, value: "Ruots" });
     });
   });
 

--- a/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
+++ b/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
@@ -65,7 +65,18 @@ const PAGE_SIZE = 25;
 
 const mapOmistajaToOmistajaRow =
   (...fieldsToSetDefaultsTo: (keyof OmistajaInput)[]) =>
-  ({ id, kiinteistotunnus, jakeluosoite, nimi, paikkakunta, postinumero, maa, maakoodi, osoitetiedotSaatu, userCreated }: Omistaja): OmistajaRow => {
+  ({
+    id,
+    kiinteistotunnus,
+    jakeluosoite,
+    nimi,
+    paikkakunta,
+    postinumero,
+    maa,
+    maakoodi,
+    osoitetiedotSaatu,
+    userCreated,
+  }: Omistaja): OmistajaRow => {
     const omistajaRow: OmistajaRow = {
       id,
       kiinteistotunnus,
@@ -507,8 +518,8 @@ export const FormContents: FunctionComponent<{
         o.userCreated
           ? mapOmistajaToOmistajaRow("kiinteistotunnus", "nimi", "jakeluosoite", "postinumero", "paikkakunta")(o)
           : o.osoitetiedotSaatu === false
-            ? mapOmistajaToOmistajaRow("jakeluosoite", "postinumero", "paikkakunta")(o)
-            : mapOmistajaToOmistajaRow()(o)
+          ? mapOmistajaToOmistajaRow("jakeluosoite", "postinumero", "paikkakunta")(o)
+          : mapOmistajaToOmistajaRow()(o)
       ),
       muutOmistajat: initialSearchResponses.muut.omistajat.map(mapOmistajaToOmistajaRow("jakeluosoite", "postinumero", "paikkakunta")),
       lisatytOmistajat: initialSearchResponses.lisatyt.omistajat.map(
@@ -617,11 +628,11 @@ export const FormContents: FunctionComponent<{
             await loadAllMuutRef.current?.();
             const lower = query.toLowerCase();
             const matchRow = (o: OmistajaRow) =>
-              [o.nimi, o.kiinteistotunnus, o.jakeluosoite, o.postinumero, o.paikkakunta, o.maa]
-                .some((val) => val?.toLowerCase().includes(lower));
+              [o.nimi, o.kiinteistotunnus, o.jakeluosoite, o.postinumero, o.paikkakunta, o.maa].some((val) =>
+                val?.toLowerCase().includes(lower)
+              );
             const values = useFormReturn.getValues();
-            const filterIndices = (rows: OmistajaRow[]) =>
-              new Set(rows.map((o, i) => (matchRow(o) ? i : -1)).filter((i) => i >= 0));
+            const filterIndices = (rows: OmistajaRow[]) => new Set(rows.map((o, i) => (matchRow(o) ? i : -1)).filter((i) => i >= 0));
             setSuodatus({
               suomifiOmistajat: filterIndices(values.suomifiOmistajat),
               muutOmistajat: filterIndices(values.muutOmistajat),
@@ -642,100 +653,113 @@ export const FormContents: FunctionComponent<{
 
   return (
     <SuodatusContext.Provider value={suodatus}>
-    <FormProvider {...useFormReturn}>
-      <DialogForm>
-        <DialogContent>
-          <SuodatusKentta onSuodata={handleSuodata} suodatusAktiivinen={!!suodatus} />
-          <Section noDivider>
-            <H3>Kiinteistönomistajien tiedotus Suomi.fi -palvelulla</H3>
-            <p>
-              Ilmoitus toimitetaan alle listatuille kiinteistönomistajille järjestelmän kautta kuulutuksen julkaisupäivänä.
-              Kiinteistönomistajista viedään vastaanottajalista automaattisesti asianhallintaan, kun kuulutus hyväksytään julkaistavaksi.
-            </p>
-            {hakutulosMaarat.suomifi ? (
-              <PaginatedTaulukko
-                key={`suomifi-${resetKey}`}
-                oid={projekti.oid}
-                initialHakutulosMaara={hakutulosMaarat.suomifi}
-                columns={suomifiColumns}
-                fieldArrayName="suomifiOmistajat"
-                loadAllRef={loadAllSuomifiRef}
-              />
-            ) : (
-              <GrayBackgroundText>
-                <p>Karttarajaukseen ei osunut ainuttakaan Suomi.fi-tiedotettavaa.</p>
-              </GrayBackgroundText>
-            )}
-          </Section>
-          <Section>
-            <H3>Kiinteistönomistajat, joille ei ole yhteystietoja</H3>
-            <p>
-              Huomaathan, että kaikkien kiinteistönomistajien tietoja ei ole mahdollista löytää järjestelmän kautta. Tällöin tieto
-              kuulutuksesta toimitetaan kiinteistönomistajalle järjestelmän ulkopuolella. Voit listata alle kiinteistönomistajien osoitteen
-              muistiin. Lähetä kaikille tässä listassa oleville kiinteistönomistajille ilmoitus kuulutuksesta postitse.
-              Kiinteistönomistajista viedään vastaanottajalista automaattisesti asianhallintaan, kun kuulutus hyväksytään julkaistavaksi.
-            </p>
-            {initialSearchResponses.muut.hakutulosMaara ? (
-              <>
+      <FormProvider {...useFormReturn}>
+        <DialogForm>
+          <DialogContent>
+            <SuodatusKentta onSuodata={handleSuodata} suodatusAktiivinen={!!suodatus} />
+            <Section noDivider>
+              <H3>Kiinteistönomistajien tiedotus Suomi.fi -palvelulla</H3>
+              <p>
+                Ilmoitus toimitetaan alle listatuille kiinteistönomistajille järjestelmän kautta kuulutuksen julkaisupäivänä.
+                Kiinteistönomistajista viedään vastaanottajalista automaattisesti asianhallintaan, kun kuulutus hyväksytään julkaistavaksi.
+              </p>
+              {hakutulosMaarat.suomifi ? (
                 <PaginatedTaulukko
+                  key={`suomifi-${resetKey}`}
                   oid={projekti.oid}
-                  initialHakutulosMaara={initialSearchResponses.muut.hakutulosMaara}
-                  columns={muutColumns}
-                  fieldArrayName="muutOmistajat"
-                  loadAllRef={loadAllMuutRef}
-                  extraActions={<TuoExcelistaButton loadAllRef={loadAllMuutRef} />}
+                  initialHakutulosMaara={hakutulosMaarat.suomifi}
+                  columns={suomifiColumns}
+                  fieldArrayName="suomifiOmistajat"
+                  loadAllRef={loadAllSuomifiRef}
                 />
-              </>
-            ) : (
-              <GrayBackgroundText>
-                <p>Karttarajaukseen ei osunut ainuttakaan muilla tavoin tiedotettavaa.</p>
-              </GrayBackgroundText>
-            )}
-            <H4>Lisää muilla tavoin tiedotettava kiinteistönomistaja</H4>
-            <p>
-              Tässä voit lisätä muulla tavalla tiedotettavia kiinteistönomistajia. Huomaathan, että ne lisätään
-              kiinteistönomistajalistaukseen vasta tallennuksen jälkeen.
-            </p>
-            <LisatytTaulukko />
-          </Section>
-          <Section noDivider>
-            <Stack direction="row" justifyContent="end">
-              <Button type="button" onClick={resetAndClose}>
-                Palaa listaukseen
-              </Button>
-              <Button type="button" onClick={handleSubmit(onSubmit)} primary>
-                Tallenna
-              </Button>
-            </Stack>
-          </Section>
-        </DialogContent>
-      </DialogForm>
-      <HassuDialog
-        open={vahvistusInfo !== null}
-        title="Kiinteistönomistajatietojen tallentaminen"
-        onClose={() => { setVahvistusInfo(null); setPendingSubmitData(null); }}
-      >
-        <DialogContent>
-          {vahvistusInfo?.poistettavat ? (
-            <p>{`Olet poistamassa ${vahvistusInfo.poistettavat} kiinteistönomistaja${vahvistusInfo.poistettavat === 1 ? "n" : "a"}.`}</p>
-          ) : null}
-          {vahvistusInfo?.ylempaan ? (
-            <p>{`${vahvistusInfo.ylempaan} kiinteistönomistaja${vahvistusInfo.ylempaan === 1 ? "" : "a"} siirtyy Suomi.fi:n kautta tiedotettavaksi.`}</p>
-          ) : null}
-          {vahvistusInfo?.alempaan ? (
-            <p>{`${vahvistusInfo.alempaan} kiinteistönomistaja${vahvistusInfo.alempaan === 1 ? "" : "a"} siirtyy kiinteistönomistajiin, joilla ei ole yhteystietoja.`}</p>
-          ) : null}
-        </DialogContent>
-        <DialogActions>
-          <Button type="button" onClick={confirmAndSave} primary>
-            Jatka
-          </Button>
-          <Button type="button" onClick={() => { setVahvistusInfo(null); setPendingSubmitData(null); }}>
-            Peruuta
-          </Button>
-        </DialogActions>
-      </HassuDialog>
-    </FormProvider>
+              ) : (
+                <GrayBackgroundText>
+                  <p>Karttarajaukseen ei osunut ainuttakaan Suomi.fi-tiedotettavaa.</p>
+                </GrayBackgroundText>
+              )}
+            </Section>
+            <Section>
+              <H3>Kiinteistönomistajat, joille ei ole yhteystietoja</H3>
+              <p>
+                Huomaathan, että kaikkien kiinteistönomistajien tietoja ei ole mahdollista löytää järjestelmän kautta. Tällöin tieto
+                kuulutuksesta toimitetaan kiinteistönomistajalle järjestelmän ulkopuolella. Voit listata alle kiinteistönomistajien
+                osoitteen muistiin. Lähetä kaikille tässä listassa oleville kiinteistönomistajille ilmoitus kuulutuksesta postitse.
+                Kiinteistönomistajista viedään vastaanottajalista automaattisesti asianhallintaan, kun kuulutus hyväksytään julkaistavaksi.
+              </p>
+              {initialSearchResponses.muut.hakutulosMaara ? (
+                <>
+                  <PaginatedTaulukko
+                    oid={projekti.oid}
+                    initialHakutulosMaara={initialSearchResponses.muut.hakutulosMaara}
+                    columns={muutColumns}
+                    fieldArrayName="muutOmistajat"
+                    loadAllRef={loadAllMuutRef}
+                    extraActions={<TuoExcelistaButton loadAllRef={loadAllMuutRef} />}
+                  />
+                </>
+              ) : (
+                <GrayBackgroundText>
+                  <p>Karttarajaukseen ei osunut ainuttakaan muilla tavoin tiedotettavaa.</p>
+                </GrayBackgroundText>
+              )}
+              <H4>Lisää muilla tavoin tiedotettava kiinteistönomistaja</H4>
+              <p>
+                Tässä voit lisätä muulla tavalla tiedotettavia kiinteistönomistajia. Huomaathan, että ne lisätään
+                kiinteistönomistajalistaukseen vasta tallennuksen jälkeen.
+              </p>
+              <LisatytTaulukko />
+            </Section>
+            <Section noDivider>
+              <Stack direction="row" justifyContent="end">
+                <Button type="button" onClick={resetAndClose}>
+                  Palaa listaukseen
+                </Button>
+                <Button type="button" onClick={handleSubmit(onSubmit)} primary>
+                  Tallenna
+                </Button>
+              </Stack>
+            </Section>
+          </DialogContent>
+        </DialogForm>
+        <HassuDialog
+          open={vahvistusInfo !== null}
+          title="Kiinteistönomistajatietojen tallentaminen"
+          onClose={() => {
+            setVahvistusInfo(null);
+            setPendingSubmitData(null);
+          }}
+        >
+          <DialogContent>
+            {vahvistusInfo?.poistettavat ? (
+              <p>{`Olet poistamassa ${vahvistusInfo.poistettavat} kiinteistönomistaja${vahvistusInfo.poistettavat === 1 ? "n" : "a"}.`}</p>
+            ) : null}
+            {vahvistusInfo?.ylempaan ? (
+              <p>{`${vahvistusInfo.ylempaan} kiinteistönomistaja${
+                vahvistusInfo.ylempaan === 1 ? "" : "a"
+              } siirtyy Suomi.fi:n kautta tiedotettavaksi.`}</p>
+            ) : null}
+            {vahvistusInfo?.alempaan ? (
+              <p>{`${vahvistusInfo.alempaan} kiinteistönomistaja${
+                vahvistusInfo.alempaan === 1 ? "" : "a"
+              } siirtyy kiinteistönomistajiin, joilla ei ole yhteystietoja.`}</p>
+            ) : null}
+          </DialogContent>
+          <DialogActions>
+            <Button type="button" onClick={confirmAndSave} primary>
+              Jatka
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                setVahvistusInfo(null);
+                setPendingSubmitData(null);
+              }}
+            >
+              Peruuta
+            </Button>
+          </DialogActions>
+        </HassuDialog>
+      </FormProvider>
     </SuodatusContext.Provider>
   );
 };
@@ -771,11 +795,14 @@ const PaginatedTaulukko = ({
   }, [fields, suodatus, fieldArrayName]);
   const slicedFields = useMemo(() => (suodatus ? filteredFields : filteredFields.slice(0, sliceAt)), [filteredFields, sliceAt, suodatus]);
 
-  const getRowId = useCallback((_row: OmistajaRow, index: number) => {
-    if (!suodatus?.[fieldArrayName]) return String(index);
-    const indices = Array.from(suodatus[fieldArrayName]!).sort((a, b) => a - b);
-    return String(indices[index]);
-  }, [suodatus, fieldArrayName]);
+  const getRowId = useCallback(
+    (_row: OmistajaRow, index: number) => {
+      if (!suodatus?.[fieldArrayName]) return String(index);
+      const indices = Array.from(suodatus[fieldArrayName]!).sort((a, b) => a - b);
+      return String(indices[index]);
+    },
+    [suodatus, fieldArrayName]
+  );
 
   const api = useApi();
   const { withLoadingSpinner } = useLoadingSpinner();
@@ -889,11 +916,14 @@ const LisatytTaulukko = () => {
     return fields.filter((_, i) => indices.has(i));
   }, [fields, suodatus]);
 
-  const getRowId = useCallback((_row: OmistajaRow, index: number) => {
-    if (!suodatus?.lisatytOmistajat) return String(index);
-    const indices = Array.from(suodatus.lisatytOmistajat).sort((a, b) => a - b);
-    return String(indices[index]);
-  }, [suodatus]);
+  const getRowId = useCallback(
+    (_row: OmistajaRow, index: number) => {
+      if (!suodatus?.lisatytOmistajat) return String(index);
+      const indices = Array.from(suodatus.lisatytOmistajat).sort((a, b) => a - b);
+      return String(indices[index]);
+    },
+    [suodatus]
+  );
 
   const table = useReactTable({
     columns: lisatytColumns,
@@ -932,7 +962,9 @@ const LisatytTaulukko = () => {
 const DialogForm = styled("form")({ display: "contents" });
 
 // Excel column headers shared with export (tiedotettavatExcel.ts)
-const TuoExcelistaButton: FunctionComponent<{ loadAllRef: React.MutableRefObject<(() => Promise<void>) | undefined> }> = ({ loadAllRef }) => {
+const TuoExcelistaButton: FunctionComponent<{ loadAllRef: React.MutableRefObject<(() => Promise<void>) | undefined> }> = ({
+  loadAllRef,
+}) => {
   const { getValues, setValue } = useFormContext<KiinteistonOmistajatFormFields>();
   const { showErrorMessage, showSuccessMessage } = useSnackbars();
   const { withLoadingSpinner } = useLoadingSpinner();
@@ -962,31 +994,46 @@ const TuoExcelistaButton: FunctionComponent<{ loadAllRef: React.MutableRefObject
             // Load all rows from backend before matching
             await loadAllRef.current?.();
             const muutOmistajat = getValues("muutOmistajat");
-            const results = matchExcelRowsToOmistajat(rows, columns, muutOmistajat);
+            const { results, errors } = matchExcelRowsToOmistajat(rows, columns, muutOmistajat);
 
-        let updatedCount = 0;
-        for (const result of results) {
-          const current = muutOmistajat[result.index];
-          let changed = false;
-          if (result.jakeluosoite !== (current.jakeluosoite ?? "")) {
-            setValue(`muutOmistajat.${result.index}.jakeluosoite`, result.jakeluosoite, { shouldDirty: true });
-            changed = true;
-          }
-          if (result.postinumero !== (current.postinumero ?? "")) {
-            setValue(`muutOmistajat.${result.index}.postinumero`, result.postinumero, { shouldDirty: true });
-            changed = true;
-          }
-          if (result.paikkakunta !== (current.paikkakunta ?? "")) {
-            setValue(`muutOmistajat.${result.index}.paikkakunta`, result.paikkakunta, { shouldDirty: true });
-            changed = true;
-          }
-          if (changed) updatedCount++;
-        }
+            const errorIndices = new Set(errors.map((e) => e.omistajaIndex));
+
+            let updatedCount = 0;
+            for (const result of results) {
+              if (errorIndices.has(result.index)) {
+                continue;
+              }
+              const current = muutOmistajat[result.index];
+              let changed = false;
+              if (result.jakeluosoite !== (current.jakeluosoite ?? "")) {
+                setValue(`muutOmistajat.${result.index}.jakeluosoite`, result.jakeluosoite, { shouldDirty: true });
+                changed = true;
+              }
+              if (result.postinumero !== (current.postinumero ?? "")) {
+                setValue(`muutOmistajat.${result.index}.postinumero`, result.postinumero, { shouldDirty: true });
+                changed = true;
+              }
+              if (result.paikkakunta !== (current.paikkakunta ?? "")) {
+                setValue(`muutOmistajat.${result.index}.paikkakunta`, result.paikkakunta, { shouldDirty: true });
+                changed = true;
+              }
+              if (result.maakoodi !== null && result.maakoodi !== (current.maakoodi ?? "")) {
+                setValue(`muutOmistajat.${result.index}.maakoodi`, result.maakoodi, { shouldDirty: true });
+                changed = true;
+              }
+              if (changed) updatedCount++;
+            }
 
             if (updatedCount > 0) {
               showSuccessMessage(`Osoitetiedot päivitetty ${updatedCount} kiinteistönomistajalle. Muista tallentaa muutokset.`);
-            } else {
+            } else if (errors.length === 0) {
               showSuccessMessage("Excelistä ei löytynyt päivitettäviä osoitetietoja.");
+            }
+            if (errors.length > 0) {
+              const tunnistamattomat = errors.map((e) => `"${e.value}" (rivi ${e.rowIndex})`).join(", ");
+              showErrorMessage(
+                `${errors.length} ${errors.length === 1 ? "rivi" : "riviä"} ohitettu tunnistamattoman maan vuoksi: ${tunnistamattomat}`
+              );
             }
           } catch (e) {
             log.error("Excel-tiedoston lukeminen epäonnistui", e);
@@ -1032,7 +1079,12 @@ const SuodatusKentta: FunctionComponent<{ onSuodata: (query: string) => void; su
           autoComplete="off"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onSuodata(query); } }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onSuodata(query);
+            }
+          }}
           size="small"
         />
         <Button primary type="button" onClick={() => onSuodata(query)} endIcon="search">

--- a/src/util/excelImport.ts
+++ b/src/util/excelImport.ts
@@ -1,6 +1,7 @@
 // Contains code generated or recommended by Amazon Q
 import { OMISTAJA_EXCEL_HEADERS } from "common/excelConstants";
 import { OMISTAJA_EXCEL_SHEETS } from "common/excelConstants";
+import lookup from "country-code-lookup";
 
 export type ExcelColumnIndices = {
   kiinteistotunnus: number;
@@ -8,6 +9,7 @@ export type ExcelColumnIndices = {
   postiosoite: number;
   postinumero: number;
   postitoimipaikka: number;
+  maa: number;
   headerRowIndex: number;
 };
 
@@ -23,8 +25,20 @@ export function findColumnIndices(rows: unknown[][]): ExcelColumnIndices | null 
     postiosoite: indexOf(OMISTAJA_EXCEL_HEADERS.postiosoite),
     postinumero: indexOf(OMISTAJA_EXCEL_HEADERS.postinumero),
     postitoimipaikka: indexOf(OMISTAJA_EXCEL_HEADERS.postitoimipaikka),
+    maa: indexOf(OMISTAJA_EXCEL_HEADERS.maa),
     headerRowIndex: rows.indexOf(headerRow),
   };
+}
+
+const regionNames = new Intl.DisplayNames("fi", { type: "region" });
+
+export function countryNameToIso2(name: string): string | null {
+  const trimmed = name.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+  const match = lookup.countries.find((c) => regionNames.of(c.iso2)?.toLowerCase() === trimmed);
+  return match?.iso2 ?? null;
 }
 
 export type OmistajaMatchInput = {
@@ -38,15 +52,29 @@ export type ExcelImportResult = {
   jakeluosoite: string;
   postinumero: string;
   paikkakunta: string;
+  maakoodi: string | null;
+};
+
+export type ExcelImportError = {
+  type: "unknown_country";
+  rowIndex: number;
+  omistajaIndex: number;
+  value: string;
+};
+
+export type ExcelImportOutput = {
+  results: ExcelImportResult[];
+  errors: ExcelImportError[];
 };
 
 export function matchExcelRowsToOmistajat(
   rows: unknown[][],
   columns: ExcelColumnIndices,
   omistajat: OmistajaMatchInput[]
-): ExcelImportResult[] {
+): ExcelImportOutput {
   const dataRows = rows.slice(columns.headerRowIndex + 1);
   const results: ExcelImportResult[] = [];
+  const errors: ExcelImportError[] = [];
 
   for (let i = 0; i < omistajat.length; i++) {
     const omistaja = omistajat[i];
@@ -65,12 +93,22 @@ export function matchExcelRowsToOmistajat(
       const jakeluosoite = columns.postiosoite >= 0 ? String(matchingRow[columns.postiosoite] ?? "").trim() : "";
       const postinumero = columns.postinumero >= 0 ? String(matchingRow[columns.postinumero] ?? "").trim() : "";
       const paikkakunta = columns.postitoimipaikka >= 0 ? String(matchingRow[columns.postitoimipaikka] ?? "").trim() : "";
+      const maaStr = columns.maa >= 0 ? String(matchingRow[columns.maa] ?? "").trim() : "";
 
-      results.push({ index: i, jakeluosoite, postinumero, paikkakunta });
+      let maakoodi: string | null = null;
+      if (maaStr) {
+        maakoodi = countryNameToIso2(maaStr);
+        if (!maakoodi) {
+          const rowIndex = dataRows.indexOf(matchingRow) + columns.headerRowIndex + 2;
+          errors.push({ type: "unknown_country", rowIndex, omistajaIndex: i, value: maaStr });
+        }
+      }
+
+      results.push({ index: i, jakeluosoite, postinumero, paikkakunta, maakoodi });
     }
   }
 
-  return results;
+  return { results, errors };
 }
 
 /**


### PR DESCRIPTION
### Muutos

Excel-tuonti huomioi nyt "Maa"-sarakkeen. Aiemmin tuonti päivitti vain osoitetiedot (postiosoite, postinumero, postitoimipaikka), mutta maa-tieto jäi huomioimatta.

### Toiminta

- Maa-sarakkeen arvo muunnetaan suomenkielisestä nimestä ISO 2 -maakoodiksi (esim. "Ruotsi" → "SE")
- Vertailu on case-insensitive: "suomi", "SUOMI" ja "Suomi" kaikki tunnistetaan
- Jos rivillä on tunnistamaton maa-arvo, koko rivi ohitetaan (osoitetietoja ei päivitetä)
  - (vaihtoehtoinen toteutus 1: voisi  päivittää rivin muilta osin ja ohittaa vain Maa-sarake)
  - (vaihtoehtoinen toteutus 2: skipataan koko import jos siinä on tunnistamattomia maa-arvoja) 
- Käyttäjälle näytetään viesti onnistuneista päivityksistä ja erillinen virheviesti ohitetuista riveistä


## AI-Assisted: Amazon Q developer,  generated
