### PR TITLE
fix: HASSUYP-816 - Ratasuunnitelman toteutusilmoitus ei päivitä automaattisesti käsittelyn tilaa

### DIFF
--- a/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
+++ b/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
@@ -81,7 +81,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
     });
 
-    it("ei aseta sutil06 kun osa muuttuu mutta koko on jo täytetty (liikenteeseenluovutus)", () => {
+    it("asettaa sutil07 kun osa muuttuu mutta koko on jo täytetty (liikenteeseenluovutus)", () => {
       const data = baseFormValues();
       data.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-10";
       data.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko jo täytetty
@@ -90,10 +90,10 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
 
       asetaKasittelynTilaAutomaatiolla(data, defaults);
 
-      expect(data.kasittelynTila!.suunnitelmanTila).not.toBe("suunnitelman-tila/sutil06");
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
     });
 
-    it("ei aseta sutil06 kun osa muuttuu mutta koko on jo täytetty (toteutusilmoitus)", () => {
+    it("asettaa sutil07 kun osa muuttuu mutta koko on jo täytetty (toteutusilmoitus)", () => {
       const data = baseFormValues();
       data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-10";
       data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-02-01"; // koko jo täytetty
@@ -102,7 +102,31 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
 
       asetaKasittelynTilaAutomaatiolla(data, defaults);
 
-      expect(data.kasittelynTila!.suunnitelmanTila).not.toBe("suunnitelman-tila/sutil06");
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
+    });
+
+    it("asettaa sutil06 kun koko poistetaan ja osa on täytetty", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-10";
+      data.kasittelynTila!.liikenteeseenluovutusKokonaan = null; // koko poistettu
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-10";
+      defaults.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko oli täytetty
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
+    });
+
+    it("ei muuta tilaa kun koko poistetaan eikä osa ole täytetty", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.liikenteeseenluovutusKokonaan = null; // koko poistettu
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko oli täytetty
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBeUndefined();
     });
 
     it("asettaa sutil07 kun sekä osa että koko muuttuvat samaan aikaan", () => {

--- a/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
+++ b/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
@@ -1,0 +1,101 @@
+// Contains code generated or recommended by Amazon Q
+import { asetaKasittelynTilaAutomaatiolla } from "src/util/asetaKasittelynTilaAutomaatiolla";
+import { KasittelynTilaFormValues } from "@pages/yllapito/projekti/[oid]/kasittelyntila";
+
+describe("asetaKasittelynTilaAutomaatiolla", () => {
+  const baseFormValues = (): KasittelynTilaFormValues => ({
+    oid: "test-oid",
+    versio: 1,
+    kasittelynTila: {
+      hyvaksymispaatos: { asianumero: "", paatoksenPvm: null },
+      liikenteeseenluovutusOsittain: null,
+      liikenteeseenluovutusKokonaan: null,
+      toteutusilmoitusOsittain: null,
+      toteutusilmoitusKokonaan: null,
+      toimitusKaynnistynyt: null,
+      lainvoimaAlkaen: null,
+      lainvoimaPaattyen: null,
+      valitustenMaara: null,
+    },
+  });
+
+  it("asettaa sutil06 kun toteutusilmoitusOsittain muuttuu", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-15";
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
+  });
+
+  it("asettaa sutil07 kun toteutusilmoitusKokonaan muuttuu", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
+  });
+
+  it("asettaa sutil06 kun liikenteeseenluovutusOsittain muuttuu", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-15";
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
+  });
+
+  it("asettaa sutil07 kun liikenteeseenluovutusKokonaan muuttuu", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-01-15";
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
+  });
+
+  it("ei muuta tilaa kun toteutusilmoitusOsittain ei muutu", () => {
+    const data = baseFormValues();
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBeUndefined();
+  });
+
+  it("toteutusilmoitusKokonaan yliajaa toteutusilmoitusOsittain kun molemmat muuttuvat", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-10";
+    data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
+  });
+
+  it("asettaa sutil04 kun hyvaksymispaatos asianumero ja pvm molemmat muuttuvat", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.hyvaksymispaatos = { asianumero: "ABC-123", paatoksenPvm: "2024-01-15" };
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil04");
+  });
+
+  it("asettaa sutil14 kun toimitusKaynnistynyt muuttuu", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.toimitusKaynnistynyt = "2024-01-15";
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil14");
+  });
+});

--- a/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
+++ b/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
@@ -19,66 +19,6 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     },
   });
 
-  it("asettaa sutil06 kun toteutusilmoitusOsittain muuttuu", () => {
-    const data = baseFormValues();
-    data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-15";
-    const defaults = baseFormValues();
-
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
-
-    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
-  });
-
-  it("asettaa sutil07 kun toteutusilmoitusKokonaan muuttuu", () => {
-    const data = baseFormValues();
-    data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
-    const defaults = baseFormValues();
-
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
-
-    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
-  });
-
-  it("asettaa sutil06 kun liikenteeseenluovutusOsittain muuttuu", () => {
-    const data = baseFormValues();
-    data.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-15";
-    const defaults = baseFormValues();
-
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
-
-    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
-  });
-
-  it("asettaa sutil07 kun liikenteeseenluovutusKokonaan muuttuu", () => {
-    const data = baseFormValues();
-    data.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-01-15";
-    const defaults = baseFormValues();
-
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
-
-    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
-  });
-
-  it("ei muuta tilaa kun toteutusilmoitusOsittain ei muutu", () => {
-    const data = baseFormValues();
-    const defaults = baseFormValues();
-
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
-
-    expect(data.kasittelynTila!.suunnitelmanTila).toBeUndefined();
-  });
-
-  it("toteutusilmoitusKokonaan yliajaa toteutusilmoitusOsittain kun molemmat muuttuvat", () => {
-    const data = baseFormValues();
-    data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-10";
-    data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
-    const defaults = baseFormValues();
-
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
-
-    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
-  });
-
   it("asettaa sutil04 kun hyvaksymispaatos asianumero ja pvm molemmat muuttuvat", () => {
     const data = baseFormValues();
     data.kasittelynTila!.hyvaksymispaatos = { asianumero: "ABC-123", paatoksenPvm: "2024-01-15" };
@@ -89,6 +29,104 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil04");
   });
 
+  it("asettaa sutil05 kun lainvoima alkaen ja paattyen molemmat muuttuvat", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.lainvoimaAlkaen = "2024-01-15";
+    data.kasittelynTila!.lainvoimaPaattyen = "2028-01-15";
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil05");
+  });
+
+  describe("Liikenteelleluovutus/Toteutusilmoitus (sutil06/sutil07)", () => {
+    it("asettaa sutil06 kun liikenteeseenluovutusOsittain muuttuu", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-15";
+      const defaults = baseFormValues();
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
+    });
+
+    it("asettaa sutil06 kun toteutusilmoitusOsittain muuttuu", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-15";
+      const defaults = baseFormValues();
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
+    });
+
+    it("asettaa sutil07 kun liikenteeseenluovutusKokonaan muuttuu", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-01-15";
+      const defaults = baseFormValues();
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
+    });
+
+    it("asettaa sutil07 kun toteutusilmoitusKokonaan muuttuu", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
+      const defaults = baseFormValues();
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
+    });
+
+    it("ei aseta sutil06 kun osa muuttuu mutta koko on jo täytetty (liikenteeseenluovutus)", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-10";
+      data.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko jo täytetty
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko ei muuttunut
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).not.toBe("suunnitelman-tila/sutil06");
+    });
+
+    it("ei aseta sutil06 kun osa muuttuu mutta koko on jo täytetty (toteutusilmoitus)", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-10";
+      data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-02-01"; // koko jo täytetty
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.toteutusilmoitusKokonaan = "2024-02-01"; // koko ei muuttunut
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).not.toBe("suunnitelman-tila/sutil06");
+    });
+
+    it("asettaa sutil07 kun sekä osa että koko muuttuvat samaan aikaan", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-10";
+      data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
+      const defaults = baseFormValues();
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
+    });
+  });
+
+  it("asettaa sutil08 kun valitustenMaara asetetaan", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.valitustenMaara = 1 as any;
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil08");
+  });
+
   it("asettaa sutil14 kun toimitusKaynnistynyt muuttuu", () => {
     const data = baseFormValues();
     data.kasittelynTila!.toimitusKaynnistynyt = "2024-01-15";
@@ -97,5 +135,14 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     asetaKasittelynTilaAutomaatiolla(data, defaults);
 
     expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil14");
+  });
+
+  it("ei muuta tilaa kun mitään ei muuteta", () => {
+    const data = baseFormValues();
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBeUndefined();
   });
 });

--- a/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
@@ -48,6 +48,7 @@ import RadioButton from "@components/form/RadioButton";
 import styled from "@emotion/styled";
 import FormGroup from "@components/form/FormGroup";
 import { useShowTallennaProjektiMessage } from "src/hooks/useShowTallennaProjektiMessage";
+import { asetaKasittelynTilaAutomaatiolla } from "src/util/asetaKasittelynTilaAutomaatiolla";
 
 export type KasittelynTilaFormValues = Pick<TallennaProjektiInput, "oid" | "versio" | "kasittelynTila">;
 
@@ -751,61 +752,3 @@ const FormGroupWithLabel = styled(FormGroup)(() => ({
     marginBottom: "0.5rem",
   },
 }));
-
-const asetaKasittelynTilaAutomaatiolla = (data: KasittelynTilaFormValues, defaults: KasittelynTilaFormValues) => {
-  const asianumeroChanged =
-    (data.kasittelynTila?.hyvaksymispaatos?.asianumero ?? null) !== defaults?.kasittelynTila?.hyvaksymispaatos?.asianumero;
-  const hyvaksymisPvmChanged =
-    (data.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm ?? null) !== defaults.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm;
-  if (asianumeroChanged && hyvaksymisPvmChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil04";
-  }
-
-  const lainvoimaAlkaenChanged = (data.kasittelynTila?.lainvoimaAlkaen ?? null) !== defaults.kasittelynTila?.lainvoimaAlkaen;
-  const lainvoimaPaatyenChanged = (data.kasittelynTila?.lainvoimaPaattyen ?? null) !== defaults.kasittelynTila?.lainvoimaPaattyen;
-  if (lainvoimaAlkaenChanged && lainvoimaPaatyenChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil05";
-  }
-
-  const liikenteeseenluovutusOsittainChanged =
-    (data.kasittelynTila?.liikenteeseenluovutusOsittain ?? null) !== defaults.kasittelynTila?.liikenteeseenluovutusOsittain;
-  if (liikenteeseenluovutusOsittainChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
-  }
-
-  const liikenteeseenluovutusKokonaanChanged =
-    (data.kasittelynTila?.liikenteeseenluovutusKokonaan ?? null) !== defaults.kasittelynTila?.liikenteeseenluovutusKokonaan;
-  if (liikenteeseenluovutusKokonaanChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
-  }
-
-  const toteutusilmoitusOsittainChanged =
-    (data.kasittelynTila?.toteutusilmoitusOsittain ?? null) !== defaults.kasittelynTila?.toteutusilmoitusOsittain;
-  if (toteutusilmoitusOsittainChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
-  }
-
-  const toteutusilmoitusKokonaanChanged =
-    (data.kasittelynTila?.toteutusilmoitusKokonaan ?? null) !== defaults.kasittelynTila?.toteutusilmoitusKokonaan;
-  if (toteutusilmoitusKokonaanChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
-  }
-
-  const valitustenMaaraChanged = data.kasittelynTila?.valitustenMaara !== null && defaults.kasittelynTila?.valitustenMaara === null;
-  if (valitustenMaaraChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil08";
-  }
-
-  const toimitusKaynnistynytChanged = (data.kasittelynTila?.toimitusKaynnistynyt ?? null) !== defaults.kasittelynTila?.toimitusKaynnistynyt;
-  if (toimitusKaynnistynytChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil14";
-  }
-};

--- a/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import React, { ReactElement, useCallback, useMemo, useEffect, FunctionComponent } from "react";
 import {
   JatkopaatettavaVaihe,
@@ -778,6 +779,20 @@ const asetaKasittelynTilaAutomaatiolla = (data: KasittelynTilaFormValues, defaul
   const liikenteeseenluovutusKokonaanChanged =
     (data.kasittelynTila?.liikenteeseenluovutusKokonaan ?? null) !== defaults.kasittelynTila?.liikenteeseenluovutusKokonaan;
   if (liikenteeseenluovutusKokonaanChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
+  }
+
+  const toteutusilmoitusOsittainChanged =
+    (data.kasittelynTila?.toteutusilmoitusOsittain ?? null) !== defaults.kasittelynTila?.toteutusilmoitusOsittain;
+  if (toteutusilmoitusOsittainChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
+  }
+
+  const toteutusilmoitusKokonaanChanged =
+    (data.kasittelynTila?.toteutusilmoitusKokonaan ?? null) !== defaults.kasittelynTila?.toteutusilmoitusKokonaan;
+  if (toteutusilmoitusKokonaanChanged) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
   }

--- a/src/util/asetaKasittelynTilaAutomaatiolla.ts
+++ b/src/util/asetaKasittelynTilaAutomaatiolla.ts
@@ -33,10 +33,12 @@ export const asetaKasittelynTilaAutomaatiolla = (data: KasittelynTilaFormValues,
   const osaChanged = liikenteeseenluovutusOsittainChanged || toteutusilmoitusOsittainChanged;
   const kokoChanged = liikenteeseenluovutusKokonaanChanged || toteutusilmoitusKokonaanChanged;
 
-  if (kokoChanged) {
+  const osaTaytetty = !!(data.kasittelynTila?.liikenteeseenluovutusOsittain || data.kasittelynTila?.toteutusilmoitusOsittain);
+
+  if ((kokoChanged || osaChanged) && kokoTaytetty) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
-  } else if (osaChanged && !kokoTaytetty) {
+  } else if ((kokoChanged || osaChanged) && osaTaytetty) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
   }

--- a/src/util/asetaKasittelynTilaAutomaatiolla.ts
+++ b/src/util/asetaKasittelynTilaAutomaatiolla.ts
@@ -11,39 +11,34 @@ export const asetaKasittelynTilaAutomaatiolla = (data: KasittelynTilaFormValues,
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil04";
   }
 
-  const lainvoimaAlkaenChanged = (data.kasittelynTila?.lainvoimaAlkaen ?? null) !== defaults.kasittelynTila?.lainvoimaAlkaen;
-  const lainvoimaPaatyenChanged = (data.kasittelynTila?.lainvoimaPaattyen ?? null) !== defaults.kasittelynTila?.lainvoimaPaattyen;
+  const lainvoimaAlkaenChanged = (data.kasittelynTila?.lainvoimaAlkaen ?? null) !== (defaults.kasittelynTila?.lainvoimaAlkaen ?? null);
+  const lainvoimaPaatyenChanged = (data.kasittelynTila?.lainvoimaPaattyen ?? null) !== (defaults.kasittelynTila?.lainvoimaPaattyen ?? null);
   if (lainvoimaAlkaenChanged && lainvoimaPaatyenChanged) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil05";
   }
 
+  // "Osa" (sutil06) ja "Koko" (sutil07): liikenteelleluovutus ja toteutusilmoitus jakavat samat tilat.
+  // Jos koko-kenttä on täytetty, tila on aina sutil07 eikä voi olla sutil06.
   const liikenteeseenluovutusOsittainChanged =
-    (data.kasittelynTila?.liikenteeseenluovutusOsittain ?? null) !== defaults.kasittelynTila?.liikenteeseenluovutusOsittain;
-  if (liikenteeseenluovutusOsittainChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
-  }
-
+    (data.kasittelynTila?.liikenteeseenluovutusOsittain ?? null) !== (defaults.kasittelynTila?.liikenteeseenluovutusOsittain ?? null);
   const liikenteeseenluovutusKokonaanChanged =
-    (data.kasittelynTila?.liikenteeseenluovutusKokonaan ?? null) !== defaults.kasittelynTila?.liikenteeseenluovutusKokonaan;
-  if (liikenteeseenluovutusKokonaanChanged) {
+    (data.kasittelynTila?.liikenteeseenluovutusKokonaan ?? null) !== (defaults.kasittelynTila?.liikenteeseenluovutusKokonaan ?? null);
+  const toteutusilmoitusOsittainChanged =
+    (data.kasittelynTila?.toteutusilmoitusOsittain ?? null) !== (defaults.kasittelynTila?.toteutusilmoitusOsittain ?? null);
+  const toteutusilmoitusKokonaanChanged =
+    (data.kasittelynTila?.toteutusilmoitusKokonaan ?? null) !== (defaults.kasittelynTila?.toteutusilmoitusKokonaan ?? null);
+
+  const kokoTaytetty = !!(data.kasittelynTila?.liikenteeseenluovutusKokonaan || data.kasittelynTila?.toteutusilmoitusKokonaan);
+  const osaChanged = liikenteeseenluovutusOsittainChanged || toteutusilmoitusOsittainChanged;
+  const kokoChanged = liikenteeseenluovutusKokonaanChanged || toteutusilmoitusKokonaanChanged;
+
+  if (kokoChanged) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
-  }
-
-  const toteutusilmoitusOsittainChanged =
-    (data.kasittelynTila?.toteutusilmoitusOsittain ?? null) !== defaults.kasittelynTila?.toteutusilmoitusOsittain;
-  if (toteutusilmoitusOsittainChanged) {
+  } else if (osaChanged && !kokoTaytetty) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
-  }
-
-  const toteutusilmoitusKokonaanChanged =
-    (data.kasittelynTila?.toteutusilmoitusKokonaan ?? null) !== defaults.kasittelynTila?.toteutusilmoitusKokonaan;
-  if (toteutusilmoitusKokonaanChanged) {
-    data.kasittelynTila ??= {};
-    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
   }
 
   const valitustenMaaraChanged = data.kasittelynTila?.valitustenMaara !== null && defaults.kasittelynTila?.valitustenMaara === null;
@@ -52,7 +47,8 @@ export const asetaKasittelynTilaAutomaatiolla = (data: KasittelynTilaFormValues,
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil08";
   }
 
-  const toimitusKaynnistynytChanged = (data.kasittelynTila?.toimitusKaynnistynyt ?? null) !== defaults.kasittelynTila?.toimitusKaynnistynyt;
+  const toimitusKaynnistynytChanged =
+    (data.kasittelynTila?.toimitusKaynnistynyt ?? null) !== (defaults.kasittelynTila?.toimitusKaynnistynyt ?? null);
   if (toimitusKaynnistynytChanged) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil14";

--- a/src/util/asetaKasittelynTilaAutomaatiolla.ts
+++ b/src/util/asetaKasittelynTilaAutomaatiolla.ts
@@ -1,0 +1,60 @@
+// Contains code generated or recommended by Amazon Q
+import { KasittelynTilaFormValues } from "@pages/yllapito/projekti/[oid]/kasittelyntila";
+
+export const asetaKasittelynTilaAutomaatiolla = (data: KasittelynTilaFormValues, defaults: KasittelynTilaFormValues) => {
+  const asianumeroChanged =
+    (data.kasittelynTila?.hyvaksymispaatos?.asianumero ?? null) !== defaults?.kasittelynTila?.hyvaksymispaatos?.asianumero;
+  const hyvaksymisPvmChanged =
+    (data.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm ?? null) !== defaults.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm;
+  if (asianumeroChanged && hyvaksymisPvmChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil04";
+  }
+
+  const lainvoimaAlkaenChanged = (data.kasittelynTila?.lainvoimaAlkaen ?? null) !== defaults.kasittelynTila?.lainvoimaAlkaen;
+  const lainvoimaPaatyenChanged = (data.kasittelynTila?.lainvoimaPaattyen ?? null) !== defaults.kasittelynTila?.lainvoimaPaattyen;
+  if (lainvoimaAlkaenChanged && lainvoimaPaatyenChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil05";
+  }
+
+  const liikenteeseenluovutusOsittainChanged =
+    (data.kasittelynTila?.liikenteeseenluovutusOsittain ?? null) !== defaults.kasittelynTila?.liikenteeseenluovutusOsittain;
+  if (liikenteeseenluovutusOsittainChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
+  }
+
+  const liikenteeseenluovutusKokonaanChanged =
+    (data.kasittelynTila?.liikenteeseenluovutusKokonaan ?? null) !== defaults.kasittelynTila?.liikenteeseenluovutusKokonaan;
+  if (liikenteeseenluovutusKokonaanChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
+  }
+
+  const toteutusilmoitusOsittainChanged =
+    (data.kasittelynTila?.toteutusilmoitusOsittain ?? null) !== defaults.kasittelynTila?.toteutusilmoitusOsittain;
+  if (toteutusilmoitusOsittainChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil06";
+  }
+
+  const toteutusilmoitusKokonaanChanged =
+    (data.kasittelynTila?.toteutusilmoitusKokonaan ?? null) !== defaults.kasittelynTila?.toteutusilmoitusKokonaan;
+  if (toteutusilmoitusKokonaanChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil07";
+  }
+
+  const valitustenMaaraChanged = data.kasittelynTila?.valitustenMaara !== null && defaults.kasittelynTila?.valitustenMaara === null;
+  if (valitustenMaaraChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil08";
+  }
+
+  const toimitusKaynnistynytChanged = (data.kasittelynTila?.toimitusKaynnistynyt ?? null) !== defaults.kasittelynTila?.toimitusKaynnistynyt;
+  if (toimitusKaynnistynytChanged) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil14";
+  }
+};


### PR DESCRIPTION

- Erotettu `asetaKasittelynTilaAutomaatiolla`-funktio omaan moduuliin (`src/util/`) testattavuuden parantamiseksi
- Lisätty toteutusilmoituksen osatoteutus- ja kokototeutuskenttien käsittely
- Korjattu prioriteettilogiikka perustumaan **nykyisiin arvoihin** tallennushetkellä:
  - Jos koko on täytetty → sutil07
  - Jos koko ei ole täytetty mutta osa on → sutil06
  - Jos kumpikaan ei ole täytetty → ei muuta tilaa
- Korjattu `undefined`/`null`-vertailu normalisoimalla molemmat puolet symmetrisesti (`?? null`)


## AI-Assisted: Amazon Q developer, generated
