### PR TITLE
chore: HASSUYP-818 - Korjaa AWSBackupServiceRolePolicyForRestores policyn ARN-polku

### DIFF
--- a/deployment/lib/hassu-database.ts
+++ b/deployment/lib/hassu-database.ts
@@ -465,7 +465,13 @@ export class HassuDatabaseStack extends Stack {
    * Only runs in production environment.
    */
   private createRestoreTestingPlan(backupVaultName: string, restoreRole: Role) {
-    restoreRole.addManagedPolicy(ManagedPolicy.fromAwsManagedPolicyName("AWSBackupServiceRolePolicyForRestores"));
+    restoreRole.addManagedPolicy(
+      ManagedPolicy.fromManagedPolicyArn(
+        this,
+        "RestorePolicy",
+        "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForRestores"
+      )
+    );
 
     const restoreTestingPlanName = `RestoreTest_${Config.env}`;
     const restoreTestingPlan = new backup.CfnRestoreTestingPlan(this, "RestoreTestingPlan", {


### PR DESCRIPTION
Policy on /service-role/ -polun alla, ei juuressa. fromAwsManagedPolicyName() ei löydä sitä, joten käytetään fromManagedPolicyArn() koko ARN:lla.


## AI-Assisted: Amazon Q developer, generated
