### PR TITLE
fix: HASSUYP-639 korjaus: Omistajien tarkastus päätöstä hyväksyntään lähetettäessä yhtenäiseksi aiempien vaiheiden kanssa

### DIFF
--- a/backend/src/handler/tila/hyvaksymisPaatosVaiheTilaManager.ts
+++ b/backend/src/handler/tila/hyvaksymisPaatosVaiheTilaManager.ts
@@ -87,7 +87,8 @@ class HyvaksymisPaatosVaiheTilaManager extends AbstractHyvaksymisPaatosVaiheTila
       throw new IllegalAineistoStateError();
     }
     const suomifiViestitEnabled = await parameters.isSuomiFiViestitIntegrationEnabled();
-    if (suomifiViestitEnabled) {
+    const skipKiinteistoRequirement = vaihe.uudelleenKuulutus?.tiedotaKiinteistonomistajia === false;
+    if (suomifiViestitEnabled && !skipKiinteistoRequirement) {
       if (!projekti.omistajahaku?.status || !(await omistajaDatabase.hasOmistajat(projekti.oid))) {
         const msg = "Kiinteistönomistajia ei ole haettu ennen hyväksymispäätöksen hyväksyntää";
         log.error(msg);

--- a/src/components/projekti/paatos/kuulutuksenTiedot/IlmoituksenVastaanottajat.tsx
+++ b/src/components/projekti/paatos/kuulutuksenTiedot/IlmoituksenVastaanottajat.tsx
@@ -35,7 +35,13 @@ interface Props {
   hasOmistajat?: boolean | null;
 }
 
-export default function IlmoituksenVastaanottajat({ paatosVaihe, paatosTyyppi, oid, omistajahakuStatus, hasOmistajat }: Props): ReactElement {
+export default function IlmoituksenVastaanottajat({
+  paatosVaihe,
+  paatosTyyppi,
+  oid,
+  omistajahakuStatus,
+  hasOmistajat,
+}: Props): ReactElement {
   const { t, lang } = useTranslation("commonFI");
   const { data: kirjaamoOsoitteet } = useKirjaamoOsoitteet();
 
@@ -256,19 +262,23 @@ export default function IlmoituksenVastaanottajat({ paatosVaihe, paatosTyyppi, o
           )}
           {!paatosIsJatkopaatos(paatosTyyppi) && (
             <>
-              <KiinteistonomistajatOhje
-                vaihe={Vaihe.HYVAKSYMISPAATOS}
-                oid={oid}
-                omistajahakuStatus={omistajahakuStatus}
-                hasOmistajat={hasOmistajat}
-                uudelleenKuulutus={paatosVaihe?.uudelleenKuulutus}
-              />
-              <KiinteistonOmistajatUudelleenkuulutus
-                oid={oid}
-                uudelleenKuulutus={paatosVaihe?.uudelleenKuulutus}
-                vaihe={Vaihe.HYVAKSYMISPAATOS}
-                hasOmistajat={hasOmistajat}
-              />
+              {!paatosVaihe?.uudelleenKuulutus && (
+                <KiinteistonomistajatOhje
+                  vaihe={Vaihe.HYVAKSYMISPAATOS}
+                  oid={oid}
+                  omistajahakuStatus={omistajahakuStatus}
+                  hasOmistajat={hasOmistajat}
+                  uudelleenKuulutus={paatosVaihe?.uudelleenKuulutus}
+                />
+              )}
+              {paatosVaihe?.uudelleenKuulutus && (
+                <KiinteistonOmistajatUudelleenkuulutus
+                  oid={oid}
+                  uudelleenKuulutus={paatosVaihe?.uudelleenKuulutus}
+                  vaihe={Vaihe.HYVAKSYMISPAATOS}
+                  hasOmistajat={hasOmistajat}
+                />
+              )}
             </>
           )}
         </Section>


### PR DESCRIPTION
## Muutokset
- Ilmoitus puuttuvista kiinteistönomistajista näytettiin hyväksymispäätöksessä kahteen kertaan puuttuvien ehtojen takia
- Yhtenäistetty päätöksen uudelleenkuulutuksen lähettäminen hyväksyttäväksi aiempien vaiheiden kanssa; jos radiobuttonilla valittu, että ei tiedoteta, niin silloin ei vaadita kiinteistönomistajia.

## AI-Assisted: Amazon Q developer, none
