### PR TITLE
fix: HASSUYP-639 Omistajia pitää olla, jotta kuulutuksen voi lähettää hyväksyntään

### DIFF
--- a/backend/src/database/omistajaDatabase.ts
+++ b/backend/src/database/omistajaDatabase.ts
@@ -83,6 +83,11 @@ class OmistajaDatabase {
     }
   }
 
+  async hasOmistajat(oid: string): Promise<boolean> {
+    const omistajat = await this.haeProjektinKaytossaolevatOmistajat(oid, "id");
+    return omistajat.length > 0;
+  }
+
   async haeProjektinKaytossaolevatOmistajat(oid: string, expression?: string): Promise<DBOmistaja[]> {
     let lastEvaluatedKey: Record<string, any> | undefined;
     const omistajat: DBOmistaja[] = [];

--- a/backend/src/handler/tila/hyvaksymisPaatosVaiheTilaManager.ts
+++ b/backend/src/handler/tila/hyvaksymisPaatosVaiheTilaManager.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { Kieli, KuulutusJulkaisuTila, NykyinenKayttaja, TilasiirtymaTyyppi, Vaihe } from "hassu-common/graphql/apiModel";
 import { DBProjekti, HyvaksymisPaatosVaihe, HyvaksymisPaatosVaiheJulkaisu, KuulutusSaamePDFt, SaameKieli } from "../../database/model";
 import { asiakirjaAdapter } from "../asiakirjaAdapter";
@@ -18,6 +19,7 @@ import { tallennaMaanomistajaluettelo } from "../../mml/tiedotettavatExcel";
 import { fileService } from "../../files/fileService";
 import { log } from "../../logger";
 import { parameters } from "../../aws/parameters";
+import { omistajaDatabase } from "../../database/omistajaDatabase";
 import { isKieliSaame } from "hassu-common/kaannettavatKielet";
 import { assertIsDefined } from "../../util/assertions";
 import { projektiEntityDatabase } from "../../database/projektiEntityDatabase";
@@ -85,10 +87,12 @@ class HyvaksymisPaatosVaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTila
       throw new IllegalAineistoStateError();
     }
     const suomifiViestitEnabled = await parameters.isSuomiFiViestitIntegrationEnabled();
-    if (suomifiViestitEnabled && !projekti.omistajahaku?.status) {
-      const msg = "Kiinteistönomistajia ei ole haettu ennen hyväksymispäätöksen hyväksyntää";
-      log.error(msg);
-      throw new Error(msg);
+    if (suomifiViestitEnabled) {
+      if (!projekti.omistajahaku?.status || !(await omistajaDatabase.hasOmistajat(projekti.oid))) {
+        const msg = "Kiinteistönomistajia ei ole haettu ennen hyväksymispäätöksen hyväksyntää";
+        log.error(msg);
+        throw new Error(msg);
+      }
     }
   }
 

--- a/backend/src/handler/tila/nahtavillaoloTilaManager.ts
+++ b/backend/src/handler/tila/nahtavillaoloTilaManager.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { AsiakirjaTyyppi, Kieli, KuulutusJulkaisuTila, NykyinenKayttaja, TilasiirtymaTyyppi, Vaihe } from "hassu-common/graphql/apiModel";
 import { KuulutusTilaManager } from "./KuulutusTilaManager";
 import {
@@ -33,6 +34,7 @@ import { isProjektiAsianhallintaIntegrationEnabled } from "../../util/isProjekti
 import { tallennaMaanomistajaluettelo } from "../../mml/tiedotettavatExcel";
 import { parameters } from "../../aws/parameters";
 import { log } from "../../logger";
+import { omistajaDatabase } from "../../database/omistajaDatabase";
 import { haeKuulutettuYhdessaSuunnitelmanimi } from "../../asiakirja/haeKuulutettuYhdessaSuunnitelmanimi";
 import { velho } from "../../velho/velhoClient";
 import { nahtavillaoloVaiheJulkaisuDatabase } from "../../database/nahtavillaoloVaiheJulkaisuDatabase";
@@ -148,10 +150,13 @@ class NahtavillaoloTilaManager extends KuulutusTilaManager<NahtavillaoloVaihe, N
       throw new IllegalAineistoStateError();
     }
     const suomifiViestitEnabled = await parameters.isSuomiFiViestitIntegrationEnabled();
-    if (suomifiViestitEnabled && !projekti.omistajahaku?.status) {
-      const msg = "Kiinteistönomistajia ei ole haettu ennen nähtävilläolon hyväksyntää";
-      log.error(msg);
-      throw new Error(msg);
+    const skipKiinteistoRequirement = vaihe.uudelleenKuulutus?.tiedotaKiinteistonomistajia === false;
+    if (suomifiViestitEnabled && !skipKiinteistoRequirement) {
+      if (!projekti.omistajahaku?.status || !(await omistajaDatabase.hasOmistajat(projekti.oid))) {
+        const msg = "Kiinteistönomistajia ei ole haettu ennen nähtävilläolon hyväksyntää";
+        log.error(msg);
+        throw new Error(msg);
+      }
     }
   }
 

--- a/backend/src/projekti/adapter/projektiAdapter.ts
+++ b/backend/src/projekti/adapter/projektiAdapter.ts
@@ -44,6 +44,7 @@ import { getLinkkiAsianhallintaan } from "../../asianhallinta/getLinkkiAsianhall
 import GetProjektiStatus from "../status/getProjektiStatus";
 import { isStatusGreaterOrEqualTo } from "hassu-common/statusOrder";
 import { adaptEnnakkoNeuvotteluJulkaisuToAPI, adaptEnnakkoNeuvotteluToAPI } from "../../ennakkoneuvottelu/mapper";
+import { omistajaDatabase } from "../../database/omistajaDatabase";
 
 export class ProjektiAdapter {
   public async adaptProjekti(
@@ -179,6 +180,7 @@ export class ProjektiAdapter {
             virhe: omistajahaku.virhe,
             kaynnistetty: omistajahaku.kaynnistetty,
             kiinteistotunnusMaara: omistajahaku.kiinteistotunnusMaara,
+            hasOmistajat: omistajahaku.status ? await omistajaDatabase.hasOmistajat(oid) : false,
           }
         : undefined,
       kustannuspaikka,

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -255,6 +255,7 @@ type OmistajaHaku {
   kaynnistetty: String
   kiinteistotunnusMaara: Int
   status: Status
+  hasOmistajat: Boolean
 }
 
 type ProjektinTiedottaminen {

--- a/src/__tests__/components/projekti/common/KiinteistonOmistajatUudelleenkuulutus.test.tsx
+++ b/src/__tests__/components/projekti/common/KiinteistonOmistajatUudelleenkuulutus.test.tsx
@@ -2,7 +2,7 @@
 import { render, screen } from "@testing-library/react";
 import { KiinteistonOmistajatUudelleenkuulutus } from "@components/projekti/common/KiinteistonOmistajatUudelleenkuulutus";
 import { UudelleenKuulutus, UudelleenkuulutusTila, Vaihe } from "@services/api";
-import { KiinteistonomistajatVaihe } from "@components/projekti/common/KiinteistonOmistajatOhje";
+import { KiinteistonomistajatUudelleenkuulutusVaihe } from "@components/projekti/common/KiinteistonOmistajatUudelleenkuulutus";
 import { FormProvider, useForm } from "react-hook-form";
 import React from "react";
 
@@ -46,9 +46,10 @@ function Wrapper({ children, defaultValues }: { children: React.ReactNode; defau
 
 function renderComponent(
   props: {
-    vaihe?: KiinteistonomistajatVaihe;
+    vaihe?: KiinteistonomistajatUudelleenkuulutusVaihe;
     oid?: string;
     uudelleenKuulutus?: UudelleenKuulutus | null;
+    hasOmistajat?: boolean | null;
   },
   defaultValues?: Record<string, unknown>
 ) {
@@ -58,6 +59,7 @@ function renderComponent(
         vaihe={props.vaihe}
         oid={props.oid ?? "test-oid"}
         uudelleenKuulutus={props.uudelleenKuulutus}
+        hasOmistajat={props.hasOmistajat}
       />
     </Wrapper>
   );
@@ -127,6 +129,7 @@ describe("KiinteistonOmistajatUudelleenkuulutus", () => {
         {
           vaihe: Vaihe.NAHTAVILLAOLO,
           uudelleenKuulutus: createUudelleenKuulutus(PAST_DATE),
+          hasOmistajat: true,
         },
         { nahtavillaoloVaihe: { uudelleenKuulutus: { tiedotaKiinteistonomistajia: true } } }
       );
@@ -187,6 +190,7 @@ describe("KiinteistonOmistajatUudelleenkuulutus", () => {
         {
           vaihe: Vaihe.HYVAKSYMISPAATOS,
           uudelleenKuulutus: createUudelleenKuulutus("2024-06-15"),
+          hasOmistajat: true,
         },
         { paatos: { uudelleenKuulutus: { tiedotaKiinteistonomistajia: true } } }
       );

--- a/src/components/projekti/TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx
+++ b/src/components/projekti/TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet.tsx
@@ -27,6 +27,7 @@ type Props<TFieldValues extends FieldValues> = {
   preSubmitFunction: (formData: TFieldValues) => Promise<TallennaProjektiInput>;
   kuntavastaanottajat: KuntaVastaanottajaInput[] | null | undefined;
   tilasiirtymaTyyppi: Exclude<TilasiirtymaTyyppi, TilasiirtymaTyyppi.VUOROVAIKUTUSKIERROS>;
+  hasOmistajat?: boolean | null;
 };
 
 const tilasiirtymaTyyppiToStatusMap: Record<Exclude<TilasiirtymaTyyppi, TilasiirtymaTyyppi.VUOROVAIKUTUSKIERROS>, Status> = {
@@ -50,6 +51,7 @@ export default function TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet<TFieldValu
   preSubmitFunction,
   kuntavastaanottajat,
   tilasiirtymaTyyppi,
+  hasOmistajat,
 }: Readonly<Props<TFieldValues>>) {
   const showTallennaProjektiMessage = useShowTallennaProjektiMessage();
   const { showSuccessMessage, showErrorMessage } = useSnackbars();
@@ -106,11 +108,10 @@ export default function TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet<TFieldValu
               (tilasiirtymaTyyppi === TilasiirtymaTyyppi.ALOITUSKUULUTUS ||
                 tilasiirtymaTyyppi === TilasiirtymaTyyppi.NAHTAVILLAOLO ||
                 tilasiirtymaTyyppi === TilasiirtymaTyyppi.HYVAKSYMISPAATOSVAIHE) &&
-              !projekti.omistajahaku?.status
+              (!hasOmistajat || !projekti.omistajahaku?.status)
             ) {
               const tiedotaKiinteistonomistajia = formData[formDataField]?.uudelleenKuulutus?.tiedotaKiinteistonomistajia;
-              const skipKiinteistoRequirement =
-                tilasiirtymaTyyppi === TilasiirtymaTyyppi.ALOITUSKUULUTUS && tiedotaKiinteistonomistajia === false;
+              const skipKiinteistoRequirement = tiedotaKiinteistonomistajia === false;
               if (!skipKiinteistoRequirement) {
                 puutteet.push("kiinteistönomistajat puuttuvat");
               }
@@ -153,6 +154,7 @@ export default function TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet<TFieldValu
       isProjektiReadyForTilaChange,
       kuntavastaanottajat,
       data?.suomifiViestitEnabled,
+      hasOmistajat,
     ]
   );
 

--- a/src/components/projekti/aloituskuulutus/IlmoituksenVastaanottajat.tsx
+++ b/src/components/projekti/aloituskuulutus/IlmoituksenVastaanottajat.tsx
@@ -40,6 +40,7 @@ interface Props {
   aloituskuulutusjulkaisu?: AloitusKuulutusJulkaisu | null;
   oid?: string;
   omistajahakuStatus?: Status | null;
+  hasOmistajat?: boolean | null;
   uudelleenKuulutus?: UudelleenKuulutus | null;
 }
 
@@ -57,6 +58,7 @@ export default function IlmoituksenVastaanottajat({
   aloituskuulutusjulkaisu,
   oid,
   omistajahakuStatus,
+  hasOmistajat,
   uudelleenKuulutus,
 }: Props): ReactElement {
   const { t, lang } = useTranslation("commonFI");
@@ -253,11 +255,12 @@ export default function IlmoituksenVastaanottajat({
           vaihe={Vaihe.ALOITUSKUULUTUS}
           oid={oid}
           omistajahakuStatus={omistajahakuStatus}
+          hasOmistajat={hasOmistajat}
           uudelleenKuulutus={uudelleenKuulutus}
         />
       )}
       {!isReadonly && oid && uudelleenKuulutus && (
-        <KiinteistonOmistajatUudelleenkuulutus oid={oid} uudelleenKuulutus={uudelleenKuulutus} vaihe={Vaihe.ALOITUSKUULUTUS} omistajahakuStatus={omistajahakuStatus} />
+        <KiinteistonOmistajatUudelleenkuulutus oid={oid} uudelleenKuulutus={uudelleenKuulutus} vaihe={Vaihe.ALOITUSKUULUTUS} hasOmistajat={hasOmistajat} />
       )}
       {isReadonly && oid && (
         <KiinteistonOmistajatOhjeLukutila

--- a/src/components/projekti/common/KiinteistonOmistajatOhje.tsx
+++ b/src/components/projekti/common/KiinteistonOmistajatOhje.tsx
@@ -12,6 +12,7 @@ interface KiinteistonomistajatOhjeProps {
   vaihe?: KiinteistonomistajatVaihe;
   oid: string;
   omistajahakuStatus: Status | null | undefined;
+  hasOmistajat?: boolean | null;
   uudelleenKuulutus?: UudelleenKuulutus | null;
   kuulutusPaiva?: string | null;
   julkaisunTila?: KuulutusJulkaisuTila | null;
@@ -91,6 +92,7 @@ export default function KiinteistonomistajatOhje({
   vaihe,
   oid,
   omistajahakuStatus,
+  hasOmistajat,
   uudelleenKuulutus,
 }: Readonly<KiinteistonomistajatOhjeProps>) {
   const { data } = useSuomifiUser();
@@ -112,7 +114,7 @@ export default function KiinteistonomistajatOhje({
   return (
     <SectionContent>
       <H3>{heading}</H3>
-      {omistajahakuStatus ? (
+      {hasOmistajat ? (
         <KiinteistotLisatty oid={oid} vaihe={vaihe} omistajahakuStatus={omistajahakuStatus} />
       ) : (
         <KiinteistojaEiLisatty oid={oid} vaihe={vaihe} omistajahakuStatus={omistajahakuStatus} />

--- a/src/components/projekti/common/KiinteistonOmistajatUudelleenkuulutus.tsx
+++ b/src/components/projekti/common/KiinteistonOmistajatUudelleenkuulutus.tsx
@@ -18,6 +18,7 @@ interface KiinteistonomistajatUudelleenkuulutusProps {
   oid: string;
   uudelleenKuulutus: UudelleenKuulutus | null | undefined;
   omistajahakuStatus?: Status | null;
+  hasOmistajat?: boolean | null;
 }
 
 type FormFields = {
@@ -47,7 +48,12 @@ const FormGroupWithBoldLabel = styled(FormGroup)(() => ({
   },
 }));
 
-export function KiinteistonOmistajatUudelleenkuulutus({ vaihe, oid, uudelleenKuulutus, omistajahakuStatus }: KiinteistonomistajatUudelleenkuulutusProps) {
+export function KiinteistonOmistajatUudelleenkuulutus({
+  vaihe,
+  oid,
+  uudelleenKuulutus,
+  hasOmistajat,
+}: KiinteistonomistajatUudelleenkuulutusProps) {
   const { data } = useSuomifiUser();
   const { control } = useFormContext<FormFields>();
   if (uudelleenKuulutus && data?.suomifiViestitEnabled && vaihe === Vaihe.NAHTAVILLAOLO) {
@@ -83,7 +89,16 @@ export function KiinteistonOmistajatUudelleenkuulutus({ vaihe, oid, uudelleenKuu
                   />
                 </FormGroupWithBoldLabel>
               )}
-              {field.value === true && (
+              {field.value === true && !hasOmistajat && (
+                <p className="text-red">
+                  Kiinteistönomistajien tietoja ei ole lisätty Tiedottaminen-sivun{" "}
+                  <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>
+                    Kiinteistönomistajat
+                  </StyledLink>{" "}
+                  -välilehdelle.
+                </p>
+              )}
+              {field.value === true && hasOmistajat && (
                 <p>
                   Tarkasta kiinteistönomistajien vastaanottajalista Tiedottaminen -sivun{" "}
                   <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>
@@ -133,14 +148,23 @@ export function KiinteistonOmistajatUudelleenkuulutus({ vaihe, oid, uudelleenKuu
                   />
                 </FormGroupWithBoldLabel>
               )}
-              {field.value === true && (
+              {field.value === true && !hasOmistajat && (
+                <p className="text-red">
+                  Kiinteistönomistajien tietoja ei ole lisätty Tiedottaminen-sivun{" "}
+                  <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>
+                    Kiinteistönomistajat
+                  </StyledLink>{" "}
+                  -välilehdelle.
+                </p>
+              )}
+              {field.value === true && hasOmistajat && (
                 <>
                   <p>
                     Tarkasta kiinteistönomistajien ja muistuttajien vastaanottajalista{" "}
                     <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>
                       Tiedottaminen
                     </StyledLink>{" "}
-                    -sivulta Kiinteistönomistajat- ja Muistuttajat-välilehdiltä. Vastaanottajalista viedään automaattisesti asianhallintaan,
+                    -sivulta Kiinteistönomistajat ja Muistuttajat-välilehdiltä. Vastaanottajalista viedään automaattisesti asianhallintaan,
                     kun kuulutus hyväksytään julkaistavaksi.
                   </p>
                   <p>
@@ -190,7 +214,7 @@ export function KiinteistonOmistajatUudelleenkuulutus({ vaihe, oid, uudelleenKuu
                   />
                 </FormGroupWithBoldLabel>
               )}
-              {field.value === true && !omistajahakuStatus && (
+              {field.value === true && !hasOmistajat && (
                 <p className="text-red">
                   Kiinteistönomistajien tietoja ei ole lisätty Tiedottaminen-sivun{" "}
                   <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>
@@ -199,7 +223,7 @@ export function KiinteistonOmistajatUudelleenkuulutus({ vaihe, oid, uudelleenKuu
                   -välilehdelle.
                 </p>
               )}
-              {field.value === true && omistajahakuStatus && (
+              {field.value === true && hasOmistajat && (
                 <p>
                   Tarkasta kiinteistönomistajien vastaanottajalista Tiedottaminen -sivun{" "}
                   <StyledLink href={{ pathname: `/yllapito/projekti/[oid]/tiedottaminen/kiinteistonomistajat`, query: { oid } }}>

--- a/src/components/projekti/nahtavillaolo/kuulutuksentiedot/IlmoituksenVastaanottajat.tsx
+++ b/src/components/projekti/nahtavillaolo/kuulutuksentiedot/IlmoituksenVastaanottajat.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import Button from "@components/button/Button";
 import TextInput from "@components/form/TextInput";
 import React, { Fragment, ReactElement } from "react";
@@ -27,6 +28,7 @@ interface Props {
   nahtavillaoloVaihe: NahtavillaoloVaihe | null | undefined;
   oid: string;
   omistajahakuStatus: Status | null | undefined;
+  hasOmistajat?: boolean | null;
 }
 
 type FormFields = {
@@ -38,7 +40,7 @@ type FormFields = {
   };
 };
 
-export default function IlmoituksenVastaanottajat({ nahtavillaoloVaihe, oid, omistajahakuStatus }: Props): ReactElement {
+export default function IlmoituksenVastaanottajat({ nahtavillaoloVaihe, oid, omistajahakuStatus, hasOmistajat }: Props): ReactElement {
   const { t, lang } = useTranslation("commonFI");
   const { data: kirjaamoOsoitteet } = useKirjaamoOsoitteet();
 
@@ -227,17 +229,23 @@ export default function IlmoituksenVastaanottajat({ nahtavillaoloVaihe, oid, omi
               </HassuGrid>
             ))}
           </SectionContent>
-          <KiinteistonomistajatOhje
-            vaihe={Vaihe.NAHTAVILLAOLO}
-            oid={oid}
-            omistajahakuStatus={omistajahakuStatus}
-            uudelleenKuulutus={nahtavillaoloVaihe?.uudelleenKuulutus}
-          />
-          <KiinteistonOmistajatUudelleenkuulutus
-            oid={oid}
-            uudelleenKuulutus={nahtavillaoloVaihe?.uudelleenKuulutus}
-            vaihe={Vaihe.NAHTAVILLAOLO}
-          />
+          {!nahtavillaoloVaihe?.uudelleenKuulutus && (
+            <KiinteistonomistajatOhje
+              vaihe={Vaihe.NAHTAVILLAOLO}
+              oid={oid}
+              omistajahakuStatus={omistajahakuStatus}
+              hasOmistajat={hasOmistajat}
+              uudelleenKuulutus={nahtavillaoloVaihe?.uudelleenKuulutus}
+            />
+          )}
+          {nahtavillaoloVaihe?.uudelleenKuulutus && (
+            <KiinteistonOmistajatUudelleenkuulutus
+              oid={oid}
+              uudelleenKuulutus={nahtavillaoloVaihe?.uudelleenKuulutus}
+              vaihe={Vaihe.NAHTAVILLAOLO}
+              hasOmistajat={hasOmistajat}
+            />
+          )}
         </Section>
       </div>
     </>

--- a/src/components/projekti/nahtavillaolo/kuulutuksentiedot/KuulutuksenTiedot.tsx
+++ b/src/components/projekti/nahtavillaolo/kuulutuksentiedot/KuulutuksenTiedot.tsx
@@ -135,6 +135,7 @@ function KuulutuksenTiedotForm({ projekti, kirjaamoOsoitteet }: KuulutuksenTiedo
                 nahtavillaoloVaihe={projekti?.nahtavillaoloVaihe}
                 oid={projekti.oid}
                 omistajahakuStatus={projekti.omistajahaku?.status}
+                hasOmistajat={projekti.omistajahaku?.hasOmistajat}
               />
               {pdfFormRef.current?.esikatselePdf && (
                 <KuulutuksenJaIlmoituksenEsikatselu esikatselePdf={pdfFormRef.current?.esikatselePdf} />

--- a/src/components/projekti/nahtavillaolo/kuulutuksentiedot/Painikkeet.tsx
+++ b/src/components/projekti/nahtavillaolo/kuulutuksentiedot/Painikkeet.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { KuulutusJulkaisuTila, MuokkausTila, TilasiirtymaTyyppi } from "@services/api";
 import React, { useCallback } from "react";
 import { useFormContext } from "react-hook-form";
@@ -77,6 +78,7 @@ export default function Painikkeet({ projekti }: Props) {
           projekti={projekti}
           preSubmitFunction={preSubmitFunction}
           tilasiirtymaTyyppi={TilasiirtymaTyyppi.NAHTAVILLAOLO}
+          hasOmistajat={projekti.omistajahaku?.hasOmistajat}
         />
       )}
     </>

--- a/src/components/projekti/paatos/kuulutuksenTiedot/IlmoituksenVastaanottajat.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/IlmoituksenVastaanottajat.tsx
@@ -32,9 +32,10 @@ interface Props {
   paatosTyyppi: PaatosTyyppi;
   oid: string;
   omistajahakuStatus: Status | null | undefined;
+  hasOmistajat?: boolean | null;
 }
 
-export default function IlmoituksenVastaanottajat({ paatosVaihe, paatosTyyppi, oid, omistajahakuStatus }: Props): ReactElement {
+export default function IlmoituksenVastaanottajat({ paatosVaihe, paatosTyyppi, oid, omistajahakuStatus, hasOmistajat }: Props): ReactElement {
   const { t, lang } = useTranslation("commonFI");
   const { data: kirjaamoOsoitteet } = useKirjaamoOsoitteet();
 
@@ -259,12 +260,14 @@ export default function IlmoituksenVastaanottajat({ paatosVaihe, paatosTyyppi, o
                 vaihe={Vaihe.HYVAKSYMISPAATOS}
                 oid={oid}
                 omistajahakuStatus={omistajahakuStatus}
+                hasOmistajat={hasOmistajat}
                 uudelleenKuulutus={paatosVaihe?.uudelleenKuulutus}
               />
               <KiinteistonOmistajatUudelleenkuulutus
                 oid={oid}
                 uudelleenKuulutus={paatosVaihe?.uudelleenKuulutus}
                 vaihe={Vaihe.HYVAKSYMISPAATOS}
+                hasOmistajat={hasOmistajat}
               />
             </>
           )}

--- a/src/components/projekti/paatos/kuulutuksenTiedot/Painikkeet.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/Painikkeet.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { HyvaksymisPaatosVaihe, HyvaksymisPaatosVaiheJulkaisu, KuulutusJulkaisuTila, MuokkausTila } from "@services/api";
 import log from "loglevel";
 import React, { useCallback } from "react";
@@ -91,6 +92,7 @@ export default function Painikkeet({ projekti, julkaisu, paatosTyyppi, julkaisem
           projekti={projekti}
           preSubmitFunction={preSubmitFunction}
           tilasiirtymaTyyppi={paatosSpecificTilasiirtymaTyyppiMap[paatosTyyppi]}
+          hasOmistajat={projekti.omistajahaku?.hasOmistajat}
         />
       )}
     </>

--- a/src/components/projekti/paatos/kuulutuksenTiedot/index.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/index.tsx
@@ -172,6 +172,7 @@ function KuulutuksenTiedotForm({ kirjaamoOsoitteet, paatosTyyppi, projekti }: Ku
                 paatosTyyppi={paatosTyyppi}
                 oid={projekti.oid}
                 omistajahakuStatus={projekti.omistajahaku?.status}
+                hasOmistajat={projekti.omistajahaku?.hasOmistajat}
               />
               {pdfFormRef.current?.esikatselePdf && (
                 <KuulutuksenJaIlmoituksenEsikatselu paatosTyyppi={paatosTyyppi} esikatselePdf={pdfFormRef.current?.esikatselePdf} />

--- a/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
+++ b/src/pages/yllapito/projekti/[oid]/aloituskuulutus.tsx
@@ -445,6 +445,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti, kirj
                   isLoading={isLoadingProjekti}
                   oid={projekti.oid}
                   omistajahakuStatus={projekti.omistajahaku?.status}
+                  hasOmistajat={projekti.omistajahaku?.hasOmistajat}
                   uudelleenKuulutus={projekti.aloitusKuulutus?.uudelleenKuulutus}
                 />
               </fieldset>
@@ -575,6 +576,7 @@ function AloituskuulutusForm({ projekti, projektiLoadError, reloadProjekti, kirj
               preSubmitFunction={preSubmitFunction}
               projekti={projekti}
               tilasiirtymaTyyppi={TilasiirtymaTyyppi.ALOITUSKUULUTUS}
+              hasOmistajat={projekti.omistajahaku?.hasOmistajat}
             />
           </FormProvider>
         </>


### PR DESCRIPTION
## Muutokset
Backend: lisää hasOmistajat-tarkistus tilamanagereihin ja projektiAdapteriin
- omistajahaku.status ei nollaudu poistettaessa, joten se ei kerro onko omistajia oikeasti jäljellä.
- Varmistetaan että kiinteistönomistajia todella löytyy tietokannasta (ei pelkästään että omistajahaku on ajettu) ennen hyväksyntään lähetystä.
- Tieto välitetään GraphQL:n ja projektiAdapterin kautta frontendille.

Frontend: välitä hasOmistajat TallennaLuonnosJaVieHyvaksyttavaksiPainikkeet-komponentille
- Ilman tätä kiinteistönomistajien olemassaoloa ei tarkisteta oikein hyväksyntään lähetyksen yhteydessä.

## AI-Assisted: Amazon Q developer, generated
