### PR TITLE
fix: HASSUYP-624 - Estä duplikaatti-UUID lausuntopyyntöjen tallennuksessa

### DIFF
--- a/backend/src/projekti/adapter/adaptToDB/adaptLausuntoPyynnotToSave.ts
+++ b/backend/src/projekti/adapter/adaptToDB/adaptLausuntoPyynnotToSave.ts
@@ -1,9 +1,21 @@
+// Contains code generated or recommended by Amazon Q
 import * as API from "hassu-common/graphql/apiModel";
 import { LausuntoPyynnonTaydennys, LausuntoPyynto } from "../../../database/model";
 import { ProjektiAdaptationResult } from "../projektiAdaptationResult";
 import mergeWith from "lodash/mergeWith";
 import { LausuntoPyynnotDB, adaptTiedostotToSave } from "./common";
 import { log } from "../../../logger";
+import { IllegalArgumentError } from "hassu-common/error";
+
+function assertNoDuplicateUuids<T extends { uuid: string }>(items: T[]): void {
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (seen.has(item.uuid)) {
+      throw new IllegalArgumentError(`Duplikaatti uuid lausuntopyynnöissä: ${item.uuid}`);
+    }
+    seen.add(item.uuid);
+  }
+}
 
 export function adaptLausuntoPyynnotToSave(
   dbLausuntoPyynnot: LausuntoPyynto[] | undefined | null,
@@ -13,6 +25,7 @@ export function adaptLausuntoPyynnotToSave(
   if (!lausuntoPyyntoInput) {
     return undefined;
   }
+  assertNoDuplicateUuids(lausuntoPyyntoInput);
   return lausuntoPyyntoInput
     .map(
       (lausuntoPyynto) =>
@@ -33,6 +46,7 @@ export function adaptLausuntoPyynnonTaydennyksetToSave(
   if (!lausuntoPyynnonTaydennysInput) {
     return undefined;
   }
+  assertNoDuplicateUuids(lausuntoPyynnonTaydennysInput);
   return lausuntoPyynnonTaydennysInput.map(
     (lausuntoPyynto) =>
       adaptLausuntoPyynnonTaydennysToSave(

--- a/backend/test/projekti/adapter/adaptToDB/adaptLausuntoPyynnotToSave.test.ts
+++ b/backend/test/projekti/adapter/adaptToDB/adaptLausuntoPyynnotToSave.test.ts
@@ -60,3 +60,36 @@ describe("adaptLausuntoPyynnotToSave", () => {
     expect(projektiAdaptationResult["events"].some((event) => event.eventType === ProjektiEventType.ZIP_LAUSUNTOPYYNNOT)).to.be.true;
   });
 });
+
+// Contains code generated or recommended by Amazon Q
+describe("adaptLausuntoPyynnotToSave - duplikaatti uuid", () => {
+  it("should throw IllegalArgumentError if input contains duplicate uuids", () => {
+    const dummyProjekti: DBProjekti = {
+      oid: "123",
+      versio: 0,
+      kayttoOikeudet: [],
+    };
+    const projektiAdaptationResult = new ProjektiAdaptationResult(dummyProjekti);
+    const input: LausuntoPyyntoInput[] = [
+      { poistumisPaiva: "2025-01-01", uuid: "sama-uuid", lisaAineistot: [], muistiinpano: "" },
+      { poistumisPaiva: "2025-01-01", uuid: "sama-uuid", lisaAineistot: [], muistiinpano: "", poistetaan: true },
+    ];
+    expect(() => adaptLausuntoPyynnotToSave(undefined, input, projektiAdaptationResult)).to.throw(
+      "Duplikaatti uuid lausuntopyynnöissä: sama-uuid"
+    );
+  });
+
+  it("should not throw if all uuids are unique", () => {
+    const dummyProjekti: DBProjekti = {
+      oid: "123",
+      versio: 0,
+      kayttoOikeudet: [],
+    };
+    const projektiAdaptationResult = new ProjektiAdaptationResult(dummyProjekti);
+    const input: LausuntoPyyntoInput[] = [
+      { poistumisPaiva: "2025-01-01", uuid: "uuid-1", lisaAineistot: [], muistiinpano: "" },
+      { poistumisPaiva: "2025-01-01", uuid: "uuid-2", lisaAineistot: [], muistiinpano: "" },
+    ];
+    expect(() => adaptLausuntoPyynnotToSave(undefined, input, projektiAdaptationResult)).to.not.throw();
+  });
+});

--- a/scripts/findDuplicateLausuntoPyyntoUuids/findDuplicateLausuntoPyyntoUuids.ts
+++ b/scripts/findDuplicateLausuntoPyyntoUuids/findDuplicateLausuntoPyyntoUuids.ts
@@ -1,0 +1,110 @@
+// Contains code generated or recommended by Amazon Q
+/**
+ * Skripti etsii projektit joissa lausuntoPyynnot- tai lausuntoPyynnonTaydennykset-taulukossa
+ * on duplikaatti-uuid:ita.
+ *
+ * Käyttö:
+ *   npx ts-node --project scripts/tsconfig.json scripts/findDuplicateLausuntoPyyntoUuids/findDuplicateLausuntoPyyntoUuids.ts
+ *
+ * Vaatii:
+ *   - AWS_PROFILE: AWS-profiili jolla on oikeudet lukea DynamoDB-taulua
+ *   - ENVIRONMENT: ympäristön nimi (dev, test, prod jne.)
+ */
+import { ScanCommand, ScanCommandOutput } from "@aws-sdk/lib-dynamodb";
+import { getDynamoDBDocumentClient } from "../../backend/src/aws/client";
+
+if (!process.env.ENVIRONMENT) {
+  throw new Error("Aseta ENVIRONMENT ympäristömuuttuja!");
+}
+
+const tableName = "Projekti-" + process.env.ENVIRONMENT;
+
+interface LausuntoPyynto {
+  uuid: string;
+  poistumisPaiva?: string;
+  poistetaan?: boolean;
+}
+
+interface Projekti {
+  oid: string;
+  lausuntoPyynnot?: LausuntoPyynto[];
+  lausuntoPyynnonTaydennykset?: LausuntoPyynto[];
+}
+
+function findDuplicateUuids(items: LausuntoPyynto[] | undefined): string[] {
+  if (!items || items.length < 2) return [];
+  const seen = new Map<string, number>();
+  for (const item of items) {
+    seen.set(item.uuid, (seen.get(item.uuid) ?? 0) + 1);
+  }
+  return Array.from(seen.entries())
+    .filter(([, count]) => count > 1)
+    .map(([uuid]) => uuid);
+}
+
+async function main() {
+  const client = getDynamoDBDocumentClient();
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+  let scannedCount = 0;
+  const results: { oid: string; field: string; duplicateUuids: string[]; items: LausuntoPyynto[] }[] = [];
+
+  console.log(`Skannataan taulua: ${tableName}`);
+
+  do {
+    const response: ScanCommandOutput = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ProjectionExpression: "oid, lausuntoPyynnot, lausuntoPyynnonTaydennykset",
+        ExclusiveStartKey: lastEvaluatedKey,
+      })
+    );
+
+    for (const item of (response.Items ?? []) as Projekti[]) {
+      const lpDuplicates = findDuplicateUuids(item.lausuntoPyynnot);
+      if (lpDuplicates.length > 0) {
+        results.push({
+          oid: item.oid,
+          field: "lausuntoPyynnot",
+          duplicateUuids: lpDuplicates,
+          items: item.lausuntoPyynnot!,
+        });
+      }
+
+      const lptDuplicates = findDuplicateUuids(item.lausuntoPyynnonTaydennykset);
+      if (lptDuplicates.length > 0) {
+        results.push({
+          oid: item.oid,
+          field: "lausuntoPyynnonTaydennykset",
+          duplicateUuids: lptDuplicates,
+          items: item.lausuntoPyynnonTaydennykset!,
+        });
+      }
+    }
+
+    scannedCount += response.Items?.length ?? 0;
+    lastEvaluatedKey = response.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  console.log(`\nSkannattu ${scannedCount} projektia.`);
+
+  if (results.length === 0) {
+    console.log("Duplikaatti-uuid:ita ei löytynyt.");
+  } else {
+    console.log(`\nLöytyi ${results.length} tapausta:\n`);
+    for (const result of results) {
+      console.log(`OID: ${result.oid}`);
+      console.log(`  Kenttä: ${result.field}`);
+      console.log(`  Duplikaatti uuid:t: ${result.duplicateUuids.join(", ")}`);
+      console.log(`  Kaikki rivit:`);
+      for (const item of result.items) {
+        console.log(`    - uuid: ${item.uuid}, poistumisPaiva: ${item.poistumisPaiva}, poistetaan: ${item.poistetaan ?? false}`);
+      }
+      console.log();
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error("Virhe:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Kuvaus

Lausuntopyyntöjen tallennuksessa ei ole ollut uuid-uniikkiusvalidaatiota. Frontend lähettää tallennuksessa `lausuntoPyynnot.concat(poistetutLausuntoPyynnot)`, ja race condition -tilanteessa sama uuid on voinut päätyä listaan kahdesti. Backend tallensi molemmat kantaan, mikä aiheutti identtiset aineistolinkit (koska hash lasketaan uuid:sta).

### Potentiaaliset syyt duplikaattien syntymiselle (ei ole saatu toistettua)

- **`useFieldArray`/`reset` race condition**: Tallennuksen jälkeen `reloadProjekti()` triggeröi `reset(defaultValues)`:n. Jos ajoitus osuu `appendToPoistetut`/`remove`-operaatioiden kanssa päällekkäin, sama lausuntopyyntö voi päätyä sekä aktiivisten että poistettujen listaan.
- **SQS-jonon hitaus**: Kun käyttäjä poistaa lausuntopyynnön ja tallentaa, backend merkitsee sen `poistetaan: true`. Jos SQS-käsittelijä ei ehdi siivota riviä ennen seuraavaa tallennusta, frontend lähettää saman uuid:n uudelleen poistettujen listassa.
- **Ei duplikaattisuojausta backendissä**: `adaptLausuntoPyynnotToSave` kävi jokaisen input-rivin läpi ja loi niistä DB-rivin ilman uuid-uniikkiustarkistusta.

## Muutokset

- Lisätty `assertNoDuplicateUuids`-validaatio `adaptLausuntoPyynnotToSave`- ja `adaptLausuntoPyynnonTaydennyksetToSave`-funktioihin
- Lisätty `scripts/findDuplicateLausuntoPyyntoUuids`-skripti kannan skannaamiseen

## Ennen vientiä eteenpäin

### 1. Skannaa tuotantokanta (ja myös muut ympäristöt)

```bash
AWS_PROFILE=<profile> ENVIRONMENT=<env> npx ts-node --project scripts/tsconfig.json scripts/findDuplicateLausuntoPyyntoUuids/findDuplicateLausuntoPyyntoUuids.ts
```

### 2. Poista duplikaattirivit kannasta
Tuotannosta löytyi 3 projektia joissa on duplikaatti-uuid lausuntopyynnöissä. Jokaisesta poistetaan toinen rivi (pidetään se jolla on uudempi/sama poistumisPaiva).

Poisto on turvallista koska:

Kaikkien duplikaattien poistumisPaiva on menneisyydessä → linkit näyttävät jo "vanhentunut"-viestin

Duplikaateilla on sama uuid → sama hash → sama linkki → toinen rivi on redundantti

S3-tiedostot (lisäaineistot, zip) ovat samassa polussa (/lausuntopyynto/<uuid>/) → toisen rivin poisto ei vaikuta tiedostoihin



## AI-Assisted: Amazon Q developer, generated
