### PR TITLE
fix: HASSUYP-489 Poista virheellinen validointi käsittelyn tila -sivun Ennakkotarkastus-kentästä

### DIFF
--- a/src/schemas/kasittelynTila.ts
+++ b/src/schemas/kasittelynTila.ts
@@ -103,21 +103,7 @@ export const kasittelynTilaSchema = Yup.object().shape({
         }
         return true;
       }),
-    ennakkotarkastus: paivamaara()
-      .notRequired()
-      .nullable()
-      .test((value, context) => {
-        if (value) {
-          if (!context.parent.hyvaksymisesitysTraficomiinPaiva) {
-            return context.createError({
-              message: "Hyväksymisesitys Traficomiin on annettava.",
-              path: `${context.path}`,
-              type: "custom",
-            });
-          }
-        }
-        return true;
-      }),
+    ennakkotarkastus: paivamaara().notRequired().nullable(),
     toimitusKaynnistynyt: paivamaara().notRequired().nullable(),
     liikenteeseenluovutusOsittain: paivamaara().notRequired().nullable(),
     liikenteeseenluovutusKokonaan: paivamaara().notRequired().nullable(),


### PR DESCRIPTION
## Muutokset
Ennakkotarkastus-kenttä ei enää vaadi Hyväksymisesitys Traficomiin -päivämäärää.

## AI-Assisted: Amazon Q developer, drafted
