### PR TITLE
fix: HASSUYP-812 - Sähköpostijakelussa virheellinen varahenkilö

### DIFF
--- a/backend/integrationtest/HyvaksymisEsitys/hyvaksy.test.ts
+++ b/backend/integrationtest/HyvaksymisEsitys/hyvaksy.test.ts
@@ -38,7 +38,7 @@ const getProjektiBase: () => DeepReadonly<DBProjekti> = () => ({
       etunimi: "Etunimi",
       sukunimi: "Sukunimi",
       email: "email@email.com",
-      kayttajatunnus: "theadminuid",
+      kayttajatunnus: "A123",
       tyyppi: API.KayttajaTyyppi.PROJEKTIPAALLIKKO,
       elyOrganisaatio: API.ELY.HAME_ELY,
       puhelinnumero: "0291234567",
@@ -48,7 +48,7 @@ const getProjektiBase: () => DeepReadonly<DBProjekti> = () => ({
       etunimi: "Etunimi2",
       sukunimi: "Sukunimi2",
       email: "email2@email.com",
-      kayttajatunnus: "thevarahenkilouid",
+      kayttajatunnus: "L222",
       tyyppi: API.KayttajaTyyppi.VARAHENKILO,
       puhelinnumero: "0291213",
       organisaatio: "org2",
@@ -164,7 +164,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
 
   it("päivittää muokattavan hyväksymisesityksen tilan ja palautusSyyn ja s.postin lähetystiedot ja lisää ashasynkronoinnin", async () => {
     MockDate.set("2000-01-01");
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -188,7 +188,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
       julkaistuHyvaksymisEsitys: {
         asianhallintaEventId: "uuid123",
         ...omit(muokattavaHyvaksymisEsitys, ["tila", "palautusSyy"]),
-        hyvaksyja: "theadminuid",
+        hyvaksyja: "A123",
         vastaanottajat: [
           {
             lahetetty: "2000-01-01T02:00:00+02:00",
@@ -224,7 +224,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
 
   it("ei onnistu, jos asha on väärässä tilassa", async () => {
     MockDate.set("2000-01-01");
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -244,7 +244,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("ei onnistu, jos projektin status on liian pieni", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -273,7 +273,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
       },
       response: "response",
     });
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -297,7 +297,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   it("merkitsee sähköpostin lähetystietoihin lähetysvirheen, jos sähköpostin lähettäminen epäonnistuu", async () => {
     MockDate.set("2000-01-01");
     emailStubTurvaposti?.onFirstCall().resolves(undefined);
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -321,7 +321,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   it("merkitsee sähköpostin lähetystietoihin lähetysvirheen, jos sähköpostin lähettäminen epäonnistuu", async () => {
     MockDate.set("2000-01-01");
     emailStubTurvaposti?.onFirstCall().resolves(undefined);
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -355,7 +355,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
       },
       response: "response",
     });
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       vastaanottajat: [
@@ -390,7 +390,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("lähettää oikeat s.postit kun tarvitaan kiireellistä käsittelyä ja asianhallinta ei ole aktiivinen", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -435,7 +435,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("lähettää oikeat s.postit kun EI tarvita kiireellistä käsittelyä ja asianhallinta on aktiivinen", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -481,7 +481,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("näyttää oikeat tiedot s.postissa, kun vastaava viranomainen on ELY-keskus ja projarin organisaatio on ELY", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = { ...TEST_HYVAKSYMISESITYS, tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA, palautusSyy: "Virheitä" };
     const versio = 2;
     const projektiBefore = {
@@ -493,7 +493,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
           etunimi: "Etunimi",
           sukunimi: "Sukunimi",
           email: "email@email.com",
-          kayttajatunnus: "theadminuid",
+          kayttajatunnus: "A123",
           tyyppi: API.KayttajaTyyppi.PROJEKTIPAALLIKKO,
           elyOrganisaatio: API.ELY.HAME_ELY,
           puhelinnumero: "0291234567",
@@ -502,7 +502,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
           etunimi: "Etunimi2",
           sukunimi: "Sukunimi2",
           email: "email2@email.com",
-          kayttajatunnus: "thevarahenkilouid",
+          kayttajatunnus: "L222",
           tyyppi: API.KayttajaTyyppi.VARAHENKILO,
           puhelinnumero: "0291234567",
         },
@@ -545,7 +545,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("näyttää oikeat tiedot s.postissa, kun vastaava viranomainen on Väylävirasto ja projarin organisaatio on Väylävirasto ja asianhallinta on aktiivinen", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -560,7 +560,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
           etunimi: "Etunimi",
           sukunimi: "Sukunimi",
           email: "email@email.com",
-          kayttajatunnus: "theadminuid",
+          kayttajatunnus: "A123",
           tyyppi: API.KayttajaTyyppi.PROJEKTIPAALLIKKO,
           organisaatio: "Väylävirasto",
           puhelinnumero: "0291234567",
@@ -569,7 +569,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
           etunimi: "Etunimi2",
           sukunimi: "Sukunimi2",
           email: "email2@email.com",
-          kayttajatunnus: "thevarahenkilouid",
+          kayttajatunnus: "L222",
           tyyppi: API.KayttajaTyyppi.VARAHENKILO,
           puhelinnumero: "0291234567",
           organisaatio: "Väylävirasto",
@@ -623,7 +623,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("sähköpostissa ei lue 'liitteenä hyväksymisesitys', jos hyväksymisesityksellä ei ole hyväksymisesitystiedostoa", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
 
@@ -694,7 +694,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
 
   it("luo julkaistun hyväksymisesityksen muokattavan perusteella", async () => {
     MockDate.set("2000-01-01");
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -711,7 +711,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
     expect(omit(projektiAfter?.julkaistuHyvaksymisEsitys, "hyvaksymisPaiva")).to.eql({
       asianhallintaEventId: "uuid123",
       ...omit(muokattavaHyvaksymisEsitys, ["tila", "palautusSyy"]),
-      hyvaksyja: "theadminuid",
+      hyvaksyja: "A123",
       vastaanottajat: [
         {
           lahetetty: "2000-01-01T02:00:00+02:00",
@@ -726,7 +726,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
 
   it("tallentaa lähetetyn s.postin s3:een", async () => {
     MockDate.set("2000-01-01");
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -734,7 +734,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
     };
     const julkaistuHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS2,
-      hyvaksyja: "theadminuid",
+      hyvaksyja: "A123",
       hyvaksymisPaiva: "2022-01-01",
       poistumisPaiva: "2033-01-01",
     };
@@ -762,7 +762,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
 
   it("poistaa vanhat julkaistut tiedostot ja kopioi muokkaustilaisen hyväksymisesityksen tiedostot julkaisulle", async () => {
     MockDate.set("2000-01-01");
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -770,7 +770,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
     };
     const julkaistuHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS2,
-      hyvaksyja: "theadminuid",
+      hyvaksyja: "A123",
       hyvaksymisPaiva: "2022-01-01",
       poistumisPaiva: "2033-01-01",
     };
@@ -813,7 +813,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
 
   it("kopioi muokkaustilaisen hyväksymisesityksen tiedostot julkaisulle, kun julkaistaan ekaa kertaa", async () => {
     MockDate.set("2000-01-01");
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,
@@ -885,7 +885,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("ei onnistu, jos muokattava hyväksymisesitys on hyväksytty-tilassa", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.HYVAKSYTTY,
@@ -904,7 +904,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("ei onnistu, jos muokattava hyväksymisesitys on muokkaustilassa", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.MUOKKAUS,
@@ -923,7 +923,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
   });
 
   it("ei onnistu, jos muokattavaa hyväksymisesitystä ei ole", async () => {
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const projektiBefore = getProjektiBase();
     const versio = projektiBefore.versio;
     await insertProjektiToDB(projektiBefore);
@@ -936,7 +936,7 @@ describe("Hyväksymisesityksen hyväksyminen", () => {
 
   it("ei onnistu jos poistumisPaiva on menneisyydessa", async () => {
     MockDate.set("2023-01-02");
-    userFixture.loginAsAdmin();
+    userFixture.loginAs(UserFixture.pekkaProjari);
     const muokattavaHyvaksymisEsitys = {
       ...TEST_HYVAKSYMISESITYS,
       tila: API.HyvaksymisTila.ODOTTAA_HYVAKSYNTAA,

--- a/backend/integrationtest/HyvaksymisEsitys/tallennaJaLahetaHyvaksyttavaksi.test.ts
+++ b/backend/integrationtest/HyvaksymisEsitys/tallennaJaLahetaHyvaksyttavaksi.test.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import sinon from "sinon";
 import { userService } from "../../src/user";
 import TEST_HYVAKSYMISESITYS, { TEST_HYVAKSYMISESITYS2, TEST_HYVAKSYMISESITYS_FILES } from "./TEST_HYVAKSYMISESITYS";
@@ -156,7 +157,7 @@ describe("Hyväksymisesityksen tallentaminen ja hyväksyttäväksi lähettämine
           etunimi: "Etunimi",
           sukunimi: "Sukunimi",
           email: "email@email.com",
-          kayttajatunnus: "theadminuid",
+          kayttajatunnus: "A111",
           tyyppi: API.KayttajaTyyppi.PROJEKTIPAALLIKKO,
           organisaatio: "Väylävirasto",
           puhelinnumero: "0291221",
@@ -165,7 +166,7 @@ describe("Hyväksymisesityksen tallentaminen ja hyväksyttäväksi lähettämine
           etunimi: "Etunimi2",
           sukunimi: "Sukunimi2",
           email: "email2@email.com",
-          kayttajatunnus: "theotheruid",
+          kayttajatunnus: "L222",
           tyyppi: API.KayttajaTyyppi.VARAHENKILO,
           organisaatio: "Väylävirasto",
           puhelinnumero: "0291221",

--- a/backend/src/email/emailTemplates.ts
+++ b/backend/src/email/emailTemplates.ts
@@ -28,6 +28,7 @@ import * as API from "hassu-common/graphql/apiModel";
 import { vastaavanViranomaisenYTunnus } from "../util/vastaavaViranomainen/yTunnus";
 import { getLinkkiAsianhallintaan } from "../asianhallinta/getLinkkiAsianhallintaan";
 import { createEnnakkoNeuvotteluHash, createHyvaksymisEsitysHash } from "../HyvaksymisEsitys/latauslinkit/hash";
+import { isAorLTunnus } from "hassu-common/util/isAorLTunnus";
 
 export function template(strs: TemplateStringsArray, ...exprs: string[]) {
   return function (obj: unknown): string {
@@ -137,6 +138,7 @@ Kehitysehdotus: ${"kehitysehdotus"}
 export function projektiPaallikkoJaVarahenkilotEmails(kayttoOikeudet: DBVaylaUser[]): string[] {
   return kayttoOikeudet
     .filter((user) => user.tyyppi == KayttajaTyyppi.PROJEKTIPAALLIKKO || user.tyyppi == KayttajaTyyppi.VARAHENKILO)
+    .filter((user) => isAorLTunnus(user.kayttajatunnus))
     .map((user) => user.email);
 }
 

--- a/backend/src/projekti/kayttoOikeudetManager.ts
+++ b/backend/src/projekti/kayttoOikeudetManager.ts
@@ -87,6 +87,15 @@ export class KayttoOikeudetManager {
     }
     // Update rest of fields
     const user: DBVaylaUser = merge({}, currentUser, inputUser);
+    // Varahenkilöksi voi asettaa vain A- tai L-tunnuksisen käyttäjän.
+    // UI piilottaa varahenkilö-checkboxin ei-A/L-tunnuksilta (shouldUnregister), jolloin inputUser
+    // ei sisällä tyyppi-kenttää lainkaan. merge() säilyttää tällöin currentUser.tyyppi:n,
+    // joten virheellinen VARAHENKILO voi jäädä roikkumaan kannassa.
+    // null käytetään undefined:n sijaan koska DynamoDBDocumentClient on konfiguroitu removeUndefinedValues: true,
+    // jolloin undefined poistuisi kokonaan eikä ylikirjoittaisi vanhaa arvoa kantaan tallennettaessa.
+    if (user.tyyppi === KayttajaTyyppi.VARAHENKILO && !isAorLTunnus(user.kayttajatunnus)) {
+      user.tyyppi = null;
+    }
     return user;
   }
 

--- a/backend/test/email/emailTemplate.test.ts
+++ b/backend/test/email/emailTemplate.test.ts
@@ -1,7 +1,8 @@
 import { describe, it } from "mocha";
 import { KayttajaTyyppi, SuunnittelustaVastaavaViranomainen } from "hassu-common/graphql/apiModel";
 import { config } from "../../src/config";
-import { createPerustamisEmail } from "../../src/email/emailTemplates";
+import { createPerustamisEmail, projektiPaallikkoJaVarahenkilotEmails } from "../../src/email/emailTemplates";
+import { DBVaylaUser } from "../../src/database/model";
 
 import { expect } from "chai";
 
@@ -21,7 +22,7 @@ describe("EmailTemplating", () => {
       },
       kayttoOikeudet: [
         {
-          kayttajatunnus: "ABC123",
+          kayttajatunnus: "A123",
           etunimi: "Veikko",
           sukunimi: "Väyläläinen",
           organisaatio: "Väylä",
@@ -40,5 +41,37 @@ describe("EmailTemplating", () => {
         "/yllapito/projekti/1.2.246.578.5.1.165\n\n" +
         "Sait tämän viestin, koska sinut on merkitty projektin projektipäälliköksi. Tämä on automaattinen sähköposti, johon ei voi vastata."
     );
+  });
+
+  it("should not send email to varahenkilo with non-A/L-tunnus (e.g. LX-tunnus)", () => {
+    const kayttoOikeudet: DBVaylaUser[] = [
+      {
+        kayttajatunnus: "A123",
+        tyyppi: KayttajaTyyppi.PROJEKTIPAALLIKKO,
+        email: "pp@vayla.fi",
+        organisaatio: "Väylävirasto",
+        etunimi: "Pekka",
+        sukunimi: "Päällikkö",
+      },
+      {
+        kayttajatunnus: "LX456",
+        tyyppi: KayttajaTyyppi.VARAHENKILO,
+        email: "konsultti@konsultti.fi",
+        organisaatio: "Konsulttitoimisto",
+        etunimi: "Kalle",
+        sukunimi: "Konsultti",
+      },
+      {
+        kayttajatunnus: "L789",
+        tyyppi: KayttajaTyyppi.VARAHENKILO,
+        email: "varahenkilo@vayla.fi",
+        organisaatio: "Väylävirasto",
+        etunimi: "Ville",
+        sukunimi: "Varahenkilö",
+      },
+    ];
+    const emails = projektiPaallikkoJaVarahenkilotEmails(kayttoOikeudet);
+    expect(emails).to.eql(["pp@vayla.fi", "varahenkilo@vayla.fi"]);
+    expect(emails).to.not.include("konsultti@konsultti.fi");
   });
 });

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,11 +6,12 @@ Apuskriptejä debuggaukseen, selvityksiin, ylläpitoon ja muihin ad-hoc-tehtävi
 
 ## Saatavilla olevat skriptit
 
-| Skripti                     | Kuvaus                                                                                 | Käyttö                                                                                                             |
-| --------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `recreateMuistutusEmail.ts` | Luo ja tulostaa muistutussähköpostit (kirjaamo + valinnaisesti kuittaus kansalaiselle) | `npx ts-node --project scripts/tsconfig.json scripts/recreateMuistutusEmail.ts <oid> <muistuttajaId> [--kuittaus]` |
-| `restoreAttribute.ts`       | Palauta yksittäinen attribuutti DynamoDB:hen                                           | `npm run restore:attribute -- <bucket> <export-prefix> <taulu> <partition-key> <attribuutti> --execute`            |
-| `importDynamodbExports.ts`  | Tuo DynamoDB:hen sieltä aiemmin exportattu item                                        | `npm run import:dynamodb -- <bucket> <export-prefix> <taulu> <partition-key> --execute`                            |
+| Skripti                     | Kuvaus                                                                                 | Käyttö                                                                                                                    |
+| --------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `recreateMuistutusEmail.ts` | Luo ja tulostaa muistutussähköpostit (kirjaamo + valinnaisesti kuittaus kansalaiselle) | `npx ts-node --project scripts/tsconfig.json scripts/recreateMuistutusEmail.ts <oid> <muistuttajaId> [--kuittaus]`        |
+| `restoreAttribute.ts`       | Palauta yksittäinen attribuutti DynamoDB:hen                                           | `npm run restore:attribute -- <bucket> <export-prefix> <taulu> <partition-key> <attribuutti> --execute`                   |
+| `importDynamodbExports.ts`  | Tuo DynamoDB:hen sieltä aiemmin exportattu item                                        | `npm run import:dynamodb -- <bucket> <export-prefix> <taulu> <partition-key> --execute`                                   |
+| `fixInvalidVarahenkilot.ts` | Etsii ja korjaa projektit joissa on VARAHENKILO-tyyppinen käyttäjä ilman A/L-tunnusta  | `npx ts-node --project scripts/tsconfig.json scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts [--dry-run\|--run]` |
 
 ## Uuden skriptin lisääminen
 

--- a/scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts
+++ b/scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts
@@ -1,0 +1,153 @@
+// Contains code generated or recommended by Amazon Q
+/**
+ * Skripti etsii ja korjaa projektit joissa on VARAHENKILO-tyyppinen käyttäjä
+ * ilman A- tai L-tunnusta (eli tunnus ei ole muotoa A[numerot] tai L[numerot]).
+ *
+ * Käyttö:
+ *   Haku:     npx ts-node --project scripts/tsconfig.json scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts
+ *   Dry run:  npx ts-node --project scripts/tsconfig.json scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts --dry-run
+ *   Korjaus:  npx ts-node --project scripts/tsconfig.json scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts --run
+ *
+ * Vaatii:
+ *   - AWS_PROFILE: AWS-profiili jolla on oikeudet lukea ja kirjoittaa DynamoDB-taulua
+ *   - ENVIRONMENT: ympäristön nimi (dev, test, prod jne.)
+ */
+import { ScanCommand } from "@aws-sdk/lib-dynamodb";
+import { UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { getDynamoDBDocumentClient } from "../../backend/src/aws/client";
+
+if (!process.env.ENVIRONMENT) {
+  throw new Error("Aseta ENVIRONMENT ympäristömuuttuja!");
+}
+
+const tableName = "Projekti-" + process.env.ENVIRONMENT;
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes("--dry-run");
+const EXECUTE = args.includes("--run");
+
+interface KayttoOikeus {
+  kayttajatunnus: string;
+  tyyppi?: string | null;
+  email?: string;
+  muokattavissa?: boolean;
+}
+
+interface Projekti {
+  oid: string;
+  versio: number;
+  velho?: { nimi?: string };
+  kayttoOikeudet: KayttoOikeus[];
+}
+
+interface Finding {
+  projekti: Projekti;
+  kayttaja: KayttoOikeus;
+}
+
+function isAorLTunnus(uid: string): boolean {
+  return !!uid.match(/^A[\d]+/)?.pop() || !!uid.match(/^L[\d]+/)?.pop();
+}
+
+async function scan(): Promise<Finding[]> {
+  const client = getDynamoDBDocumentClient();
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+  let totalProjektit = 0;
+  const findings: Finding[] = [];
+
+  console.log(`Skannataan taulu: ${tableName}\n`);
+
+  do {
+    const response = await client.send(
+      new ScanCommand({
+        TableName: tableName,
+        ProjectionExpression: "oid, versio, velho.nimi, kayttoOikeudet",
+        ExclusiveStartKey: lastEvaluatedKey,
+      })
+    );
+
+    for (const item of (response.Items ?? []) as Projekti[]) {
+      totalProjektit++;
+      for (const ko of item.kayttoOikeudet ?? []) {
+        if (ko.tyyppi === "VARAHENKILO" && !isAorLTunnus(ko.kayttajatunnus)) {
+          findings.push({ projekti: item, kayttaja: ko });
+        }
+      }
+    }
+
+    lastEvaluatedKey = response.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  console.log(`Skannattiin ${totalProjektit} projektia.`);
+  console.log(`Löytyi ${findings.length} virheellistä varahenkilöä:\n`);
+
+  for (const f of findings) {
+    console.log(`Projekti: ${f.projekti.velho?.nimi ?? "?"}`);
+    console.log(`  OID:            ${f.projekti.oid}`);
+    console.log(`  Käyttäjätunnus: ${f.kayttaja.kayttajatunnus}`);
+    console.log(`  Email:          ${f.kayttaja.email ?? "-"}`);
+    console.log(`  Muokattavissa:  ${f.kayttaja.muokattavissa}`);
+    console.log("");
+  }
+
+  return findings;
+}
+
+async function fix(findings: Finding[], dryRun: boolean): Promise<void> {
+  const client = getDynamoDBDocumentClient();
+
+  if (dryRun) {
+    console.log("DRY RUN - näytetään mitä tapahtuisi:\n");
+  }
+
+  for (const { projekti, kayttaja } of findings) {
+    const updatedKayttoOikeudet = projekti.kayttoOikeudet.map((ko) => {
+      if (ko.kayttajatunnus === kayttaja.kayttajatunnus) {
+        const { tyyppi: _removed, ...rest } = ko;
+        return rest;
+      }
+      return ko;
+    });
+
+    if (dryRun) {
+      console.log(`Päivitettäisiin: ${projekti.velho?.nimi ?? projekti.oid}`);
+      console.log(`  ${kayttaja.kayttajatunnus}: tyyppi VARAHENKILO -> poistetaan`);
+      continue;
+    }
+
+    await client.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { oid: projekti.oid },
+        UpdateExpression: "SET kayttoOikeudet = :kayttoOikeudet",
+        ExpressionAttributeValues: { ":kayttoOikeudet": updatedKayttoOikeudet },
+      })
+    );
+    console.log(`Päivitetty: ${projekti.velho?.nimi ?? projekti.oid} (${kayttaja.kayttajatunnus})`);
+  }
+
+  if (dryRun) {
+    console.log(`\nYhteensä ${findings.length} päivitystä. Aja --run suorittaaksesi oikeat muutokset.`);
+  } else {
+    console.log(`\nValmis! Päivitetty ${findings.length} käyttäjää.`);
+  }
+}
+
+async function main() {
+  const findings = await scan();
+
+  if (findings.length === 0) {
+    console.log("Ei korjattavaa.");
+    return;
+  }
+
+  if (DRY_RUN || EXECUTE) {
+    await fix(findings, DRY_RUN);
+  } else {
+    console.log("Aja --dry-run nähdäksesi muutokset tai --run tehdäksesi ne.");
+  }
+}
+
+main().catch((e) => {
+  console.error("Virhe:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Ongelma

VLS lähetti sähköpostia hyväksymisesityksen hyväksynnästä konsultille, joka ei voi hyväksyä hyväksymisesitystä.

## Juurisyyn analyysi

Sähköposti lähetetään funktiossa `projektiPaallikkoJaVarahenkilotEmails`, joka filtteröi vastaanottajat pelkän `tyyppi`-kentän perusteella – ilman tarkistusta käyttäjätunnuksen muodosta. Konsultilla oli DynamoDB:ssä `tyyppi: VARAHENKILO`, joten hän sai sähköpostin.

Varahenkilöksi voi asettaa vain käyttäjän, jolla on A- tai L-tunnus (muoto `A[numerot]` tai `L[numerot]`). Tämä tarkistus (`isAorLTunnus`) on olemassa uusia käyttäjiä lisättäessä ja Velhosta synkronoitaessa, mutta se puuttui `mergeEditableUser`-funktiosta, jota kutsutaan kun olemassa olevaa käyttäjää päivitetään.

Todennäköinen tapahtumaketju:
1. Konsultilla oli aiemmin A- tai L-tunnus → asetettu varahenkilöksi
2. Konsultin tunnus vaihtui LX-muotoiseksi (esim. organisaatiomuutos)
3. Käyttöliittymä piilottaa varahenkilö-checkboxin ei-A/L-tunnuksilta (`shouldUnregister`), joten `tyyppi`-kenttää ei lähetetä inputissa lainkaan
4. `merge()` säilyttää `currentUser.tyyppi = VARAHENKILO` koska inputissa ei ole `tyyppi`-kenttää ylikirjoittamassa sitä
5. `tyyppi: VARAHENKILO` jää roikkumaan DynamoDB:ssä vaikka tunnus ei enää kelpaa varahenkilöksi

Skannaus löysi **11 projektia** joissa on tällainen virheellinen varahenkilömerkintä.

## Muutokset

### `backend/src/projekti/kayttoOikeudetManager.ts`
Lisätty `isAorLTunnus`-tarkistus `mergeEditableUser`-funktioon. Jos käyttäjällä on `tyyppi: VARAHENKILO` mutta tunnus ei ole A/L-muotoinen, tyyppi nollataan `null`-arvoksi. `null` käytetään `undefined`:n sijaan koska `DynamoDBDocumentClient` on konfiguroitu `removeUndefinedValues: true` – `undefined` poistuisi kokonaan eikä ylikirjoittaisi vanhaa arvoa kantaan tallennettaessa.

### `backend/src/email/emailTemplates.ts`
Lisätty `isAorLTunnus`-tarkistus `projektiPaallikkoJaVarahenkilotEmails`-funktioon. Tämä on lisäsuojaus: sähköposti ei lähde vaikka datassa olisi virhe jostain muusta syystä (esim. suora DynamoDB-muutos).

### `backend/test/email/emailTemplate.test.ts`
- Korjattu olemassa oleva testi: projektipäällikön käyttäjätunnus muutettu `ABC123` → `A123` (A/L-tunnus vaaditaan)
- Lisätty regressiotesti: varmistaa että LX-tunnuksinen varahenkilö ei saa sähköpostia, mutta A/L-tunnuksiset projektipäällikkö ja varahenkilö saavat

### `scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts`
Uusi skripti joka etsii ja korjaa DynamoDB:stä projektit joissa on `tyyppi: VARAHENKILO` käyttäjällä ilman A/L-tunnusta.

```bash
# Haku
AWS_PROFILE=<profiili> ENVIRONMENT=<env> npx ts-node --project scripts/tsconfig.json scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts

# Dry run
AWS_PROFILE=<profiili> ENVIRONMENT=<env> npx ts-node --project scripts/tsconfig.json scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts --dry-run

# Korjaus
AWS_PROFILE=<profiili> ENVIRONMENT=<env> npx ts-node --project scripts/tsconfig.json scripts/fixInvalidVarahenkilot/fixInvalidVarahenkilot.ts --run
```



## AI-Assisted: Amazon Q developer, generated
