### PR TITLE
feat: Hassuyp-869 - Lisätty kiinteistönomistajat mukaan aloituskuulutusvaiheeseen

### DIFF
--- a/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
+++ b/backend/src/handler/tila/aloitusKuulutusTilaManager.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import {
   AsiakirjaTyyppi,
   Kieli,
@@ -37,6 +38,8 @@ import { findAloitusKuulutusWaitingForApproval } from "../../projekti/projektiUt
 import { getLinkkiAsianhallintaan } from "../../asianhallinta/getLinkkiAsianhallintaan";
 import { isProjektiAsianhallintaIntegrationEnabled } from "../../util/isProjektiAsianhallintaIntegrationEnabled";
 import { haeKuulutettuYhdessaSuunnitelmanimi } from "../../asiakirja/haeKuulutettuYhdessaSuunnitelmanimi";
+import { parameters } from "../../aws/parameters";
+import { log } from "../../logger";
 
 async function createAloituskuulutusPDF(
   asiakirjaTyyppi: AsiakirjaTyyppi,
@@ -141,6 +144,12 @@ class AloitusKuulutusTilaManager extends KuulutusTilaManager<AloitusKuulutus, Al
     validateSaamePDFsExistIfRequired(projekti.kielitiedot?.toissijainenKieli, vaihe);
     if (!this.getVaiheAineisto(projekti).isReady()) {
       throw new IllegalAineistoStateError();
+    }
+    const suomifiViestitEnabled = await parameters.isSuomiFiViestitIntegrationEnabled();
+    if (suomifiViestitEnabled && !projekti.omistajahaku?.status) {
+      const msg = "Kiinteistönomistajia ei ole haettu ennen aloituskuulutuksen hyväksyntää";
+      log.error(msg);
+      throw new Error(msg);
     }
   }
 

--- a/src/components/projekti/TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx
+++ b/src/components/projekti/TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx
@@ -103,7 +103,8 @@ export default function TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet<TFieldValu
             }
             if (
               data?.suomifiViestitEnabled &&
-              (tilasiirtymaTyyppi === TilasiirtymaTyyppi.NAHTAVILLAOLO ||
+              (tilasiirtymaTyyppi === TilasiirtymaTyyppi.ALOITUSKUULUTUS ||
+                tilasiirtymaTyyppi === TilasiirtymaTyyppi.NAHTAVILLAOLO ||
                 tilasiirtymaTyyppi === TilasiirtymaTyyppi.HYVAKSYMISPAATOSVAIHE) &&
               !projekti.omistajahaku?.status
             ) {

--- a/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
+++ b/src/components/projekti/aloituskuulutus/AloituskuulutusLukunakyma.tsx
@@ -268,7 +268,7 @@ export default function AloituskuulutusLukunakyma({ aloituskuulutusjulkaisu, pro
           <AloituskuulutusTiedostot aloituskuulutusjulkaisu={aloituskuulutusjulkaisu} oid={projekti.oid} epaaktiivinen={epaaktiivinen} />
         )}
       </Section>
-      <IlmoituksenVastaanottajat isLoading={isLoadingProjekti} aloituskuulutusjulkaisu={aloituskuulutusjulkaisu} />
+      <IlmoituksenVastaanottajat isLoading={isLoadingProjekti} aloituskuulutusjulkaisu={aloituskuulutusjulkaisu} oid={projekti.oid} omistajahakuStatus={projekti.omistajahaku?.status} />
     </>
   );
 }

--- a/src/components/projekti/aloituskuulutus/IlmoituksenVastaanottajat.tsx
+++ b/src/components/projekti/aloituskuulutus/IlmoituksenVastaanottajat.tsx
@@ -1,10 +1,11 @@
+// Contains code generated or recommended by Amazon Q
 import Button from "@components/button/Button";
 import TextInput from "@components/form/TextInput";
 import React, { ReactElement } from "react";
 import { Controller, FieldError, useFieldArray, useFormContext } from "react-hook-form";
 import useTranslation from "next-translate/useTranslation";
 import IconButton from "@components/button/IconButton";
-import { AloitusKuulutusJulkaisu, IlmoitettavaViranomainen, KuulutusJulkaisuTila, KuntaVastaanottaja } from "@services/api";
+import { AloitusKuulutusJulkaisu, IlmoitettavaViranomainen, KuulutusJulkaisuTila, KuntaVastaanottaja, Status, Vaihe } from "@services/api";
 import Section from "@components/layout/Section";
 import SectionContent from "@components/layout/SectionContent";
 import HassuGrid from "@components/HassuGrid";
@@ -18,6 +19,7 @@ import HassuMuiSelect from "@components/form/HassuMuiSelect";
 import { MenuItem } from "@mui/material";
 import { H2, H3, H4 } from "../../Headings";
 import { TukiEmailLink } from "../../EiOikeuksia";
+import KiinteistonomistajatOhje, { KiinteistonOmistajatOhjeLukutila } from "@components/projekti/common/KiinteistonOmistajatOhje";
 
 interface HelperType {
   kunnat?: FieldError | { nimi?: FieldError | undefined; sahkoposti?: FieldError | undefined }[] | undefined;
@@ -27,6 +29,8 @@ interface HelperType {
 interface Props {
   isLoading: boolean;
   aloituskuulutusjulkaisu?: AloitusKuulutusJulkaisu | null;
+  oid?: string;
+  omistajahakuStatus?: Status | null;
 }
 
 type FormFields = {
@@ -38,7 +42,7 @@ type FormFields = {
   };
 };
 
-export default function IlmoituksenVastaanottajat({ isLoading, aloituskuulutusjulkaisu }: Props): ReactElement {
+export default function IlmoituksenVastaanottajat({ isLoading, aloituskuulutusjulkaisu, oid, omistajahakuStatus }: Props): ReactElement {
   const { t, lang } = useTranslation("commonFI");
   const isReadonly = !!aloituskuulutusjulkaisu;
   const isKuntia = !!aloituskuulutusjulkaisu?.ilmoituksenVastaanottajat?.kunnat;
@@ -228,6 +232,23 @@ export default function IlmoituksenVastaanottajat({ isLoading, aloituskuulutusju
           />
         )}
       </SectionContent>
+      {!isReadonly && oid && (
+        <KiinteistonomistajatOhje
+          vaihe={Vaihe.ALOITUSKUULUTUS}
+          oid={oid}
+          omistajahakuStatus={omistajahakuStatus}
+        />
+      )}
+      {isReadonly && oid && (
+        <KiinteistonOmistajatOhjeLukutila
+          vaihe={Vaihe.ALOITUSKUULUTUS}
+          oid={oid}
+          omistajahakuStatus={omistajahakuStatus}
+          uudelleenKuulutus={aloituskuulutusjulkaisu?.uudelleenKuulutus}
+          kuulutusPaiva={aloituskuulutusjulkaisu?.kuulutusPaiva}
+          julkaisunTila={aloituskuulutusjulkaisu?.tila}
+        />
+      )}
     </Section>
   );
 }

--- a/src/components/projekti/common/KiinteistonOmistajatOhje.tsx
+++ b/src/components/projekti/common/KiinteistonOmistajatOhje.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import StyledLink from "@components/StyledLink";
 import SectionContent from "@components/layout/SectionContent";
 import { KuulutusJulkaisuTila, Status, UudelleenKuulutus, Vaihe } from "@services/api";
@@ -6,7 +7,7 @@ import dayjs from "dayjs";
 import useSuomifiUser from "src/hooks/useSuomifiUser";
 import { H3 } from "../../Headings";
 
-export type KiinteistonomistajatVaihe = Vaihe.NAHTAVILLAOLO | Vaihe.HYVAKSYMISPAATOS;
+export type KiinteistonomistajatVaihe = Vaihe.ALOITUSKUULUTUS | Vaihe.NAHTAVILLAOLO | Vaihe.HYVAKSYMISPAATOS;
 interface KiinteistonomistajatOhjeProps {
   vaihe?: KiinteistonomistajatVaihe;
   oid: string;
@@ -31,7 +32,24 @@ function KiinteistojaEiLisatty({ oid }: Readonly<KiinteistonomistajatOhjeProps>)
 }
 
 function KiinteistotLisatty({ oid, vaihe }: Readonly<KiinteistonomistajatOhjeProps>) {
-  if (vaihe === Vaihe.NAHTAVILLAOLO) {
+  if (vaihe === Vaihe.ALOITUSKUULUTUS) {
+    return (
+      <>
+        <p>
+          Tarkasta kiinteistönomistajien vastaanottajalista Tiedottaminen-sivun{" "}
+          <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>
+            Kiinteistönomistajat
+          </StyledLink>{" "}
+          -välilehdeltä. Kiinteistönomistajista viedään vastaanottajalista automaattisesti asianhallintaan, kun kuulutus hyväksytään
+          julkaistavaksi.
+        </p>
+        <p>
+          Kiinteistönomistajia, joille on tiedossa yhteystiedot, tiedotetaan automaattisesti Suomi.fi-palvelun kautta. Tiedot
+          kiinteistönomistajista löytyvät Tiedottaminen sivulta.
+        </p>
+      </>
+    );
+  } else if (vaihe === Vaihe.NAHTAVILLAOLO) {
     return (
       <>
         <p>
@@ -77,9 +95,10 @@ export default function KiinteistonomistajatOhje({
 }: Readonly<KiinteistonomistajatOhjeProps>) {
   const { data } = useSuomifiUser();
   if (!uudelleenKuulutus && data?.suomifiViestitEnabled && vaihe) {
+    const heading = vaihe === Vaihe.HYVAKSYMISPAATOS ? "Kiinteistönomistajat ja muistuttajat" : "Kiinteistönomistajat";
     return (
       <SectionContent>
-        <H3>{vaihe === Vaihe.NAHTAVILLAOLO ? "Kiinteistönomistajat" : "Kiinteistönomistajat ja muistuttajat"}</H3>
+        <H3>{heading}</H3>
         {omistajahakuStatus ? (
           <KiinteistotLisatty oid={oid} vaihe={vaihe} omistajahakuStatus={omistajahakuStatus} />
         ) : (
@@ -102,7 +121,27 @@ export function KiinteistonOmistajatOhjeLukutila({
   const { data } = useSuomifiUser();
   const pvm = dayjs(kuulutusPaiva, "DD.MM.YYYY").startOf("date");
   const inPast = pvm.isBefore(nyt()) && julkaisunTila !== KuulutusJulkaisuTila.ODOTTAA_HYVAKSYNTAA;
-  if (data?.suomifiViestitEnabled && vaihe === Vaihe.NAHTAVILLAOLO) {
+  if (data?.suomifiViestitEnabled && vaihe === Vaihe.ALOITUSKUULUTUS) {
+    return (
+      <SectionContent>
+        <H3 variant="h5">Kiinteistönomistajat</H3>
+        <>
+          <p>
+            Lista kuulutuksen ilmoituksen vastaanottaneista kiinteistönomistajista muodostuu asianhallintaan, kun kuulutus hyväksytään
+            julkaistavaksi.
+          </p>
+          <p>
+            Kiinteistönomistajia, joille on tiedossa yhteystiedot, tiedotetaan automaattisesti Suomi.fi-palvelun kautta. Tiedot
+            kiinteistönomistajista löytyvät{" "}
+            <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>
+              Tiedottaminen
+            </StyledLink>{" "}
+            -sivulta.
+          </p>
+        </>
+      </SectionContent>
+    );
+  } else if (data?.suomifiViestitEnabled && vaihe === Vaihe.NAHTAVILLAOLO) {
     return (
       <SectionContent>
         <H3 variant="h5">Kiinteistönomistajat</H3>

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import Textarea from "@components/form/Textarea";
 import ProjektiPageLayout, { ProjektiPageLayoutContext } from "@components/projekti/ProjektiPageLayout";
 import { ProjektiLisatiedolla, ProjektiValidationContext } from "hassu-common/ProjektiValidationContext";
@@ -417,7 +418,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti, kirj
                   </ContentSpacer>
                 </Section>
                 <KuulutuksenYhteystiedot projekti={projekti} />
-                <IlmoituksenVastaanottajat isLoading={isLoadingProjekti} />
+                <IlmoituksenVastaanottajat isLoading={isLoadingProjekti} oid={projekti.oid} omistajahakuStatus={projekti.omistajahaku?.status} />
               </fieldset>
             </form>
           </FormProvider>


### PR DESCRIPTION
## Muutokset

- Nyt sekä frontend (snackbar-esto) että backend (varsinainen validointi) estävät aloituskuulutuksen hyväksyttäväksi lähettämisen ilman kiinteistönomistajahakua.
- Lisätty infoteksti aloituskuulutuksen "esikatselusivulle" (ennen hyväksyntää).
- Lisätty kiinteistönomistajien infoteksti aloituskuulutussivulle (kuulutuksen jälkeen)

## AI-Assisted: Amazon Q developer, generated
