### PR TITLE
fix: HASSUYP-487 Ilmoita kokorajoitus, jos käyttäjä yrittää ladata yli 25mt tiedostoa

### DIFF
--- a/common/fileValidationSettings.ts
+++ b/common/fileValidationSettings.ts
@@ -21,6 +21,6 @@ export const allowedFileTypesKansalaisille = [
 ];
 
 // 25MB
-export const maxFileSize = 25 * 1024 * 1024;
+export const maxFileSize = 25000000;
 
 export default { allowedFileTypesVirkamiehille, allowedFileTypesKansalaisille, maxFileSize };

--- a/src/components/form/FileInput.tsx
+++ b/src/components/form/FileInput.tsx
@@ -1,9 +1,11 @@
+// Contains code generated or recommended by Amazon Q
 import Button from "@components/button/Button";
 import React from "react";
 import { FieldError } from "react-hook-form";
 import FormGroup from "./FormGroup";
 import { DropzoneOptions, useDropzone } from "react-dropzone";
 import classNames from "classnames";
+import useSnackbars from "src/hooks/useSnackbars";
 
 type DropzoneProps = {
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
@@ -29,11 +31,27 @@ export const FileInput = ({
   noDropzone = false,
   ...otherDropzoneOptions
 }: DropzoneProps) => {
+  const { showErrorMessage } = useSnackbars();
+
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
     multiple,
     noClick,
     maxSize,
     accept,
+    onDropRejected: (fileRejections) => {
+      fileRejections.forEach((rejection) => {
+        rejection.errors.forEach((err) => {
+          if (err.code === "file-too-large") {
+            const maxSizeMB = Math.round(maxSize / 1000000);
+            showErrorMessage(`Tiedoston koko ylittää sallitun ${maxSizeMB} Mt rajan`);
+          } else if (err.code === "file-invalid-type") {
+            showErrorMessage("Tiedostotyyppi ei ole sallittu");
+          } else {
+            showErrorMessage(err.message);
+          }
+        });
+      });
+    },
     ...otherDropzoneOptions,
   });
 

--- a/src/hooks/useHandleUploadedFiles.ts
+++ b/src/hooks/useHandleUploadedFiles.ts
@@ -1,4 +1,4 @@
-import { allowedFileTypesVirkamiehille } from "common/fileValidationSettings";
+import { allowedFileTypesVirkamiehille, maxFileSize } from "common/fileValidationSettings";
 import { lataaTiedosto } from "../util/fileUtil";
 import { KunnallinenLadattuTiedostoInput, LadattuTiedostoInputNew } from "@services/api";
 import { uuid } from "common/util/uuid";
@@ -36,15 +36,19 @@ export default function useHandleUploadedFiles<F extends FieldValues>(
 
           if (files?.length) {
             const nonAllowedTypeFiles: File[] = [];
+            const tooLargeFiles: File[] = [];
             const allowedTypeFiles: File[] = [];
             const uploadedFileNamesPromises: Promise<string>[] = [];
 
             Array.from(Array(files.length).keys()).forEach((key: number) => {
-              if (allowedFileTypesVirkamiehille.find((type) => type === files[key].type)) {
-                uploadedFileNamesPromises.push(lataaTiedosto(api, files[key], true));
-                allowedTypeFiles.push(files[key]);
+              const file = files[key];
+              if (file.size > maxFileSize) {
+                tooLargeFiles.push(file);
+              } else if (allowedFileTypesVirkamiehille.find((type) => type === file.type)) {
+                uploadedFileNamesPromises.push(lataaTiedosto(api, file, true));
+                allowedTypeFiles.push(file);
               } else {
-                nonAllowedTypeFiles.push(files[key]);
+                nonAllowedTypeFiles.push(file);
               }
             });
 
@@ -74,6 +78,12 @@ export default function useHandleUploadedFiles<F extends FieldValues>(
               shouldDirty: true,
             });
 
+            if (tooLargeFiles.length) {
+              const maxSizeMB = Math.round(maxFileSize / 1000000);
+              showErrorMessage(
+                `Tiedosto on liian suuri: ${tooLargeFiles.map((f) => f.name).join(", ")}. Suurin sallittu koko on ${maxSizeMB} Mt.`
+              );
+            }
             if (nonAllowedTypeFiles.length) {
               const nonAllowedTypeFileNames = nonAllowedTypeFiles.map((f) => f.name);
               showErrorMessage("Väärä tiedostotyyppi: " + nonAllowedTypeFileNames + ". Sallitut tyypit JPG, PNG, PDF ja MS Word.");


### PR DESCRIPTION
## Muutokset
- Näytä kokorajoitus käyttäjälle, jos yrittää ladata liian isoa tiedostoa.
- Yhtenäistä käytetty tiedoston maksimikoko
 
## AI-Assisted: Amazon Q developer, generated
