### PR TITLE
fix: HASSUYP-615- Korjaa Macien toiminta

### DIFF
--- a/deployment/lib/hassu-account.ts
+++ b/deployment/lib/hassu-account.ts
@@ -37,6 +37,7 @@ import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { AwsApi, LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import * as macie from "aws-cdk-lib/aws-macie";
+import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from "aws-cdk-lib/custom-resources";
 
 // These should correspond to CfnOutputs produced by this stack
 export type AccountStackOutputs = {
@@ -578,11 +579,25 @@ export class HassuAccountStack extends Stack {
    * Enables Macie session for this account.
    * Account-level resource — deployed once, persists across environment stacks.
    * Before first deploy: run `aws macie2 disable-macie` if session already exists outside CFN.
+   *
+   * Automated sensitive data discovery is explicitly disabled — scanning is handled by
+   * scheduled classification jobs (macieSensitiveData.js) targeting only palautteet/ and muistutukset/ prefixes.
    */
   private ensureMacieSession() {
-    new macie.CfnSession(this, "MacieSession", {
+    const session = new macie.CfnSession(this, "MacieSession", {
       status: "ENABLED",
       findingPublishingFrequency: "FIFTEEN_MINUTES",
     });
+
+    const disableAutomatedDiscovery = new AwsCustomResource(this, "MacieDisableAutomatedDiscovery", {
+      onUpdate: {
+        service: "Macie2",
+        action: "updateAutomatedDiscoveryConfiguration",
+        parameters: { status: "DISABLED" },
+        physicalResourceId: PhysicalResourceId.of("MacieDisableAutomatedDiscovery"),
+      },
+      policy: AwsCustomResourcePolicy.fromSdkCalls({ resources: AwsCustomResourcePolicy.ANY_RESOURCE }),
+    });
+    disableAutomatedDiscovery.node.addDependency(session);
   }
 }

--- a/deployment/lib/hassu-security.ts
+++ b/deployment/lib/hassu-security.ts
@@ -131,8 +131,8 @@ Region: ${events.EventField.region}`
 }
 
 function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTopic: sns.ITopic) {
-  // Macie is only enabled on the dev account. Prod account has no Macie session.
-  if (!Config.isDevAccount()) {
+  // Macie is only enabled on the dev account's dev environment.
+  if (Config.env !== "dev") {
     return;
   }
   // Macie Session is created in hassu-account stack (account-level resource).

--- a/deployment/lib/hassu-security.ts
+++ b/deployment/lib/hassu-security.ts
@@ -1,5 +1,5 @@
 // Contains code generated or recommended by Amazon Q
-import { CfnOutput, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
 import { Config } from "./config";
 import { BlockPublicAccess, Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
 import * as events from "aws-cdk-lib/aws-events";
@@ -12,6 +12,7 @@ import * as macie from "aws-cdk-lib/aws-macie";
 import * as kms from "aws-cdk-lib/aws-kms";
 import { SSMParameterName } from "./config";
 import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from "aws-cdk-lib/custom-resources";
 
 interface SecurityScanningProps {
   stack: Stack;
@@ -130,24 +131,27 @@ Region: ${events.EventField.region}`
 }
 
 function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTopic: sns.ITopic) {
+  // Macie is only enabled on the dev account. Prod account has no Macie session.
+  if (!Config.isDevAccount()) {
+    return;
+  }
   // Macie Session is created in hassu-account stack (account-level resource).
   // It must be deployed before this stack's Macie resources can function.
-  if (Config.env === "dev") {
-    // Custom identifier for Finnish personal identity codes (henkilötunnus)
-    new macie.CfnCustomDataIdentifier(stack, "FinnishPersonalIdIdentifier", {
-      name: "FinnishPersonalIdentityCode",
-      regex: "\\b\\d{6}[+\\-A]\\d{3}[0-9A-FHJ-NPR-Y]\\b",
-      description: "Detects Finnish personal identity codes (henkilötunnus format: DDMMYY+/-A###X)",
-    });
+  // Custom identifier for Finnish personal identity codes (henkilötunnus)
+  const finnishPersonalIdIdentifier = new macie.CfnCustomDataIdentifier(stack, "FinnishPersonalIdIdentifier", {
+    name: `FinnishPersonalIdentityCode-${Config.env}`,
+    regex: "\\b\\d{6}[+\\-A]\\d{3}[0-9A-FHJ-NPR-Y]\\b",
+    description: "Detects Finnish personal identity codes (henkilötunnus format: DDMMYY+/-A###X)",
+  });
 
-    // KMS key for Macie findings bucket — Macie requires KMS when configuring findings repository
-    const macieFindingsKey = new kms.Key(stack, "MacieFindingsKey", {
+  // KMS key for Macie findings bucket — Macie requires KMS when configuring findings repository
+  const macieFindingsKey = new kms.Key(stack, "MacieFindingsKey", {
       alias: `${Config.env}-macie-findings-key`,
       description: "KMS key for Macie sensitive data discovery results",
       enableKeyRotation: true,
       removalPolicy: RemovalPolicy.DESTROY,
-    });
-    macieFindingsKey.addToResourcePolicy(
+  });
+  macieFindingsKey.addToResourcePolicy(
       new PolicyStatement({
         sid: "AllowMacieToUseKey",
         effect: Effect.ALLOW,
@@ -166,10 +170,10 @@ function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTop
           },
         },
       })
-    );
+  );
 
-    // Macie findings repository bucket
-    const macieFindingsBucket = new Bucket(stack, "MacieFindingsBucket", {
+  // Macie findings repository bucket
+  const macieFindingsBucket = new Bucket(stack, "MacieFindingsBucket", {
       bucketName: `${Config.env}-macie-findings-${stack.account}`,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       encryption: BucketEncryption.KMS,
@@ -177,11 +181,11 @@ function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTop
       enforceSSL: true,
       removalPolicy: RemovalPolicy.DESTROY,
       lifecycleRules: [{ id: "delete-old-findings", expiration: Duration.days(90) }],
-    });
+  });
 
-    macieFindingsBucket.addToResourcePolicy(
-      new PolicyStatement({
-        sid: "AllowMacieGetBucketLocation",
+  macieFindingsBucket.addToResourcePolicy(
+    new PolicyStatement({
+      sid: "AllowMacieGetBucketLocation",
         effect: Effect.ALLOW,
         principals: [new ServicePrincipal("macie.amazonaws.com")],
         actions: ["s3:GetBucketLocation"],
@@ -198,10 +202,10 @@ function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTop
           },
         },
       })
-    );
-    macieFindingsBucket.addToResourcePolicy(
-      new PolicyStatement({
-        sid: "AllowMaciePutObject",
+  );
+  macieFindingsBucket.addToResourcePolicy(
+    new PolicyStatement({
+      sid: "AllowMaciePutObject",
         effect: Effect.ALLOW,
         principals: [new ServicePrincipal("macie.amazonaws.com")],
         actions: ["s3:PutObject"],
@@ -218,22 +222,27 @@ function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTop
           },
         },
       })
-    );
+  );
 
-    // Note: CfnFindingsPublicationConfiguration is not available in aws-cdk-lib v2.241.0.
-    // Configure the findings repository manually:
-    // AWS Console → Amazon Macie → Settings → Repository for sensitive data discovery results
-    // → Configure now → Select bucket: dev-macie-findings-{account-id}
-    new CfnOutput(stack, "MacieFindingsBucketName", {
-      value: macieFindingsBucket.bucketName,
-      description: "Bucket for Macie findings - configure in Macie console Settings",
-    });
-
-    new CfnOutput(stack, "MacieFindingsKmsKeyArn", {
-      value: macieFindingsKey.keyArn,
-      description: "KMS key ARN for Macie findings - select this key in Macie console Settings",
-    });
-  }
+  // CfnFindingsPublicationConfiguration is not available in aws-cdk-lib, so we use AwsCustomResource.
+  const configureFindingsRepo = new AwsCustomResource(stack, "MacieConfigureFindingsRepository", {
+      onUpdate: {
+        service: "Macie2",
+        action: "putClassificationExportConfiguration",
+        parameters: {
+          configuration: {
+            s3Destination: {
+              bucketName: macieFindingsBucket.bucketName,
+              kmsKeyArn: macieFindingsKey.keyArn,
+            },
+          },
+        },
+        physicalResourceId: PhysicalResourceId.of("MacieConfigureFindingsRepository"),
+      },
+      policy: AwsCustomResourcePolicy.fromSdkCalls({ resources: AwsCustomResourcePolicy.ANY_RESOURCE }),
+  });
+  configureFindingsRepo.node.addDependency(macieFindingsBucket);
+  configureFindingsRepo.node.addDependency(macieFindingsKey);
 
   // Weekly scheduled classification job for sensitive data scanning
   const macieJobLambda = new lambda.Function(stack, "MacieClassificationJobLambda", {
@@ -243,6 +252,7 @@ function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTop
     environment: {
       BUCKET_NAME: bucket.bucketName,
       ACCOUNT_ID: stack.account,
+      CUSTOM_DATA_IDENTIFIER_ID: finnishPersonalIdIdentifier.attrId,
     },
     timeout: Duration.seconds(30),
   });
@@ -260,7 +270,7 @@ function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTop
     targets: [new targets.LambdaFunction(macieJobLambda)],
   });
 
-  // Alert on sensitive data findings
+  // Alert on sensitive data findings — filter by this environment's bucket to avoid duplicate alerts across environments
   new events.Rule(stack, "MacieFindingsRule", {
     eventPattern: {
       source: ["aws.macie"],
@@ -272,6 +282,11 @@ function createMacieSensitiveDataScanning(stack: Stack, bucket: Bucket, alertTop
           "SensitiveData:S3Object/Credentials",
           "SensitiveData:S3Object/CustomIdentifier",
         ],
+        resourcesAffected: {
+          s3Bucket: {
+            name: [Config.yllapitoBucketName],
+          },
+        },
       },
     },
     targets: [

--- a/deployment/lib/lambda/macieSensitiveData.js
+++ b/deployment/lib/lambda/macieSensitiveData.js
@@ -4,6 +4,7 @@ const { Macie2Client, CreateClassificationJobCommand } = require("@aws-sdk/clien
 const macie = new Macie2Client();
 const BUCKET_NAME = process.env.BUCKET_NAME;
 const ACCOUNT_ID = process.env.ACCOUNT_ID;
+const CUSTOM_DATA_IDENTIFIER_ID = process.env.CUSTOM_DATA_IDENTIFIER_ID;
 
 exports.handler = async () => {
   const jobName = `hassu-sensitive-data-scan-${Date.now()}`;
@@ -12,6 +13,7 @@ exports.handler = async () => {
   const command = new CreateClassificationJobCommand({
     jobType: "ONE_TIME",
     name: jobName,
+    customDataIdentifierIds: CUSTOM_DATA_IDENTIFIER_ID ? [CUSTOM_DATA_IDENTIFIER_ID] : [],
     s3JobDefinition: {
       bucketDefinitions: [
         {


### PR DESCRIPTION
## Muutokset
Macie skannasi kaikkia bucketteja. Syyksi löytyi automated sensitive data discovery oli ENABLED ja autoEnableOrganizationMembers: ALL ilman poissulkuja. Classification scope s3.excludes.bucketNames oli tyhjä.
- Automated discovery pois  : Lisättiin AwsCustomResource hassu-account.ts:iin kutsumaan updateAutomatedDiscoveryConfiguration statuksella DISABLED deployn yhteydessä.

Skannaus ei kuitenkaan löytänyt hetuja sisältäviä tiedostoja.
- Custom data identifier ei välittynyt lambdalle : macieSensitiveData.js ei välittänyt customDataIdentifierIds-kenttää classification job -kutsussa. Korjattiin lisäämällä CUSTOM_DATA_IDENTIFIER_ID ympäristömuuttujaksi.

Findings repository koodiin, jotta ei tarvitse käsin lisätä 
- Korvattiin manuaaliset konsoliohjeet AwsCustomResource-kutsulla putClassificationExportConfiguration hassu-security.ts:ssa.

## AI-Assisted: Amazon Q developer, generated
