### PR TITLE
fix: HASSUYP-843 & HASSUYP-879 - Hyväksymispäätöstietojen täyttäminen mahdolliseksi kaikille projektin henkilöille

### DIFF
--- a/backend/src/projekti/validator/validateKasittelyntila.ts
+++ b/backend/src/projekti/validator/validateKasittelyntila.ts
@@ -1,6 +1,7 @@
+// Contains code generated or recommended by Amazon Q
 import { DBProjekti, KasittelynTila } from "../../database/model";
 import { KasittelyntilaInput, Projekti, Status, TallennaProjektiInput } from "hassu-common/graphql/apiModel";
-import { requireAdmin, requireOmistaja } from "../../user/userService";
+import { requireAdmin, requirePermissionMuokkaa } from "../../user/userService";
 import assert from "assert";
 import { IllegalArgumentError } from "hassu-common/error";
 import { isStatusGreaterOrEqualTo } from "hassu-common/statusOrder";
@@ -42,8 +43,8 @@ const inputChangesHyvaksymispaatosField = (projekti: DBProjekti, input: Tallenna
 };
 
 function validateHasAccessToEditKasittelyntilaFields(projekti: DBProjekti, input: KasittelyntilaInput): void {
-  requireOmistaja(projekti, "Käsittelyn tilaa voi muokata vain projektipäällikkö");
-  const { hyvaksymispaatos: _inputHyvaksymispaatos, ...inputAdminOikeudetVaativatKentat } = input;
+  requirePermissionMuokkaa(projekti);
+  const { hyvaksymispaatos: _inputHyvaksymispaatos, suunnitelmanTila: _suunnitelmanTila, ...inputAdminOikeudetVaativatKentat } = input;
   if (!isEmpty(inputAdminOikeudetVaativatKentat)) {
     requireAdmin("Muita Käsittelyn tila -tietoja kuin hyväksymispäätöstietoja voi tallentaa vain Hassun yllapitaja");
   }

--- a/backend/test/projekti/validator/kasittelyntilaValidator.test.ts
+++ b/backend/test/projekti/validator/kasittelyntilaValidator.test.ts
@@ -222,12 +222,10 @@ describe("kasittelyntilaValidator", () => {
     await validateTallennaProjekti(projekti, input);
   });
 
-  it("Projektin henkilö (ei projektipäällikkö) ei voi tallentaa kasittelynTilaa", async () => {
+  it("Projektin henkilö (ei projektipäällikkö) voi tallentaa kasittelynTilaa", async () => {
     userFixture.loginAs(UserFixture.mattiMeikalainen);
     const projekti = fixture.dbProjekti2();
     const input: TallennaProjektiInput = { oid: projekti.oid, versio: projekti.versio, kasittelynTila: {} };
-    await expect(validateTallennaProjekti(projekti, input)).to.eventually.be.rejectedWith(
-      "Et ole projektin omistaja (Käsittelyn tilaa voi muokata vain projektipäällikkö)"
-    );
+    await expect(validateTallennaProjekti(projekti, input)).to.eventually.be.fulfilled;
   });
 });

--- a/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
+++ b/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
@@ -24,7 +24,27 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     data.kasittelynTila!.hyvaksymispaatos = { asianumero: "ABC-123", paatoksenPvm: "2024-01-15" };
     const defaults = baseFormValues();
 
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
+    asetaKasittelynTilaAutomaatiolla(data, defaults, false, false);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil04");
+  });
+
+  it("ei aseta sutil04 kun hyvaksymispaatos on jo aktiivinen eika ole yllapitaja", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.hyvaksymispaatos = { asianumero: "ABC-123", paatoksenPvm: "2024-01-15" };
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults, false, true);
+
+    expect(data.kasittelynTila!.suunnitelmanTila).toBeUndefined();
+  });
+
+  it("asettaa sutil04 kun yllapitaja muokkaa vaikka hyvaksymispaatos on jo aktiivinen", () => {
+    const data = baseFormValues();
+    data.kasittelynTila!.hyvaksymispaatos = { asianumero: "ABC-123", paatoksenPvm: "2024-01-15" };
+    const defaults = baseFormValues();
+
+    asetaKasittelynTilaAutomaatiolla(data, defaults, true, true);
 
     expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil04");
   });
@@ -35,7 +55,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     data.kasittelynTila!.lainvoimaPaattyen = "2028-01-15";
     const defaults = baseFormValues();
 
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
+    asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
     expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil05");
   });
@@ -46,7 +66,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       data.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-15";
       const defaults = baseFormValues();
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
     });
@@ -56,7 +76,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       data.kasittelynTila!.toteutusilmoitusOsittain = "2024-01-15";
       const defaults = baseFormValues();
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
     });
@@ -66,7 +86,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       data.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-01-15";
       const defaults = baseFormValues();
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
     });
@@ -76,7 +96,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
       const defaults = baseFormValues();
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
     });
@@ -88,7 +108,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       const defaults = baseFormValues();
       defaults.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko ei muuttunut
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
     });
@@ -100,7 +120,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       const defaults = baseFormValues();
       defaults.kasittelynTila!.toteutusilmoitusKokonaan = "2024-02-01"; // koko ei muuttunut
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
     });
@@ -113,7 +133,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       defaults.kasittelynTila!.liikenteeseenluovutusOsittain = "2024-01-10";
       defaults.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko oli täytetty
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil06");
     });
@@ -124,7 +144,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       const defaults = baseFormValues();
       defaults.kasittelynTila!.liikenteeseenluovutusKokonaan = "2024-02-01"; // koko oli täytetty
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBeUndefined();
     });
@@ -135,7 +155,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
       data.kasittelynTila!.toteutusilmoitusKokonaan = "2024-01-15";
       const defaults = baseFormValues();
 
-      asetaKasittelynTilaAutomaatiolla(data, defaults);
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
       expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil07");
     });
@@ -146,7 +166,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     data.kasittelynTila!.valitustenMaara = 1 as any;
     const defaults = baseFormValues();
 
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
+    asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
     expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil08");
   });
@@ -156,7 +176,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     data.kasittelynTila!.toimitusKaynnistynyt = "2024-01-15";
     const defaults = baseFormValues();
 
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
+    asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
     expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil14");
   });
@@ -165,7 +185,7 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     const data = baseFormValues();
     const defaults = baseFormValues();
 
-    asetaKasittelynTilaAutomaatiolla(data, defaults);
+    asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
 
     expect(data.kasittelynTila!.suunnitelmanTila).toBeUndefined();
   });

--- a/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
@@ -100,7 +100,7 @@ export default function KasittelyntilaSivu(): ReactElement {
         </Notification>
       )}
       {projekti &&
-        (!projekti?.nykyinenKayttaja.onProjektipaallikkoTaiVarahenkilo ? (
+        (!projekti?.nykyinenKayttaja.omaaMuokkausOikeuden ? (
           <KasittelyntilaLukutila projekti={projekti} />
         ) : (
           <KasittelyntilaPageContent projekti={projekti} projektiLoadError={projektiLoadError} reloadProjekti={reloadProjekti} />
@@ -166,7 +166,7 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
   const disableAdminOnlyFields = !projekti?.nykyinenKayttaja.onYllapitaja || !!projektiLoadError || isLoadingProjekti || isFormSubmitting;
 
   const hyvaksymispaatosDisabled =
-    !projekti.nykyinenKayttaja.onProjektipaallikkoTaiVarahenkilo ||
+    !projekti.nykyinenKayttaja.omaaMuokkausOikeuden ||
     !!projektiLoadError ||
     isLoadingProjekti ||
     isFormSubmitting ||
@@ -290,10 +290,15 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
 
   const onSubmit = useCallback(
     (data: KasittelynTilaFormValues) => {
-      asetaKasittelynTilaAutomaatiolla(data, defaultValues);
+      asetaKasittelynTilaAutomaatiolla(
+        data,
+        defaultValues,
+        !!projekti.nykyinenKayttaja.onYllapitaja,
+        !!projekti.kasittelynTila?.hyvaksymispaatos?.aktiivinen
+      );
       return withLoadingSpinner(save(data));
     },
-    [defaultValues, save, withLoadingSpinner]
+    [defaultValues, projekti.kasittelynTila?.hyvaksymispaatos?.aktiivinen, projekti.nykyinenKayttaja.onYllapitaja, save, withLoadingSpinner]
   );
 
   useEffect(() => {
@@ -410,7 +415,7 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
             <HassuGrid cols={{ lg: 3 }}>
               <DatePickerConditionallyInTheForm
                 label={`Päätöksen päivä ${projekti.kasittelynTila?.hyvaksymispaatos?.aktiivinen ? "*" : ""}`}
-                includeInForm={projekti.nykyinenKayttaja.onProjektipaallikkoTaiVarahenkilo}
+                includeInForm={projekti.nykyinenKayttaja.omaaMuokkausOikeuden}
                 disabled={hyvaksymispaatosDisabled}
                 controllerProps={{ control, name: "kasittelynTila.hyvaksymispaatos.paatoksenPvm" }}
                 value={parseValidDateOtherwiseReturnNull(projekti.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm)}

--- a/src/util/asetaKasittelynTilaAutomaatiolla.ts
+++ b/src/util/asetaKasittelynTilaAutomaatiolla.ts
@@ -11,6 +11,10 @@ export const asetaKasittelynTilaAutomaatiolla = (
     (data.kasittelynTila?.hyvaksymispaatos?.asianumero ?? null) !== defaults?.kasittelynTila?.hyvaksymispaatos?.asianumero;
   const hyvaksymisPvmChanged =
     (data.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm ?? null) !== defaults.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm;
+  // Ei-adminille sutil04 asetetaan vain ensimmäisellä tallennuskerralla (aktiivinen=false),
+  // jotta automaatio ei ylikirjoita adminin mahdollisesti asettamaa isompaa tilaa.
+  // Adminille automaatio toimii aina. suunnitelmanTila-kenttä on myös disabloitu
+  // frontissa ja estetty backendissä ei-admineille.
   if (asianumeroChanged && hyvaksymisPvmChanged && (onYllapitaja || !hyvaksymispaatosAktiivinen)) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil04";

--- a/src/util/asetaKasittelynTilaAutomaatiolla.ts
+++ b/src/util/asetaKasittelynTilaAutomaatiolla.ts
@@ -1,12 +1,17 @@
 // Contains code generated or recommended by Amazon Q
 import { KasittelynTilaFormValues } from "@pages/yllapito/projekti/[oid]/kasittelyntila";
 
-export const asetaKasittelynTilaAutomaatiolla = (data: KasittelynTilaFormValues, defaults: KasittelynTilaFormValues) => {
+export const asetaKasittelynTilaAutomaatiolla = (
+  data: KasittelynTilaFormValues,
+  defaults: KasittelynTilaFormValues,
+  onYllapitaja: boolean,
+  hyvaksymispaatosAktiivinen: boolean
+) => {
   const asianumeroChanged =
     (data.kasittelynTila?.hyvaksymispaatos?.asianumero ?? null) !== defaults?.kasittelynTila?.hyvaksymispaatos?.asianumero;
   const hyvaksymisPvmChanged =
     (data.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm ?? null) !== defaults.kasittelynTila?.hyvaksymispaatos?.paatoksenPvm;
-  if (asianumeroChanged && hyvaksymisPvmChanged) {
+  if (asianumeroChanged && hyvaksymisPvmChanged && (onYllapitaja || !hyvaksymispaatosAktiivinen)) {
     data.kasittelynTila ??= {};
     data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil04";
   }


### PR DESCRIPTION
### Tausta

Projektipäällikkö ei pystynyt tallentamaan hyväksymispäätöksen tietoja. Virhe johtui kahdesta ongelmasta:

1. Backend vaati projektipäällikön tai varahenkilön oikeudet (`requireOmistaja`) käsittelyn tilan muokkaamiseen — vaikka tarkoitus oli sallia se kaikille projektin henkilöille
2. Frontend näytti muokkausnäkymän ja aktivoi kentät vain projektipäällikölle/varahenkilölle

### Ratkaisu

Halutaan ongelman korjaamisen lisäksi muuttaa möys niin, että kuka vain projektin henkilö voi täyttää hyväksymispäätöksen tiedot
**Backend (`validateKasittelyntila.ts`)**
- `requireOmistaja` → `requirePermissionMuokkaa`: kaikki projektin henkilöt voivat nyt tallentaa hyväksymispäätöstiedot
- `suunnitelmanTila` lisätty poikkeuksiin admin-tarkistuksesta — kenttä on jo estetty frontissa ei-admineille, joten backend-tarkistus on redundantti

**Frontend (`kasittelyntila.tsx`)**
- Muokkausnäkymän ehto: `onProjektipaallikkoTaiVarahenkilo` → `omaaMuokkausOikeuden`
- `hyvaksymispaatosDisabled`-ehto: sama muutos
- `includeInForm` päätöksen päivä -kentässä: sama muutos

**Automaatio (`asetaKasittelynTilaAutomaatiolla.ts`)**

Koska ei-adminit voivat nyt tallentaa hyväksymispäätöstiedot, sutil04-automaatioon lisätty rajoitus: ei-adminille `suunnitelmanTila` asetetaan automaattisesti vain ensimmäisellä tallennuskerralla (`aktiivinen = false`). Tämä estää automaatiota ylikirjoittamasta adminin mahdollisesti asettamaa isompaa tilaa myöhemmillä tallennuksilla. Adminille automaatio toimii kuten ennen.

Funktio sai kaksi uutta parametria: `onYllapitaja` ja `hyvaksymispaatosAktiivinen`.


## AI-Assisted: Amazon Q developer, generated
