### PR TITLE
feat: HASSUYP-871 - Lisää Suomi.fi-viestien lähetys aloituskuulutukselle

### DIFF
--- a/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
+++ b/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
@@ -37,6 +37,8 @@ import { findAloitusKuulutusWaitingForApproval } from "../../projekti/projektiUt
 import { getLinkkiAsianhallintaan } from "../../asianhallinta/getLinkkiAsianhallintaan";
 import { isProjektiAsianhallintaIntegrationEnabled } from "../../util/isProjektiAsianhallintaIntegrationEnabled";
 import { haeKuulutettuYhdessaSuunnitelmanimi } from "../../asiakirja/haeKuulutettuYhdessaSuunnitelmanimi";
+import { parameters } from "../../aws/parameters";
+import { log } from "../../logger";
 
 async function createAloituskuulutusPDF(
   asiakirjaTyyppi: AsiakirjaTyyppi,
@@ -141,6 +143,12 @@ class AloitusKuulutusTilaManager extends KuulutusTilaManager<AloitusKuulutus, Al
     validateSaamePDFsExistIfRequired(projekti.kielitiedot?.toissijainenKieli, vaihe);
     if (!this.getVaiheAineisto(projekti).isReady()) {
       throw new IllegalAineistoStateError();
+    }
+    const suomifiViestitEnabled = await parameters.isSuomiFiIntegrationEnabled();
+    if (suomifiViestitEnabled && !projekti.omistajahaku?.status) {
+      const msg = "Kiinteistönomistajia ei ole haettu ennen aloituskuulutuksen hyväksyntää";
+      log.error(msg);
+      throw new IllegalArgumentError(msg);
     }
   }
 

--- a/backend/src/sqsEvents/sqsEventHandlerLambda.ts
+++ b/backend/src/sqsEvents/sqsEventHandlerLambda.ts
@@ -484,6 +484,13 @@ export const handlerFactory = (event: SQSEvent) => async () => {
           projekti.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil13";
           await projektiDatabase.saveProjekti({ oid: projekti.oid, versio: projekti.versio, kasittelynTila: projekti.kasittelynTila });
           await velho.saveProjektiSuunnitelmanTila(projekti.oid, projekti.kasittelynTila.suunnitelmanTila);
+          // Lähetetään Suomi.fi-viestit kiinteistönomistajille
+          const julkaisu = projekti.aloitusKuulutusJulkaisut?.[projekti.aloitusKuulutusJulkaisut.length - 1];
+          if (!julkaisu?.uudelleenKuulutus || julkaisu.uudelleenKuulutus.tiedotaKiinteistonomistajia) {
+            await lahetaSuomiFiViestit(projekti, sqsEvent.approvalType);
+          } else {
+            log.info("Ei Suomi.fi tiedoteta kiinteistönomistajia");
+          }
         } else if (
           successfulSynchronization &&
           sqsEvent.approvalType === PublishOrExpireEventType.EXPIRE &&

--- a/backend/src/suomifi/suomifiHandler.ts
+++ b/backend/src/suomifi/suomifiHandler.ts
@@ -272,7 +272,16 @@ type PaivitaLahetysStatusParameter = {
   lahetysTapa?: LahetysTapa;
 };
 
-async function paivitaLahetysStatus({ oid, id, omistaja, tila, approvalType, traceId, lahetysaika, lahetysTapa }: PaivitaLahetysStatusParameter) {
+async function paivitaLahetysStatus({
+  oid,
+  id,
+  omistaja,
+  tila,
+  approvalType,
+  traceId,
+  lahetysaika,
+  lahetysTapa,
+}: PaivitaLahetysStatusParameter) {
   const params = new UpdateCommand({
     TableName: omistaja ? getKiinteistonomistajaTableName() : getMuistuttajaTableName(),
     Key: {
@@ -308,7 +317,51 @@ async function createGenerateEvent(
   projektiFromDB: DBProjekti,
   kohde: Kohde
 ): Promise<GeneratePDFEvent | undefined> {
+  // PLACEHOLDER: Aloituskuulutukselle käytetään väliaikaisesti nähtävilläolovaiheen PDF-generointia (HASSUYP-872)
   if (
+    asiakirjaTyyppi === AsiakirjaTyyppi.ILMOITUS_NAHTAVILLAOLOKUULUTUKSESTA_KIINTEISTOJEN_OMISTAJILLE &&
+    tyyppi === PublishOrExpireEventType.PUBLISH_ALOITUSKUULUTUS &&
+    projektiFromDB.aloitusKuulutusJulkaisut
+  ) {
+    const aloitusJulkaisu = projektiFromDB.aloitusKuulutusJulkaisut[projektiFromDB.aloitusKuulutusJulkaisut.length - 1];
+    // Käytetään nahtavillaoloVaiheJulkaisut dataa jos sellainen löytyy, muuten luodaan dummy-data
+    const julkaisu =
+      projektiFromDB.nahtavillaoloVaiheJulkaisut?.[projektiFromDB.nahtavillaoloVaiheJulkaisut.length - 1] ??
+      ({
+        id: 1,
+        kuulutusPaiva: aloitusJulkaisu.kuulutusPaiva,
+        kuulutusVaihePaattyyPaiva: aloitusJulkaisu.kuulutusPaiva,
+        hankkeenKuvaus: { SUOMI: "Suunnittelu on aloitettu" },
+        kielitiedot: aloitusJulkaisu.kielitiedot,
+        velho: aloitusJulkaisu.velho,
+        yhteystiedot: aloitusJulkaisu.yhteystiedot,
+        tila: aloitusJulkaisu.tila,
+      } as any);
+    return {
+      createNahtavillaoloKuulutusPdf: {
+        asiakirjaTyyppi,
+        kuulutettuYhdessaSuunnitelmanimi: await haeKuulutettuYhdessaSuunnitelmanimi(julkaisu.projektinJakautuminen, Kieli.SUOMI),
+        asianhallintaPaalla: !(projektiFromDB.asianhallinta?.inaktiivinen ?? true),
+        kayttoOikeudet: projektiFromDB.kayttoOikeudet,
+        kieli: Kieli.SUOMI,
+        linkkiAsianhallintaan: undefined,
+        luonnos: false,
+        lyhytOsoite: projektiFromDB.lyhytOsoite,
+        nahtavillaoloVaihe: julkaisu,
+        oid: projektiFromDB.oid,
+        velho: projektiFromDB.velho!,
+        vahainenMenettely: projektiFromDB.vahainenMenettely,
+        euRahoitusLogot: projektiFromDB.euRahoitusLogot,
+        suunnitteluSopimus: projektiFromDB.suunnitteluSopimus as SuunnitteluSopimus | undefined,
+        osoite: {
+          nimi: kohde.nimi,
+          katuosoite: kohde.lahiosoite,
+          postinumero: kohde.postinumero,
+          postitoimipaikka: kohde.postitoimipaikka,
+        },
+      },
+    };
+  } else if (
     asiakirjaTyyppi === AsiakirjaTyyppi.ILMOITUS_NAHTAVILLAOLOKUULUTUKSESTA_KIINTEISTOJEN_OMISTAJILLE &&
     tyyppi === PublishOrExpireEventType.PUBLISH_NAHTAVILLAOLO &&
     projektiFromDB.nahtavillaoloVaiheJulkaisut
@@ -416,7 +469,11 @@ async function getFilesAndLanguages(
 }
 
 function determineAsiakirjaTyyppi(tyyppi: PublishOrExpireEventType, projektiFromDB: DBProjekti): AsiakirjaTyyppi | undefined {
-  if (tyyppi === PublishOrExpireEventType.PUBLISH_NAHTAVILLAOLO && projektiFromDB.nahtavillaoloVaiheJulkaisut) {
+  // PLACEHOLDER: Käytetään väliaikaisesti nähtävilläolovaiheen asiakirjatyyppiä
+  // kunnes aloituskuulutuksen oma PDF-generointilogiikka on valmis (HASSUYP-872)
+  if (tyyppi === PublishOrExpireEventType.PUBLISH_ALOITUSKUULUTUS && projektiFromDB.aloitusKuulutusJulkaisut) {
+    return AsiakirjaTyyppi.ILMOITUS_NAHTAVILLAOLOKUULUTUKSESTA_KIINTEISTOJEN_OMISTAJILLE;
+  } else if (tyyppi === PublishOrExpireEventType.PUBLISH_NAHTAVILLAOLO && projektiFromDB.nahtavillaoloVaiheJulkaisut) {
     return AsiakirjaTyyppi.ILMOITUS_NAHTAVILLAOLOKUULUTUKSESTA_KIINTEISTOJEN_OMISTAJILLE;
   } else if (tyyppi === PublishOrExpireEventType.PUBLISH_HYVAKSYMISPAATOSVAIHE && projektiFromDB.hyvaksymisPaatosVaiheJulkaisut) {
     return AsiakirjaTyyppi.ILMOITUS_HYVAKSYMISPAATOSKUULUTUKSESTA_MUISTUTTAJILLE;
@@ -477,7 +534,30 @@ async function getFinnishFileAsBuffer(
 }
 
 function getSaateteksti(tyyppi: PublishOrExpireEventType, projektiFromDB: DBProjekti, kielet: Kieli[]) {
-  if (tyyppi === PublishOrExpireEventType.PUBLISH_NAHTAVILLAOLO) {
+  // PLACEHOLDER: Käytetään väliaikaisesti nähtävilläolovaiheen saateviestin pohjaa (HASSUYP-872)
+  if (tyyppi === PublishOrExpireEventType.PUBLISH_ALOITUSKUULUTUS) {
+    let sisalto = `Hei,
+
+Olette saaneet kirjeen, jossa kerrotaan suunnitelman aloittamisesta. Kirje on tämän viestin liitteenä. Löydät kirjeestä linkin Valtion liikenneväylien suunnittelu -palveluun, missä pääsette tutustumaan suunnitelmaan tarkemmin.
+
+Ystävällisin terveisin
+${translate("viranomainen." + projektiFromDB.velho?.suunnittelustaVastaavaViranomainen, Kieli.SUOMI)}`;
+    if (kielet.includes(Kieli.RUOTSI)) {
+      sisalto += `
+
+Hej,
+
+Ni har fått ett brev med information om planläggningens början. Brevet finns som bilaga till detta meddelande. I brevet hittar du en länk till tjänsten Planering av statens trafikleder, där ni kan bekanta er närmare med planen.
+
+Med vänlig hälsning
+${translate("viranomainen." + projektiFromDB.velho?.suunnittelustaVastaavaViranomainen, Kieli.RUOTSI)}
+`;
+    }
+    return {
+      otsikko: `Ilmoitus suunnitelman aloittamisesta${kielet.includes(Kieli.RUOTSI) ? " / Meddelande om planläggningens början" : ""}`,
+      sisalto,
+    };
+  } else if (tyyppi === PublishOrExpireEventType.PUBLISH_NAHTAVILLAOLO) {
     let sisalto = `Hei,
 
 Olette saaneet kirjeen, jossa kerrotaan suunnitelman nähtäville asettamisesta sekä mahdollisuudesta tehdä suunnitelmasta muistutus. Kirje on tämän viestin liitteenä. Löydät kirjeestä linkin Valtion liikenneväylien suunnittelu -palveluun, missä pääsette tutustumaan suunnitelmaan tarkemmin.
@@ -631,12 +711,7 @@ async function lahetaPdfViesti({
 
 // REST-rajapinta tukee pelkän paperikirjeen lähettämistä pelkällä osoitteella ilman hetua/y-tunnusta
 function isOmistajanTiedotOk(kohde: DBOmistaja): boolean {
-  return (
-    (!!kohde.nimi || (!!kohde.etunimet && !!kohde.sukunimi)) &&
-    !!kohde.jakeluosoite &&
-    !!kohde.paikkakunta &&
-    !!kohde.postinumero
-  );
+  return (!!kohde.nimi || (!!kohde.etunimet && !!kohde.sukunimi)) && !!kohde.jakeluosoite && !!kohde.paikkakunta && !!kohde.postinumero;
 }
 
 function isMuistuttujanTiedotOk(kohde: DBMuistuttaja): boolean {

--- a/backend/test/handler/tila/aloitusKuulutusTilaManager.test.ts
+++ b/backend/test/handler/tila/aloitusKuulutusTilaManager.test.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 /* tslint:disable:only-arrow-functions */
 
 import { aloitusKuulutusTilaManager } from "../../../src/handler/tila/aloitusKuulutusTilaManager";
@@ -21,13 +22,13 @@ describe("aloitusKuulutusTilaManager", () => {
   let projekti: DBProjekti;
   const userFixture = new UserFixture(userService);
   new S3Mock();
-  let isSuomiFiIntegrationEnabledStub: sinon.SinonStub;
+  let isSuomiFiViestitIntegrationEnabledStub: sinon.SinonStub;
   before(() => {
     saveProjektiStub = sinon.stub(projektiDatabase, "saveProjekti");
     sinon.stub(projektiDatabase.aloitusKuulutusJulkaisut, "update");
     sinon.stub(parameters, "isAsianhallintaIntegrationEnabled").returns(Promise.resolve(false));
     sinon.stub(parameters, "isUspaIntegrationEnabled").returns(Promise.resolve(false));
-    isSuomiFiIntegrationEnabledStub = sinon.stub(parameters, "isSuomiFiIntegrationEnabled").returns(Promise.resolve(false));
+    isSuomiFiViestitIntegrationEnabledStub = sinon.stub(parameters, "isSuomiFiViestitIntegrationEnabled").returns(Promise.resolve(false));
   });
 
   beforeEach(() => {
@@ -114,7 +115,7 @@ describe("aloitusKuulutusTilaManager", () => {
   });
 
   it("should validate omistajahaku status when SuomiFi integration is enabled", async function () {
-    isSuomiFiIntegrationEnabledStub.returns(Promise.resolve(true));
+    isSuomiFiViestitIntegrationEnabledStub.returns(Promise.resolve(true));
     projekti.omistajahaku = undefined;
     await expect(aloitusKuulutusTilaManager.validateSendForApproval(projekti)).to.eventually.be.rejectedWith(
       IllegalArgumentError,
@@ -123,7 +124,7 @@ describe("aloitusKuulutusTilaManager", () => {
   });
 
   it("should not validate omistajahaku status when SuomiFi integration is disabled", async function () {
-    isSuomiFiIntegrationEnabledStub.returns(Promise.resolve(false));
+    isSuomiFiViestitIntegrationEnabledStub.returns(Promise.resolve(false));
     projekti.omistajahaku = undefined;
     await expect(aloitusKuulutusTilaManager.validateSendForApproval(projekti)).to.eventually.be.fulfilled;
   });

--- a/backend/test/handler/tila/aloitusKuulutusTilaManager.test.ts
+++ b/backend/test/handler/tila/aloitusKuulutusTilaManager.test.ts
@@ -21,11 +21,13 @@ describe("aloitusKuulutusTilaManager", () => {
   let projekti: DBProjekti;
   const userFixture = new UserFixture(userService);
   new S3Mock();
+  let isSuomiFiIntegrationEnabledStub: sinon.SinonStub;
   before(() => {
     saveProjektiStub = sinon.stub(projektiDatabase, "saveProjekti");
     sinon.stub(projektiDatabase.aloitusKuulutusJulkaisut, "update");
     sinon.stub(parameters, "isAsianhallintaIntegrationEnabled").returns(Promise.resolve(false));
     sinon.stub(parameters, "isUspaIntegrationEnabled").returns(Promise.resolve(false));
+    isSuomiFiIntegrationEnabledStub = sinon.stub(parameters, "isSuomiFiIntegrationEnabled").returns(Promise.resolve(false));
   });
 
   beforeEach(() => {
@@ -109,6 +111,21 @@ describe("aloitusKuulutusTilaManager", () => {
       alkuperainenHyvaksymisPaiva: "2022-03-21",
       alkuperainenKuulutusPaiva: projekti.aloitusKuulutusJulkaisut![0].kuulutusPaiva,
     });
+  });
+
+  it("should validate omistajahaku status when SuomiFi integration is enabled", async function () {
+    isSuomiFiIntegrationEnabledStub.returns(Promise.resolve(true));
+    projekti.omistajahaku = undefined;
+    await expect(aloitusKuulutusTilaManager.validateSendForApproval(projekti)).to.eventually.be.rejectedWith(
+      IllegalArgumentError,
+      "Kiinteistönomistajia ei ole haettu ennen aloituskuulutuksen hyväksyntää"
+    );
+  });
+
+  it("should not validate omistajahaku status when SuomiFi integration is disabled", async function () {
+    isSuomiFiIntegrationEnabledStub.returns(Promise.resolve(false));
+    projekti.omistajahaku = undefined;
+    await expect(aloitusKuulutusTilaManager.validateSendForApproval(projekti)).to.eventually.be.fulfilled;
   });
 
   it("should remove saamePDFs from old kuulutus when making uudelleenkuulutus", async function () {

--- a/backend/test/suomifi/__snapshots__/suomifiHandler.test.ts.snap
+++ b/backend/test/suomifi/__snapshots__/suomifiHandler.test.ts.snap
@@ -271,6 +271,35 @@ Väylävirasto",
 }
 `;
 
+exports[`suomifiHandler omistajan pdf viesti suomi.fi aloituskuulutus 1`] = `
+Object {
+  "hetu": "ABC",
+  "kustannuspaikka": undefined,
+  "lahiosoite": "Osoite 1",
+  "maa": "FI",
+  "nimi": "Testi Teppo",
+  "otsikko": "Ilmoitus suunnitelman aloittamisesta",
+  "postinumero": "00100",
+  "postitoimipaikka": "Helsinki",
+  "sisalto": "Hei,
+
+Olette saaneet kirjeen, jossa kerrotaan suunnitelman aloittamisesta. Kirje on tämän viestin liitteenä. Löydät kirjeestä linkin Valtion liikenneväylien suunnittelu -palveluun, missä pääsette tutustumaan suunnitelmaan tarkemmin.
+
+Ystävällisin terveisin
+Väylävirasto",
+  "suunnittelustaVastaavaViranomainen": "VAYLAVIRASTO",
+  "tiedosto": Object {
+    "kuvaus": "T415 Ilmoitus kiinteistönomistajille nähtäville asettamisesta",
+    "nimi": "T415 Ilmoitus kiinteistonomistajille nahtaville asettamisesta.pdf",
+    "sisalto": Object {
+      "data": Array [],
+      "type": "Buffer",
+    },
+  },
+  "ytunnus": undefined,
+}
+`;
+
 exports[`suomifiHandler omistajan pdf viesti suomi.fi hyväksymispäätös 1`] = `
 Object {
   "hetu": "ABC",

--- a/backend/test/suomifi/suomifiHandler.test.ts
+++ b/backend/test/suomifi/suomifiHandler.test.ts
@@ -1312,6 +1312,143 @@ describe("suomifiHandler", () => {
     sinon.restore();
   });
 
+  it("lähetä suomi.fi viestit aloituskuulutukselle", async () => {
+    sinon.stub(parameters, "isSuomiFiViestitIntegrationEnabled").resolves(true);
+    sinon.stub(parameters, "getSuomiFiSQSUrl").resolves("");
+    const dbProjekti: Partial<DBProjektiSlim> = {
+      oid: "1",
+    };
+    mockClient(DynamoDBDocumentClient)
+      .on(QueryCommand, { TableName: config.kiinteistonomistajaTableName })
+      .resolves({
+        Items: [
+          { id: "1", henkilotunnus: "ABC", suomifiLahetys: true },
+          { id: "2", henkilotunnus: "ABC", suomifiLahetys: true },
+          { id: "3", henkilotunnus: "DEF", suomifiLahetys: true },
+        ],
+      })
+      .on(QueryCommand, { TableName: config.projektiMuistuttajaTableName })
+      .resolves({ Items: [] });
+
+    const sqsMock = mockClient(SQS).on(SendMessageBatchCommand).resolves({ Failed: [], Successful: [] });
+    await lahetaSuomiFiViestit(dbProjekti as DBProjektiSlim, PublishOrExpireEventType.PUBLISH_ALOITUSKUULUTUS);
+    expect(sqsMock.commandCalls(SendMessageBatchCommand).length).to.equal(1);
+    const input = sqsMock.commandCalls(SendMessageBatchCommand)[0].args[0].input;
+    assert(input.Entries);
+    const ids = input.Entries.map((e) => e.Id);
+    expect(ids).to.eql(["omistaja-1", "omistaja-3"]);
+    sinon.restore();
+  });
+
+  it("omistajan pdf viesti suomi.fi aloituskuulutus", async () => {
+    const parameterStub = sinon.stub(parameters, "isSuomiFiViestitIntegrationEnabled").resolves(true);
+    const omistaja: DBOmistaja = {
+      id: "123",
+      expires: 0,
+      lisatty: now().toString(),
+      oid: "1",
+      henkilotunnus: "ABC",
+      etunimet: "Testi",
+      sukunimi: "Teppo",
+      jakeluosoite: "Osoite 1",
+      postinumero: "00100",
+      paikkakunta: "Helsinki",
+      kiinteistotunnus: "123",
+      suomifiLahetys: true,
+      kaytossa: true,
+    };
+    const request: SuomiFiRequest = {};
+    const client = mockSuomiFiClient(request, 300);
+    setMockSuomiFiClient(client);
+    const aloitusKuulutusJulkaisut = [{ id: 1 } as any];
+    const dbProjekti: Partial<DBProjektiSlim> = {
+      oid: "1",
+      aloitusKuulutus: { id: 1 },
+      aloitusKuulutusJulkaisut: aloitusKuulutusJulkaisut,
+      velho: {
+        nimi: "Projektin nimi",
+        asiatunnusVayla: "vayla123",
+        asiatunnusELY: "ely123",
+        tyyppi: ProjektiTyyppi.TIE,
+        vaylamuoto: [],
+        suunnittelustaVastaavaViranomainen: SuunnittelustaVastaavaViranomainen.VAYLAVIRASTO,
+      },
+    };
+    const mock = mockClient(DynamoDBDocumentClient)
+      .on(GetCommand, { TableName: config.kiinteistonomistajaTableName })
+      .resolves({ Item: omistaja })
+      .on(GetCommand, { TableName: config.projektiTableName })
+      .resolves({
+        Item: dbProjekti,
+      })
+      .on(QueryCommand, { TableName: config.aloitusKuulutusJulkaisuTableName })
+      .resolves({ Items: aloitusKuulutusJulkaisut });
+    const fileStub = sinon.stub(fileService, "getProjektiFile").resolves(Buffer.from("tiedosto"));
+    const body: SuomiFiSanoma = { oid: "1", omistajaId: "123", tyyppi: PublishOrExpireEventType.PUBLISH_ALOITUSKUULUTUS };
+    const msg = { Records: [{ body: JSON.stringify(body) }] };
+    await handleEvent(msg as SQSEvent);
+    assert(request.pdfViesti);
+    request.pdfViesti.tiedosto.sisalto = Buffer.from("");
+    expect(request.pdfViesti).toMatchSnapshot();
+    expect(mock.commandCalls(UpdateCommand).length).to.equal(1);
+    const input = mock.commandCalls(UpdateCommand)[0].args[0].input;
+    assert(input.ExpressionAttributeValues);
+    expect(input.ExpressionAttributeValues[":status"][0].tila).to.equal("OK");
+    expect(input.ExpressionAttributeValues[":status"][0].tyyppi).to.equal(PublishOrExpireEventType.PUBLISH_ALOITUSKUULUTUS);
+    assert(input.Key);
+    expect(input.Key["id"]).to.equal("123");
+    parameterStub.restore();
+    fileStub.restore();
+  });
+
+  it("lisää tiedot saman henkilön muista kiinteistöistä ja muistutuksista aloituskuulutuksessa", async () => {
+    sinon.stub(parameters, "isSuomiFiViestitIntegrationEnabled").resolves(true);
+    sinon.stub(parameters, "getSuomiFiSQSUrl").resolves("");
+    const dbProjekti: Partial<DBProjektiSlim> = {
+      oid: "1",
+    };
+    mockClient(DynamoDBDocumentClient)
+      .on(QueryCommand, { TableName: config.kiinteistonomistajaTableName })
+      .resolves({
+        Items: [
+          { id: "1", henkilotunnus: "ABC", suomifiLahetys: true },
+          { id: "2", henkilotunnus: "ABC", suomifiLahetys: true },
+          { id: "3", henkilotunnus: "DEF", suomifiLahetys: true },
+          { id: "4", ytunnus: "123", suomifiLahetys: true },
+          { id: "5", ytunnus: "123", suomifiLahetys: true },
+        ],
+      })
+      .on(QueryCommand, { TableName: config.projektiMuistuttajaTableName })
+      .resolves({ Items: [] });
+
+    const sqsMock = mockClient(SQS).on(SendMessageBatchCommand).resolves({ Failed: [], Successful: [] });
+    await lahetaSuomiFiViestit(dbProjekti as DBProjektiSlim, PublishOrExpireEventType.PUBLISH_ALOITUSKUULUTUS);
+    expect(sqsMock.commandCalls(SendMessageBatchCommand).length).to.equal(1);
+    const input = sqsMock.commandCalls(SendMessageBatchCommand)[0].args[0].input;
+    assert(input.Entries);
+    const entryIdsToMuistuttajaOmistaja = input.Entries.map((entry) => {
+      if (!entry.MessageBody) {
+        return undefined;
+      }
+      const msg: SuomiFiSanoma = JSON.parse(entry.MessageBody);
+      return {
+        Id: entry.Id,
+        eriOmistukset: msg.omistajaIdsForLahetystilaUpdate,
+        eriMuistutukset: msg.muistuttajaIdsForLahetystilaUpdate,
+      };
+    });
+    expect(entryIdsToMuistuttajaOmistaja).to.eql([
+      {
+        Id: "omistaja-1",
+        eriOmistukset: ["2"],
+        eriMuistutukset: [],
+      },
+      { Id: "omistaja-3", eriOmistukset: [], eriMuistutukset: [] },
+      { Id: "omistaja-4", eriOmistukset: ["5"], eriMuistutukset: [] },
+    ]);
+    sinon.restore();
+  });
+
   it("test parse elyn laskutustunnisteet", async () => {
     const tunniste = `${SuunnittelustaVastaavaViranomainen.ETELA_POHJANMAAN_ELY}: 1, ${SuunnittelustaVastaavaViranomainen.UUDENMAAN_ELY}:2, ${SuunnittelustaVastaavaViranomainen.LAPIN_ELY}:1, ${SuunnittelustaVastaavaViranomainen.POHJOIS_POHJANMAAN_ELY} :32 `;
     const parsed = parseLaskutus(tunniste);


### PR DESCRIPTION
# Suomi.fi-viestien lähetys aloituskuulutukselle

## Tausta

Toteutettu Suomi.fi-viestien lähetystoiminnallisuus aloituskuulutus-vaiheelle.
Toiminnallisuus peilaa olemassa olevaa nähtävilläolovaiheen toteutusta ja käyttää samaa 
lahetaSuomiFiViestit()-funktiota yhtenäisen toiminnan varmistamiseksi.

## Toteutus

### 1. Validointi ennen hyväksyntää

Tiedosto: backend/src/handler/tila/aloitusKuulutusTilaManager.ts

Lisätty validateSendForApproval()-metodiin tarkistus että projekti.omistajahaku?.status 
on olemassa. Heittää IllegalArgumentError-virheen jos kiinteistönomistajia ei ole haettu. 
Tarkistus suoritetaan vain kun isSuomiFiIntegrationEnabled() palauttaa true.

### 2. Viestien lähetys julkaisutapahtumassa

Tiedosto: backend/src/sqsEvents/sqsEventHandlerLambda.ts

Lisätty PUBLISH_ALOITUSKUULUTUS-tapahtumankäsittelijään Suomi.fi-viestien lähetys. 
Tarkistaa julkaisu?.uudelleenKuulutus?.tiedotaKiinteistonomistajia-lipun. 
Ensimmäisessä kuulutuksessa (ei uudelleenkuulutusta) viestit lähetetään automaattisesti.

### 3. Placeholder-toteutus PDF-generoinnille

Tiedosto: backend/src/suomifi/suomifiHandler.ts

Lisätty placeholder-tuki kolmessa funktiossa:

a) determineAsiakirjaTyyppi():
   - Palauttaa väliaikaisesti ILMOITUS_NAHTAVILLAOLOKUULUTUKSESTA_KIINTEISTOJEN_OMISTAJILLE

b) createGenerateEvent():
   - Luo PDF-generointitapahtuman käyttäen nähtävilläolon logiikkaa
   - Luo dummy-datan jos nahtavillaoloVaiheJulkaisut puuttuu:
     - kuulutusVaihePaattyyPaiva: kopioidaan kuulutusPaiva
     - hankkeenKuvaus: { SUOMI: "Suunnittelu on aloitettu" }

c) getSaateteksti():
   - Luo suomen- ja ruotsinkielisen saateviestin suunnitelman aloittamisesta
   - Otsikko: "Ilmoitus suunnitelman aloittamisesta / Meddelande om planläggningens början"

Kaikki placeholderit merkitty kommentilla: (HASSUYP-872)

## Toiminnallisuus

### Ensimmäinen aloituskuulutus
- Viestit lähetetään automaattisesti kaikille kiinteistönomistajille
- Edellyttää että projekti.omistajahaku?.status on olemassa
- Toimii kun isSuomiFiIntegrationEnabled() palauttaa true

### Uudelleenkuulutus ilman lippua
- Viestit EI lähde jos uudelleenKuulutus.tiedotaKiinteistonomistajia puuttuu tai on false

### Uudelleenkuulutus lipun kanssa
- Viestit lähetetään kun uudelleenKuulutus.tiedotaKiinteistonomistajia = true

### Virheiden käsittely
- Epäonnistuneet lähetykset merkitään TiedotettavanLahetyksenTila.VIRHE tietokantaan
- Ei automaattista uudelleenyrityslogiikkaa (yhtenäinen toiminta kaikissa vaiheissa)
- Virheet logitetaan audit trail -merkinnöillä

## Testit

### Yksikkötestit

1. Validointitestit (aloitusKuulutusTilaManager.test.ts):
   - Tarkistaa että validointi heittää virheen kun omistajahaku puuttuu ja Suomi.fi on päällä
   - Tarkistaa että validointi ohitetaan kun Suomi.fi on pois päältä

2. Viestinlähetystestit (suomifiHandler.test.ts):
   - "lähetä suomi.fi viestit aloituskuulutukselle": Testaa uniikkien omistajien viestien lähetystä
   - "omistajan pdf viesti suomi.fi aloituskuulutus": Testaa PDF-viestin generointia ja tietokannan päivityksiä
   - "lisää tiedot saman henkilön muista kiinteistöistä ja muistutuksista aloituskuulutuksessa": 
     Testaa usean kiinteistön omistajuuden seurantaa

### Integraatiotestit
Ei muutoksia tarvittu, koska Suomi.fi-integraatio on oletuksena pois päältä testeissä.

## Rajoitukset ja tuleva työ

### Placeholder-toteutus (HASSUYP-872)
Tällä hetkellä käytössä väliaikaiset ratkaisut:
- Käyttää nähtävilläolon asiakirjatyyppiä
- Käyttää nähtävilläolon PDF-templateja
- Dummy-data pakollisille kentille

Tuleva työ HASSUYP-872:ssa:
- Uusi AsiakirjaTyyppi.ILMOITUS_ALOITUSKUULUTUKSESTA_KIINTEISTOJEN_OMISTAJILLE
- Oikea PDF-generointilogiikka vastaanottajan osoitteella
- Lopulliset suomen- ja ruotsinkieliset saateviestit

## Liittyvät tiketit
- HASSUYP-872: Oikea aloituskuulutuksen PDF-generointi ja viestimallit



### AI-Assisted: Amazon Q developer, generated
