### PR TITLE
fix: HASSUYP-835 Piilota kaikki esittelyaineistot kansalaispuolelta nähtävilläolokuulutuksen myötä

### DIFF
--- a/backend/src/projekti/adapter/adaptToAPI/julkinen/adaptVuorovaikutusKierroksetJulkinen.ts
+++ b/backend/src/projekti/adapter/adaptToAPI/julkinen/adaptVuorovaikutusKierroksetJulkinen.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import * as API from "hassu-common/graphql/apiModel";
 import {
   DBProjekti,
@@ -63,8 +64,8 @@ export function adaptVuorovaikutusKierroksetJulkinen(dbProjekti: DBProjekti): AP
       vuorovaikutusTilaisuudet: adaptVuorovaikutusTilaisuudet(julkaistutTilaisuudet),
       vuorovaikutusJulkaisuPaiva: viimeisinVuorovaikutusKierros.vuorovaikutusJulkaisuPaiva,
       kysymyksetJaPalautteetViimeistaan: viimeisinVuorovaikutusKierros.kysymyksetJaPalautteetViimeistaan,
-      videot: videotAdaptoituna,
-      suunnittelumateriaali: adaptLokalisoidutLinkitToAPI(viimeisinVuorovaikutusKierros.suunnittelumateriaali),
+      videot: isAineistoVisible ? videotAdaptoituna : undefined,
+      suunnittelumateriaali: isAineistoVisible ? adaptLokalisoidutLinkitToAPI(viimeisinVuorovaikutusKierros.suunnittelumateriaali) : undefined,
       esittelyaineistot: isAineistoVisible
         ? adaptAineistotJulkinen(esittelyaineistot, vuorovaikutusPaths.aineisto, julkaisuPaiva)
         : undefined,


### PR DESCRIPTION
## Muutokset
Aiemmin vain esittelyaineistot ja suunnitelmaluonnokset piilotettiin kansalaispuolelta nähtävilläolokuulutuksen myötä, mutta myös videot ja muu suunnittelumateriaalit pitää piilottaa samalla

## AI-Assisted: Amazon Q developer, generated
