### PR TITLE
feat: HASSUYP-891

### DIFF
--- a/src/components/projekti/KuulutuksenHyvaksyminenDialog.tsx
+++ b/src/components/projekti/KuulutuksenHyvaksyminenDialog.tsx
@@ -115,8 +115,8 @@ export default function KuulutuksenHyvaksyminenDialog({
               ilmoituksien lähettämisen. Ilmoitukset lähetetään automaattisesti painikkeen klikkaamisen jälkeen.
             </p>
             <p>
-              Suunnitelman nähtäville asettamisen sekä hyväksymispäätöksen kuuluttamisen yhteydessä järjestelmä lähettää ilmoituksen osalle
-              asianosaisista Tiedottaminen -sivun mukaan. Viestit lähetetään vastaanottajille kuulutuksen julkaisupäivänä.
+              Aloituskuulutuksen, suunnitelman nähtäville asettamisen sekä hyväksymispäätöksen kuuluttamisen yhteydessä järjestelmä lähettää
+              ilmoituksen asianosaisille Tiedottaminen -sivun mukaan. Viestit lähetetään vastaanottajille kuulutuksen julkaisupäivänä.
             </p>
             <p>
               {projekti.asianhallinta.inaktiivinen

--- a/src/components/projekti/common/IlmoituksenVastaanottajatLukutila.tsx
+++ b/src/components/projekti/common/IlmoituksenVastaanottajatLukutila.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import React, { ReactElement } from "react";
 import { KuulutusJulkaisuTila, IlmoituksenVastaanottajat as IlmoituksenVastaanottajatType, Status, UudelleenKuulutus } from "@services/api";
 import Section from "@components/layout/Section";
@@ -96,15 +97,7 @@ export default function IlmoituksenVastaanottajat({
     <Section>
       <SectionContent>
         <H2>Ilmoituksen vastaanottajat</H2>
-        {!epaaktiivinen && (
-          <>
-            {julkaisunTila === KuulutusJulkaisuTila.HYVAKSYTTY ? (
-              <HyvaksyttyInfoText paatosTyyppi={paatosTyyppi} />
-            ) : (
-              <InfoText paatosTyyppi={paatosTyyppi} />
-            )}
-          </>
-        )}
+        {!epaaktiivinen && julkaisunTila === KuulutusJulkaisuTila.HYVAKSYTTY && <HyvaksyttyInfoText paatosTyyppi={paatosTyyppi} />}
       </SectionContent>
       <IlmoituksenVastaanottajatCommon ilmoituksenVastaanottajat={ilmoituksenVastaanottajat} />
       {vaihe && (


### PR DESCRIPTION
- Korjattu Kuulutuksen hyväksymisdialogia sisältämään aloituskuulutus
- Ei näytetä infotekstiä nähtävilläolo ja päätösvaiheessa, jos ollaan lukutilassa (aloituskuulutus toimii jo näin)


## AI-Assisted: Amazon Q developer,  generated
