### PR TITLE
chore: HASSUYP-622 Lisää hankesivuille oma sidecard

### DIFF
--- a/src/components/projekti/kansalaisnakyma/ProjektiJulkinenPageLayout.tsx
+++ b/src/components/projekti/kansalaisnakyma/ProjektiJulkinenPageLayout.tsx
@@ -10,8 +10,6 @@ import ProjektiJulkinenStepper from "./ProjektiJulkinenStepper";
 import Notification, { NotificationType } from "@components/notification/Notification";
 import useTranslation from "next-translate/useTranslation";
 import { H1, H2 } from "@components/Headings";
-import HassuWidget from "@components/layout/HassuWidget";
-import ExtLink from "@components/ExtLink";
 import { ProjektinJakotietoJulkinen } from "@components/kansalainen/ProjektinJakotietoJulkinen";
 import ContentSpacer from "@components/layout/ContentSpacer";
 import Trans from "next-translate/Trans";
@@ -51,14 +49,6 @@ export default function ProjektiPageLayout({
       <div className="flex flex-col md:flex-row gap-8 mb-3">
         {!smallScreen && (
           <div>
-            {velho?.linkki && (
-              <HassuWidget title={t("hankesivut_otsikko")}>
-                <p>{t("lue_hankesivulta")}</p>
-                <p>
-                  <ExtLink href={velho.linkki}>{t("siirry_hankesivulle")}</ExtLink>
-                </p>
-              </HassuWidget>
-            )}
             <ProjektiJulkinenSideBar sx={{ width: { md: "345px" } }} />
           </div>
         )}
@@ -114,14 +104,6 @@ export default function ProjektiPageLayout({
                   </ContentSpacer>
                 </Notification>
               )}
-            {smallScreen && velho?.linkki && (
-              <HassuWidget smallScreen>
-                <p>{t("lue_hankesivulta")}</p>
-                <p>
-                  <ExtLink href={velho.linkki}>{t("siirry_hankesivulle")}</ExtLink>
-                </p>
-              </HassuWidget>
-            )}
             {children}
           </Section>
         </div>

--- a/src/components/projekti/kansalaisnakyma/ProjektiJulkinenSideBar.tsx
+++ b/src/components/projekti/kansalaisnakyma/ProjektiJulkinenSideBar.tsx
@@ -1,11 +1,13 @@
+// Contains code generated or recommended by Amazon Q
 import React, { ComponentProps, useEffect, useState } from "react";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useProjektiJulkinen } from "src/hooks/useProjektiJulkinen";
 import HassuStack from "@components/layout/HassuStack";
 import Section from "@components/layout/Section";
 import { Kieli, SuunnittelustaVastaavaViranomainen } from "@services/api";
 import useTranslation from "next-translate/useTranslation";
 import { kuntametadata } from "hassu-common/kuntametadata";
-import { styled } from "@mui/material";
+import { styled, useTheme } from "@mui/material";
 import { formatNimi } from "../../../util/userUtil";
 import { muodostaOrganisaatioTeksti } from "src/util/kayttajaTransformationUtil";
 import { KarttaKansalaiselle } from "../common/KarttaKansalaiselle";
@@ -13,11 +15,15 @@ import { SideCard, SideCardHeading, SideCardContent } from "./SideCard";
 import axios from "axios";
 import { DynaaminenVideoUpotus } from "./videoupotus/DynaaminenVideoUpotus";
 import { useRouter } from "next/router";
+import ExtLink from "@components/ExtLink";
+import Image from "next/image";
 
 const ProjektiSideNavigation = styled((props) => {
   const { t, lang } = useTranslation("projekti-side-bar");
   const { data: projekti } = useProjektiJulkinen();
 
+  const theme = useTheme();
+  const smallScreen = useMediaQuery(theme.breakpoints.down("lg"));
   const [geoJSON, setGeoJSON] = useState<string | null>(projekti?.velho.geoJSON ?? null);
 
   useEffect(() => {
@@ -67,6 +73,9 @@ const ProjektiSideNavigation = styled((props) => {
 
   return (
     <Section noDivider {...props}>
+      {!smallScreen && projekti.velho?.linkki && (
+        <Image src="/assets/rata_ja_tie_background.jpeg" alt="kuvituskuva" width={345} height={194} />
+      )}
       <SideCard>
         <SideCardHeading>{t("suunnitteluhankkeen_yhteystiedot")}</SideCardHeading>
         <SideCardContent>
@@ -139,6 +148,17 @@ const ProjektiSideNavigation = styled((props) => {
           )}
         </SideCardContent>
       </SideCard>
+      {projekti.velho?.linkki && (
+        <SideCard>
+          <SideCardHeading>{t("hankesivut_otsikko")}</SideCardHeading>
+          <SideCardContent>
+            <p>{t("lue_hankesivulta")}</p>
+            <p>
+              <ExtLink href={projekti.velho.linkki}>{t("siirry_hankesivulle")}</ExtLink>
+            </p>
+          </SideCardContent>
+        </SideCard>
+      )}
       <SideCard>
         {geoJSON && (
           <>

--- a/src/locales/fi/projekti-side-bar.json
+++ b/src/locales/fi/projekti-side-bar.json
@@ -1,5 +1,8 @@
 {
   "suunnitteluhankkeen_yhteystiedot": "Suunnitteluhankkeen yhteyshenkilöt",
+  "hankesivut_otsikko": "Hankkeen sivu",
+  "lue_hankesivulta": "Laajemmat tiedot suunnitelmasta ovat esillä hankkeen verkkosivulla.",
+  "siirry_hankesivulle": "Siirry hankesivulle",
   "suunnitelma_kartalla": "Suunnitelma kartalla",
   "tutustu-videoiden-avulla-TIE": "Tutustu tiesuunnitteluun",
   "tutustu-videoiden-avulla-RATA": "Tutustu ratasuunnitteluun",

--- a/src/locales/fi/projekti.json
+++ b/src/locales/fi/projekti.json
@@ -490,8 +490,5 @@
       "genetiivi": "ratasuunnitelman",
       "genetiivi_isolla": "Ratasuunnitelman"
     }
-  },
-  "lue_hankesivulta": "Lue hankkeesta lisää hankesivulta",
-  "siirry_hankesivulle": "Siirry hankesivulle",
-  "hankesivut_otsikko": "Hankesivut"
+  }
 }

--- a/src/locales/sv/projekti-side-bar.json
+++ b/src/locales/sv/projekti-side-bar.json
@@ -1,5 +1,8 @@
 {
   "suunnitteluhankkeen_yhteystiedot": "Kontaktpersoner för planeringsprojektet",
+  "hankesivut_otsikko": "Projektsidor",
+  "lue_hankesivulta": "Mer information om planen finns på projektets webbsida.",
+  "siirry_hankesivulle": "Gå till projektsidorna",
   "suunnitelma_kartalla": "Planera på kartan",
   "tutustu-videoiden-avulla-TIE": "Bekanta dig med vägplanering",
   "tutustu-videoiden-avulla-RATA": "Bekanta dig med järnvägsplanering",

--- a/src/locales/sv/projekti.json
+++ b/src/locales/sv/projekti.json
@@ -491,8 +491,5 @@
       "genetiivi": "järnvägsplanen",
       "genetiivi_isolla": "Järnvägsplanen"
     }
-  },
-  "lue_hankesivulta": "Läs mer om projektet på projektsidorna",
-  "siirry_hankesivulle": "Gå till projektsidorna",
-  "hankesivut_otsikko": "Projektsidor"
+  }
 }


### PR DESCRIPTION
## Muutokset
Siirretty kansalaispuolen suunnitelmasivun vasemman reunan sidecardeissa aiemmin ylimpänä ollut hankesivut-osio omaksi sidecardikseen yhteystietojen alle.

## AI-Assisted: Amazon Q developer, generated
