### PR TITLE
chore: HASSUYP-818  - Korjaa Restore testin EventBridgen event pattern

### DIFF
--- a/deployment/lib/hassu-database.ts
+++ b/deployment/lib/hassu-database.ts
@@ -503,15 +503,18 @@ export class HassuDatabaseStack extends Stack {
     const alarmTopic = sns.Topic.fromTopicArn(this, "BackupAlarmTopic", alarmTopicArn);
 
     new events.Rule(this, "RestoreTestResultRule", {
+      description: "Notify on restore testing job completion or failure",
       eventPattern: {
         source: ["aws.backup"],
         detailType: ["Restore Job State Change"],
-        detail: { state: ["COMPLETED", "FAILED"] },
+        detail: {
+          status: ["COMPLETED", "FAILED"],
+        },
       },
       targets: [
         new targets.SnsTopic(alarmTopic, {
           message: events.RuleTargetInput.fromText(
-            `[${Config.env}] AWS Backup Restore Testing Plan: ${events.EventField.fromPath("$.detail.state")}
+            `[${Config.env}] AWS Backup Restore Testing: ${events.EventField.fromPath("$.detail.status")}
 
 Automated restore test for Hassu application backups (compliance).
 Runs semi-annually (June 1st and December 1st) to verify that DynamoDB snapshot backups
@@ -519,9 +522,9 @@ and S3 PITR backups are restorable.
 
 Environment: ${Config.env}
 Resource type: ${events.EventField.fromPath("$.detail.resourceType")}
-Status: ${events.EventField.fromPath("$.detail.state")}
-Restored resource: ${events.EventField.fromPath("$.detail.createdResourceArn")}
+Status: ${events.EventField.fromPath("$.detail.status")}
 Restore job ID: ${events.EventField.fromPath("$.detail.restoreJobId")}
+Created resource: ${events.EventField.fromPath("$.detail.createdResourceArn")}
 
 Results: AWS Backup console → Restore testing
 Configuration: deployment/lib/hassu-database.ts → createRestoreTestingPlan()`


### PR DESCRIPTION
### Ongelma

AWS Backup restore testing plan oli konfiguroitu lähettämään SNS-ilmoituksia kun restore-testit valmistuvat tai epäonnistuvat, mutta **ilmoituksia ei koskaan lähetetty**.

### syy ja korjaus

EventBridge-säännön event pattern käytti **väärää kenttää**:

**Vanha (virheellinen):**
```typescript
eventPattern: {
  source: ["aws.backup"],
  detailType: ["Restore Job State Change"],
  detail: { state: ["COMPLETED", "FAILED"] },  // ❌ VÄÄRÄ
}
```

**Uusi (oikea):**
```typescript
eventPattern: {
  source: ["aws.backup"],
  detailType: ["Restore Job State Change"],
  detail: { status: ["COMPLETED", "FAILED"] },  // ✅ OIKEA
}
```


## AI-Assisted: Amazon Q developer, generated
