### PR TITLE
fix. HASSUYP-778 - Korjaa UI:n jäätyminen Loading Spinnerin Backdropin jäädessä DOM:iin

### DIFF
--- a/src/components/layout/LoadingSpinnerProvider.tsx
+++ b/src/components/layout/LoadingSpinnerProvider.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import React, { ReactElement, createContext, ReactNode, useCallback, useMemo, useState } from "react";
 import { Backdrop, CircularProgress } from "@mui/material";
 
@@ -47,9 +48,18 @@ interface SpinnerProps {
   open: boolean;
 }
 
+// Workaround for MUI issue https://github.com/mui/material-ui/issues/32286
+// MUI Backdrop uses react-transition-group Fade transition which can get stuck
+// in "exiting" state during page navigation, leaving an invisible element
+// (opacity: 0, pointer-events: auto) that blocks all user interaction.
+// Conditional rendering ensures Backdrop is removed from DOM immediately
+// when not needed, eliminating the stuck transition issue entirely.
 const HassuSpinner = (props: SpinnerProps): ReactElement => {
+  if (!props.open) {
+    return <></>;
+  }
   return (
-    <Backdrop sx={{ color: "#49C2F1", zIndex: (theme) => theme.zIndex.modal + 1 }} open={props.open}>
+    <Backdrop sx={{ color: "#49C2F1", zIndex: (theme) => theme.zIndex.modal + 1 }} open>
       <CircularProgress color="inherit" />
     </Backdrop>
   );


### PR DESCRIPTION
## Kuvaus

Korjaa satunnaisen UI:n "jäätymisen" jossa käyttöliittymä lakkaa reagoimasta klikkauksiin. Ongelma on saatu toistettuanavigoitaessa "Kutsu vuorovaikutukseen" -välilehdelle "Tallenna ja siirry" -painikkeella suunnitteluvaiheen perustiedoista.

## Juurisyy

MUI:n `Backdrop`-komponentti käyttää `react-transition-group`-kirjaston `Fade`-transitiota. Kun Loading Spinnerin `open`-prop vaihtuu `false`:ksi samanaikaisesti sivunavigaation (`router.push`) kanssa, `react-transition-group`:n transitio ei ehdi suoriutua loppuun (`exiting` → `exited`). Tämän seurauksena:

1. Backdrop jää DOM:iin tilaan: `opacity: 0`, `visibility: visible`, `pointer-events: auto`, `position: fixed` (koko ruudun kokoinen)
2. Näkymätön elementti estää kaikki klikkaukset alla oleviin elementteihin
3. Käyttäjälle sivu näyttää normaalilta mutta mikään ei reagoi

## Todentaminen

Jäätyneellä sivulla selaimen konsolissa:
```javascript
document.querySelectorAll('.MuiBackdrop-root')
// → NodeList [div.MuiBackdrop-root.css-cxttz2]

performance.getEntriesByType('resource').filter(r => r.name.includes('graphql') && r.duration === 0)
// → [] (ei pending-pyyntöjä, HTTP-tasolla kaikki valmistuneet)

document.querySelectorAll('.MuiBackdrop-root')[0]?.getAttribute('aria-hidden')
// → "true" (MUI:n Backdrop open={false} tilassa)

document.querySelectorAll('.MuiBackdrop-root')[0]?.className
// → "MuiBackdrop-root css-cxttz2"

getComputedStyle(document.querySelector('.MuiBackdrop-root')).visibility
// → "visible"

getComputedStyle(document.querySelector('.MuiBackdrop-root')).opacity
// → "0"

getComputedStyle(document.querySelector('.MuiBackdrop-root')).pointerEvents
// → "auto"

// Vapauttaa sivun:
document.querySelectorAll('.MuiBackdrop-root').forEach(el => el.remove())
```

## Korjaus
Ehdollinen renderöinti HassuSpinner-komponentissa: kun spinner ei ole aktiivinen (open={false}), Backdrop-komponenttia ei renderöidä lainkaan. Tämä eliminoi ongelman kokonaan koska elementti ei voi jäädä jumiin DOM:iin kun sitä ei ole siellä.

Menetetään fade-out -animaatio (~225ms) jonka aikana spinner häipyi näkyvistä. Käytännössä tämä on huomaamaton muutos.

## Vaihtoehtoinen korjaus
MUI issue -keskustelussa yleisesti käytetty workaround on teema-tason MuiBackdrop styleOverride:

```typescript
MuiBackdrop: {
  styleOverrides: {
    root: {
      '&[style*="opacity: 0;"], &[style$="opacity: 0"]': {
        pointerEvents: "none",
      },
    },
  },
},
```

Tämä korjaisi ongelman kaikissa MUI:n Backdrop-käyttöpaikoissa kerralla (Dialog, Drawer, Menu, Spinner). Teema-tason muutosta ei kuitenkaan valittu tässä kohtaa, koska:

Vaikuttaa kaikkiin Backdrop-komponentteihin sovelluksessa (~35 Dialog-käyttöpaikkaa, hamburger-menu jne.)

Muuttaa fade-out -animaation aikaista käyttäytymistä kaikissa näissä

Ongelmaa ei ole raportoitu muissa kuin Loading Spinner -kontekstissa

Jos sama ongelma havaitaan myöhemmin muissa komponenteissa (Dialog, Menu), teema-tason korjaus voidaan ottaa käyttöön.

## Refs
MUI issue: [#32286 - Backdrop stuck open at 0% opacity and blocks all clicks on the page due to react-transition-group bug](https://github.com/mui/material-ui/issues/32286) (avattu 2022, edelleen avoin)

react-transition-group issue: [#817 - Bug - animations get stuck in exiting, "exited" never fires](https://github.com/reactjs/react-transition-group/issues/817) (avattu 2022, edelleen avoin)

react-transition-group repo on ollut käytännössä ylläpitämätön 3 vuotta (viimeisin release 4.4.5, elokuu 2022)

Ongelma ei ole korjattu missään MUI-versiossa (tarkistettu v5.10.17 – v5.18.0 ja v6.0.0 – v6.5.0)


## AI-Assisted: Amazon Q developer,  generated
