### PR TITLE
fix: HASSUYP-537-virtualisointikorjaus: Virtualisointi jätetään vain muutOmistajat-taulukolle

### DIFF
--- a/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
+++ b/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
@@ -868,7 +868,7 @@ const PaginatedTaulukko = ({
     enableSorting: false,
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
     state: { pagination: undefined },
-    meta: fieldArrayName === "muutOmistajat" ? { virtualization: { type: "window" } } : undefined,
+
     getRowId,
   });
 

--- a/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
+++ b/src/components/projekti/tiedottaminen/OmistajienMuokkausLomake.tsx
@@ -868,7 +868,7 @@ const PaginatedTaulukko = ({
     enableSorting: false,
     defaultColumn: { cell: (cell) => cell.getValue() || "-" },
     state: { pagination: undefined },
-    meta: { virtualization: { type: "window" } },
+    meta: fieldArrayName === "muutOmistajat" ? { virtualization: { type: "window" } } : undefined,
     getRowId,
   });
 


### PR DESCRIPTION
## Muutokset

Alkuperäinen ongelma: suomifiOmistajat-taulukossa virtualisointi aiheutti infinite loopin.
Muutettu niin, että meta-kenttä asettaa virtualisoinnin vain muutOmistajat-taulukolle, ja suomifiOmistajat-taulukolla se on undefined.

## AI-Assisted: Amazon Q developer, generated
