### PR TITLE
fix: HASSUYP-826 Korjaa lisätiedot-labelin teksti oikeaksi myös toissijaisella kielellä

### DIFF
--- a/src/components/projekti/suunnitteluvaihe/komponentit/VuorovaikutustilaisuusDialog/Lisatiedot.tsx
+++ b/src/components/projekti/suunnitteluvaihe/komponentit/VuorovaikutustilaisuusDialog/Lisatiedot.tsx
@@ -136,7 +136,7 @@ export default function Lisatiedot({ index, kielitiedot, tilaisuustyyppi }: Prop
       {toissijainenKaannettavaKieli && ensisijainenKaannettavaKieli && (
         <TextInput
           label={label({
-            label: "Tiivistetty hankkeen sisällönkuvaus",
+            label: "Lisätiedot",
             inputLanguage: toissijainenKaannettavaKieli,
             kielitiedot,
           })}


### PR DESCRIPTION
## Muutokset
Korjaa lisätiedot-labelin teksti oikeaksi myös toissijaisella kielellä

## AI-Assisted: Amazon Q developer, none
