### PR TITLE
feat: HASSUYP-764 - Nähtävilläolon ajankohdalle päivämääräkentät käsittelyn tila - sivulle ja automaatiolla asettaminen

### DIFF
--- a/backend/integrationtest/api/testUtil/hyvaksymisPaatosVaihe.ts
+++ b/backend/integrationtest/api/testUtil/hyvaksymisPaatosVaihe.ts
@@ -60,6 +60,8 @@ export async function testHyvaksymisPaatosVaihe(oid: string, userFixture: UserFi
     versio,
     kasittelynTila: {
       hyvaksymispaatos: { asianumero: "asianro123", paatoksenPvm: "2022-06-09" },
+      nahtavillaAlku: "2022-03-01",
+      nahtavillaLoppu: "2022-03-30",
     },
   });
 

--- a/backend/integrationtest/api/testUtil/hyvaksymisPaatosVaihe.ts
+++ b/backend/integrationtest/api/testUtil/hyvaksymisPaatosVaihe.ts
@@ -60,8 +60,8 @@ export async function testHyvaksymisPaatosVaihe(oid: string, userFixture: UserFi
     versio,
     kasittelynTila: {
       hyvaksymispaatos: { asianumero: "asianro123", paatoksenPvm: "2022-06-09" },
-      nahtavillaAlku: "2022-03-01",
-      nahtavillaLoppu: "2022-03-30",
+      nahtavillaoloAlkaen: "2022-03-01",
+      nahtavillaoloPaattyen: "2022-03-30",
     },
   });
 

--- a/backend/src/database/model/projekti.ts
+++ b/backend/src/database/model/projekti.ts
@@ -134,6 +134,8 @@ export type KasittelynTila = {
   suunnitelmanTila?: keyof typeof suunnitelmanTilat; // Esimerkiksi "suunnitelman-tila/sutil01"
   hyvaksymisesitysTraficomiinPaiva?: string;
   ennakkoneuvotteluPaiva?: string;
+  nahtavillaAlku?: string;
+  nahtavillaLoppu?: string;
   hyvaksymispaatos?: Hyvaksymispaatos;
   ensimmainenJatkopaatos?: Hyvaksymispaatos;
   toinenJatkopaatos?: Hyvaksymispaatos;

--- a/backend/src/database/model/projekti.ts
+++ b/backend/src/database/model/projekti.ts
@@ -134,8 +134,8 @@ export type KasittelynTila = {
   suunnitelmanTila?: keyof typeof suunnitelmanTilat; // Esimerkiksi "suunnitelman-tila/sutil01"
   hyvaksymisesitysTraficomiinPaiva?: string;
   ennakkoneuvotteluPaiva?: string;
-  nahtavillaAlku?: string;
-  nahtavillaLoppu?: string;
+  nahtavillaoloAlkaen?: string;
+  nahtavillaoloPaattyen?: string;
   hyvaksymispaatos?: Hyvaksymispaatos;
   ensimmainenJatkopaatos?: Hyvaksymispaatos;
   toinenJatkopaatos?: Hyvaksymispaatos;

--- a/backend/src/handler/tila/nahtavillaoloTilaManager.ts
+++ b/backend/src/handler/tila/nahtavillaoloTilaManager.ts
@@ -163,6 +163,18 @@ class NahtavillaoloTilaManager extends KuulutusTilaManager<NahtavillaoloVaihe, N
   async approve(projekti: DBProjekti, hyvaksyja: NykyinenKayttaja): Promise<void> {
     // super.approve muuttaa tilan, joten haetaan odottavan julkaisun tiedot talteen Velhoa varten
     const nahtavillaoloJulkaisuWaitingForApproval = this.getKuulutusWaitingForApproval(projekti);
+    // Päivitetään kasittelynTila julkaisun uusilla päivämäärillä jotta käsittelyn tila pysyy synkassa
+    if (nahtavillaoloJulkaisuWaitingForApproval?.kuulutusPaiva) {
+      await projektiDatabase.saveProjekti({
+        oid: projekti.oid,
+        versio: projekti.versio,
+        kasittelynTila: {
+          ...projekti.kasittelynTila,
+          nahtavillaAlku: nahtavillaoloJulkaisuWaitingForApproval.kuulutusPaiva,
+          nahtavillaLoppu: nahtavillaoloJulkaisuWaitingForApproval.kuulutusVaihePaattyyPaiva ?? projekti.kasittelynTila?.nahtavillaLoppu,
+        },
+      });
+    }
     await super.approve(projekti, hyvaksyja);
     if (nahtavillaoloJulkaisuWaitingForApproval) {
       await velho.saveJulkaisupvm(projekti.oid, nahtavillaoloJulkaisuWaitingForApproval);

--- a/backend/src/handler/tila/nahtavillaoloTilaManager.ts
+++ b/backend/src/handler/tila/nahtavillaoloTilaManager.ts
@@ -170,8 +170,9 @@ class NahtavillaoloTilaManager extends KuulutusTilaManager<NahtavillaoloVaihe, N
         versio: projekti.versio,
         kasittelynTila: {
           ...projekti.kasittelynTila,
-          nahtavillaAlku: nahtavillaoloJulkaisuWaitingForApproval.kuulutusPaiva,
-          nahtavillaLoppu: nahtavillaoloJulkaisuWaitingForApproval.kuulutusVaihePaattyyPaiva ?? projekti.kasittelynTila?.nahtavillaLoppu,
+          nahtavillaoloAlkaen: nahtavillaoloJulkaisuWaitingForApproval.kuulutusPaiva,
+          nahtavillaoloPaattyen:
+            nahtavillaoloJulkaisuWaitingForApproval.kuulutusVaihePaattyyPaiva ?? projekti.kasittelynTila?.nahtavillaoloPaattyen,
         },
       });
     }

--- a/backend/src/velho/velhoAdapter.ts
+++ b/backend/src/velho/velhoAdapter.ts
@@ -391,8 +391,8 @@ function adaptKasittelynTilaFromVelho(ominaisuudet: ProjektiProjektiLuontiOminai
   kasittelynTila.ennakkoneuvotteluPaiva = objectToString(ominaisuudet["ennakkoneuvottelu"]);
   kasittelynTila.hyvaksymisesitysTraficomiinPaiva = objectToString(ominaisuudet["hyvaksymisesitys"]?.lahetetty);
   kasittelynTila.ennakkotarkastus = objectToString(ominaisuudet["hyvaksymisesitys"]?.saapunut);
-  setIfDefined(ominaisuudet["nahtavilla-olo"]?.alkaen, (value) => (kasittelynTila.nahtavillaAlku = objectToString(value)));
-  setIfDefined(ominaisuudet["nahtavilla-olo"]?.paattyen, (value) => (kasittelynTila.nahtavillaLoppu = objectToString(value)));
+  setIfDefined(ominaisuudet["nahtavilla-olo"]?.alkaen, (value) => (kasittelynTila.nahtavillaoloAlkaen = objectToString(value)));
+  setIfDefined(ominaisuudet["nahtavilla-olo"]?.paattyen, (value) => (kasittelynTila.nahtavillaoloPaattyen = objectToString(value)));
   const hyvaksymispaatos = ominaisuudet.hyvaksymispaatos;
   if (hyvaksymispaatos) {
     kasittelynTila.hyvaksymispaatos = kasittelynTila.hyvaksymispaatos ?? {};
@@ -438,10 +438,10 @@ export function applyKasittelyntilaToVelho(projekti: ProjektiProjektiMuokkaus, p
   const ominaisuudet = projekti.ominaisuudet;
   setIfDefined(params.suunnitelmanTila, (value) => (ominaisuudet["hallinnollisen-kasittelyn-tila"] = stringToObject(value)));
   setIfDefined(params.ennakkoneuvotteluPaiva, (value) => (ominaisuudet["ennakkoneuvottelu"] = toLocalDate(value)));
-  setIfDefined(params.nahtavillaAlku, (value) => {
+  setIfDefined(params.nahtavillaoloAlkaen, (value) => {
     ominaisuudet["nahtavilla-olo"] = {
       alkaen: toLocalDate(value),
-      paattyen: params.nahtavillaLoppu ? toLocalDate(params.nahtavillaLoppu) : ominaisuudet["nahtavilla-olo"]?.paattyen ?? null,
+      paattyen: params.nahtavillaoloPaattyen ? toLocalDate(params.nahtavillaoloPaattyen) : ominaisuudet["nahtavilla-olo"]?.paattyen ?? null,
     };
   });
   setIfDefined(

--- a/backend/src/velho/velhoAdapter.ts
+++ b/backend/src/velho/velhoAdapter.ts
@@ -391,6 +391,8 @@ function adaptKasittelynTilaFromVelho(ominaisuudet: ProjektiProjektiLuontiOminai
   kasittelynTila.ennakkoneuvotteluPaiva = objectToString(ominaisuudet["ennakkoneuvottelu"]);
   kasittelynTila.hyvaksymisesitysTraficomiinPaiva = objectToString(ominaisuudet["hyvaksymisesitys"]?.lahetetty);
   kasittelynTila.ennakkotarkastus = objectToString(ominaisuudet["hyvaksymisesitys"]?.saapunut);
+  setIfDefined(ominaisuudet["nahtavilla-olo"]?.alkaen, (value) => (kasittelynTila.nahtavillaAlku = objectToString(value)));
+  setIfDefined(ominaisuudet["nahtavilla-olo"]?.paattyen, (value) => (kasittelynTila.nahtavillaLoppu = objectToString(value)));
   const hyvaksymispaatos = ominaisuudet.hyvaksymispaatos;
   if (hyvaksymispaatos) {
     kasittelynTila.hyvaksymispaatos = kasittelynTila.hyvaksymispaatos ?? {};
@@ -436,6 +438,12 @@ export function applyKasittelyntilaToVelho(projekti: ProjektiProjektiMuokkaus, p
   const ominaisuudet = projekti.ominaisuudet;
   setIfDefined(params.suunnitelmanTila, (value) => (ominaisuudet["hallinnollisen-kasittelyn-tila"] = stringToObject(value)));
   setIfDefined(params.ennakkoneuvotteluPaiva, (value) => (ominaisuudet["ennakkoneuvottelu"] = toLocalDate(value)));
+  setIfDefined(params.nahtavillaAlku, (value) => {
+    ominaisuudet["nahtavilla-olo"] = {
+      alkaen: toLocalDate(value),
+      paattyen: params.nahtavillaLoppu ? toLocalDate(params.nahtavillaLoppu) : ominaisuudet["nahtavilla-olo"]?.paattyen ?? null,
+    };
+  });
   setIfDefined(
     params.hyvaksymisesitysTraficomiinPaiva,
     (value) =>

--- a/backend/test/email/emailHandler.test.ts
+++ b/backend/test/email/emailHandler.test.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { describe, it } from "mocha";
 import * as sinon from "sinon";
 import { projektiDatabase } from "../../src/database/projektiDatabase";
@@ -37,6 +38,7 @@ describe("emailHandler", () => {
   let updateAloitusKuulutusJulkaisuStub: sinon.SinonStub;
   let putNahtavillaoloKuulutusJulkaisuStub: sinon.SinonStub;
   let putJulkaisutStub: sinon.SinonStub;
+  let saveProjektiStub: sinon.SinonStub;
   let publishProjektiFileStub: sinon.SinonStub;
   let synchronizeProjektiFilesStub: sinon.SinonStub;
   let fixture: ProjektiFixture;
@@ -52,6 +54,7 @@ describe("emailHandler", () => {
     updateAloitusKuulutusJulkaisuStub = sinon.stub(projektiDatabase.aloitusKuulutusJulkaisut, "update");
     putNahtavillaoloKuulutusJulkaisuStub = sinon.stub(nahtavillaoloVaiheJulkaisuDatabase, "put");
     putJulkaisutStub = sinon.stub(projektiEntityDatabase, "put");
+    saveProjektiStub = sinon.stub(projektiDatabase, "saveProjekti").resolves();
     publishProjektiFileStub = sinon.stub(fileService, "publishProjektiFile");
     synchronizeProjektiFilesStub = sinon.stub(projektiSchedulerService, "synchronizeProjektiFiles");
     sinon.stub(parameters, "isAsianhallintaIntegrationEnabled").returns(Promise.resolve(false));

--- a/backend/test/projekti/adapter/adaptToDB/adaptKasittelynTilaToSave.test.ts
+++ b/backend/test/projekti/adapter/adaptToDB/adaptKasittelynTilaToSave.test.ts
@@ -9,16 +9,16 @@ import { KasittelynTila } from "../../../../src/database/model";
 import { expect } from "chai";
 
 describe("adaptKasittelynTilaToSave", () => {
-  it("should save nahtavillaAlku and nahtavillaLoppu", async () => {
+  it("should save nahtavillaoloAlkaen and nahtavillaoloPaattyen", async () => {
     const dbProjekti = new ProjektiFixture().dbProjekti1();
     dbProjekti.kasittelynTila = undefined;
     const kasittelynTilaInput: KasittelyntilaInput = {
-      nahtavillaAlku: "2024-03-01",
-      nahtavillaLoppu: "2024-03-30",
+      nahtavillaoloAlkaen: "2024-03-01",
+      nahtavillaoloPaattyen: "2024-03-30",
     };
     const result = adaptKasittelynTilaToSave(dbProjekti.kasittelynTila, kasittelynTilaInput, new ProjektiAdaptationResult(dbProjekti));
-    expect(result?.nahtavillaAlku).to.equal("2024-03-01");
-    expect(result?.nahtavillaLoppu).to.equal("2024-03-30");
+    expect(result?.nahtavillaoloAlkaen).to.equal("2024-03-01");
+    expect(result?.nahtavillaoloPaattyen).to.equal("2024-03-30");
   });
 
   it("should save paatos when valipaatos is already saved", async () => {

--- a/backend/test/projekti/adapter/adaptToDB/adaptKasittelynTilaToSave.test.ts
+++ b/backend/test/projekti/adapter/adaptToDB/adaptKasittelynTilaToSave.test.ts
@@ -9,6 +9,18 @@ import { KasittelynTila } from "../../../../src/database/model";
 import { expect } from "chai";
 
 describe("adaptKasittelynTilaToSave", () => {
+  it("should save nahtavillaAlku and nahtavillaLoppu", async () => {
+    const dbProjekti = new ProjektiFixture().dbProjekti1();
+    dbProjekti.kasittelynTila = undefined;
+    const kasittelynTilaInput: KasittelyntilaInput = {
+      nahtavillaAlku: "2024-03-01",
+      nahtavillaLoppu: "2024-03-30",
+    };
+    const result = adaptKasittelynTilaToSave(dbProjekti.kasittelynTila, kasittelynTilaInput, new ProjektiAdaptationResult(dbProjekti));
+    expect(result?.nahtavillaAlku).to.equal("2024-03-01");
+    expect(result?.nahtavillaLoppu).to.equal("2024-03-30");
+  });
+
   it("should save paatos when valipaatos is already saved", async () => {
     const dbProjekti = new ProjektiFixture().dbProjekti1();
     dbProjekti.kasittelynTila = {

--- a/backend/test/velho/velhoAdapter.test.ts
+++ b/backend/test/velho/velhoAdapter.test.ts
@@ -1,9 +1,10 @@
+// Contains code generated or recommended by Amazon Q
 import { describe, it } from "mocha";
-import { adaptProjekti, findUpdatedFields } from "../../src/velho/velhoAdapter";
+import { adaptProjekti, applyKasittelyntilaToVelho, findUpdatedFields } from "../../src/velho/velhoAdapter";
 import { default as velhoTieProjecti } from "./fixture/velhoTieProjekti.json";
 import cloneDeep from "lodash/cloneDeep";
 import { Velho } from "../../src/database/model";
-import { ProjektiProjekti } from "../../src/velho/projektirekisteri";
+import { ProjektiProjekti, ProjektiProjektiMuokkaus } from "../../src/velho/projektirekisteri";
 
 import { expect } from "chai";
 import sinon from "sinon";
@@ -16,6 +17,11 @@ describe("VelhoAdapter", () => {
   before(() => {
     isAsianhallintaIntegrationEnabledStub = sinon.stub(parameters, "isAsianhallintaIntegrationEnabled");
     isUspaIntegrationEnabledStub = sinon.stub(parameters, "isUspaIntegrationEnabled");
+  });
+
+  after(() => {
+    isAsianhallintaIntegrationEnabledStub.restore();
+    isUspaIntegrationEnabledStub.restore();
   });
 
   beforeEach(() => {
@@ -47,5 +53,35 @@ describe("VelhoAdapter", () => {
     newVelho.vastuuhenkilonEmail = "uusi@vayla.fi";
     const differencies = findUpdatedFields(oldVelho, newVelho);
     expect(differencies).toMatchSnapshot();
+  });
+
+  it("should write nahtavillaAlku and nahtavillaLoppu to Velho nahtavilla-olo field", () => {
+    const projekti = { ominaisuudet: {} } as unknown as ProjektiProjektiMuokkaus;
+    applyKasittelyntilaToVelho(projekti, { nahtavillaAlku: "2024-03-01", nahtavillaLoppu: "2024-03-30" });
+    const nahtavillaOlo = projekti.ominaisuudet["nahtavilla-olo"] as { alkaen: unknown; paattyen: unknown };
+    expect(nahtavillaOlo).to.exist;
+    expect(nahtavillaOlo.alkaen).to.exist;
+    expect(nahtavillaOlo.paattyen).to.exist;
+  });
+
+  it("should not overwrite existing nahtavilla-olo paattyen when nahtavillaLoppu is not given", () => {
+    const existingPaattyen = {} as unknown;
+    const projekti = {
+      ominaisuudet: { "nahtavilla-olo": { alkaen: {}, paattyen: existingPaattyen } },
+    } as unknown as ProjektiProjektiMuokkaus;
+    applyKasittelyntilaToVelho(projekti, { nahtavillaAlku: "2024-03-01" });
+    const nahtavillaOlo = projekti.ominaisuudet["nahtavilla-olo"] as { alkaen: unknown; paattyen: unknown };
+    expect(nahtavillaOlo.paattyen).to.equal(existingPaattyen);
+  });
+
+  it("should adapt nahtavillaAlku and nahtavillaLoppu from Velho nahtavilla-olo field", async () => {
+    const velhoData = cloneDeep(velhoTieProjecti.data as unknown as ProjektiProjekti);
+    velhoData.ominaisuudet["nahtavilla-olo"] = {
+      alkaen: "2024-03-01T00:00:00+02:00" as unknown as object,
+      paattyen: "2024-03-30T00:00:00+02:00" as unknown as object,
+    };
+    const result = await adaptProjekti(velhoData);
+    expect(result.kasittelynTila?.nahtavillaAlku).to.exist;
+    expect(result.kasittelynTila?.nahtavillaLoppu).to.exist;
   });
 });

--- a/backend/test/velho/velhoAdapter.test.ts
+++ b/backend/test/velho/velhoAdapter.test.ts
@@ -55,33 +55,33 @@ describe("VelhoAdapter", () => {
     expect(differencies).toMatchSnapshot();
   });
 
-  it("should write nahtavillaAlku and nahtavillaLoppu to Velho nahtavilla-olo field", () => {
+  it("should write nahtavillaoloAlkaen and nahtavillaoloPaattyen to Velho nahtavilla-olo field", () => {
     const projekti = { ominaisuudet: {} } as unknown as ProjektiProjektiMuokkaus;
-    applyKasittelyntilaToVelho(projekti, { nahtavillaAlku: "2024-03-01", nahtavillaLoppu: "2024-03-30" });
+    applyKasittelyntilaToVelho(projekti, { nahtavillaoloAlkaen: "2024-03-01", nahtavillaoloPaattyen: "2024-03-30" });
     const nahtavillaOlo = projekti.ominaisuudet["nahtavilla-olo"] as { alkaen: unknown; paattyen: unknown };
     expect(nahtavillaOlo).to.exist;
     expect(nahtavillaOlo.alkaen).to.exist;
     expect(nahtavillaOlo.paattyen).to.exist;
   });
 
-  it("should not overwrite existing nahtavilla-olo paattyen when nahtavillaLoppu is not given", () => {
+  it("should not overwrite existing nahtavilla-olo paattyen when nahtavillaoloPaattyen is not given", () => {
     const existingPaattyen = {} as unknown;
     const projekti = {
       ominaisuudet: { "nahtavilla-olo": { alkaen: {}, paattyen: existingPaattyen } },
     } as unknown as ProjektiProjektiMuokkaus;
-    applyKasittelyntilaToVelho(projekti, { nahtavillaAlku: "2024-03-01" });
+    applyKasittelyntilaToVelho(projekti, { nahtavillaoloAlkaen: "2024-03-01" });
     const nahtavillaOlo = projekti.ominaisuudet["nahtavilla-olo"] as { alkaen: unknown; paattyen: unknown };
     expect(nahtavillaOlo.paattyen).to.equal(existingPaattyen);
   });
 
-  it("should adapt nahtavillaAlku and nahtavillaLoppu from Velho nahtavilla-olo field", async () => {
+  it("should adapt nahtavillaoloAlkaen and nahtavillaoloPaattyen from Velho nahtavilla-olo field", async () => {
     const velhoData = cloneDeep(velhoTieProjecti.data as unknown as ProjektiProjekti);
     velhoData.ominaisuudet["nahtavilla-olo"] = {
       alkaen: "2024-03-01T00:00:00+02:00" as unknown as object,
       paattyen: "2024-03-30T00:00:00+02:00" as unknown as object,
     };
     const result = await adaptProjekti(velhoData);
-    expect(result.kasittelynTila?.nahtavillaAlku).to.exist;
-    expect(result.kasittelynTila?.nahtavillaLoppu).to.exist;
+    expect(result.kasittelynTila?.nahtavillaoloAlkaen).to.exist;
+    expect(result.kasittelynTila?.nahtavillaoloPaattyen).to.exist;
   });
 });

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -558,6 +558,8 @@ input KasittelyntilaInput {
   toinenJatkopaatos: HyvaksymispaatosInput
   hyvaksymisesitysTraficomiinPaiva: String
   ennakkoneuvotteluPaiva: String
+  nahtavillaAlku: String
+  nahtavillaLoppu: String
   valitustenMaara: Int
   lainvoimaAlkaen: String
   lainvoimaPaattyen: String

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -558,8 +558,8 @@ input KasittelyntilaInput {
   toinenJatkopaatos: HyvaksymispaatosInput
   hyvaksymisesitysTraficomiinPaiva: String
   ennakkoneuvotteluPaiva: String
-  nahtavillaAlku: String
-  nahtavillaLoppu: String
+  nahtavillaoloAlkaen: String
+  nahtavillaoloPaattyen: String
   valitustenMaara: Int
   lainvoimaAlkaen: String
   lainvoimaPaattyen: String

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -1517,6 +1517,8 @@ type KasittelynTila {
   toinenJatkopaatos: Hyvaksymispaatos
   hyvaksymisesitysTraficomiinPaiva: String
   ennakkoneuvotteluPaiva: String
+  nahtavillaAlku: String
+  nahtavillaLoppu: String
   valitustenMaara: Int
   lainvoimaAlkaen: String
   lainvoimaPaattyen: String

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -1517,8 +1517,8 @@ type KasittelynTila {
   toinenJatkopaatos: Hyvaksymispaatos
   hyvaksymisesitysTraficomiinPaiva: String
   ennakkoneuvotteluPaiva: String
-  nahtavillaAlku: String
-  nahtavillaLoppu: String
+  nahtavillaoloAlkaen: String
+  nahtavillaoloPaattyen: String
   valitustenMaara: Int
   lainvoimaAlkaen: String
   lainvoimaPaattyen: String

--- a/src/components/projekti/lukutila/KasittelynTilaLukutila.tsx
+++ b/src/components/projekti/lukutila/KasittelynTilaLukutila.tsx
@@ -62,8 +62,16 @@ export default function KasittelynTilaLukutila({ projekti }: Readonly<Props>): R
         <div className="grid grid-cols-1 md:grid-cols-4">
           <p className="vayla-label md:col-span-1">Nähtävilläolo alkaen</p>
           <p className="vayla-label md:col-span-3">Nähtävilläolo päättyen</p>
-          <p className="md:col-span-1 mb-0">{formatDateIfExistsAndValidOtherwiseDash(projekti.kasittelynTila?.nahtavillaAlku)}</p>
-          <p className="md:col-span-3 mb-0">{formatDateIfExistsAndValidOtherwiseDash(projekti.kasittelynTila?.nahtavillaLoppu)}</p>
+          <p className="md:col-span-1 mb-0">
+            {formatDateIfExistsAndValidOtherwiseDash(
+              projekti.kasittelynTila?.nahtavillaAlku ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva
+            )}
+          </p>
+          <p className="md:col-span-3 mb-0">
+            {formatDateIfExistsAndValidOtherwiseDash(
+              projekti.kasittelynTila?.nahtavillaLoppu ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva
+            )}
+          </p>
         </div>
       </Section>
       <Section>

--- a/src/components/projekti/lukutila/KasittelynTilaLukutila.tsx
+++ b/src/components/projekti/lukutila/KasittelynTilaLukutila.tsx
@@ -64,12 +64,12 @@ export default function KasittelynTilaLukutila({ projekti }: Readonly<Props>): R
           <p className="vayla-label md:col-span-3">Nähtävilläolo päättyen</p>
           <p className="md:col-span-1 mb-0">
             {formatDateIfExistsAndValidOtherwiseDash(
-              projekti.kasittelynTila?.nahtavillaAlku ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva
+              projekti.kasittelynTila?.nahtavillaoloAlkaen ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva
             )}
           </p>
           <p className="md:col-span-3 mb-0">
             {formatDateIfExistsAndValidOtherwiseDash(
-              projekti.kasittelynTila?.nahtavillaLoppu ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva
+              projekti.kasittelynTila?.nahtavillaoloPaattyen ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva
             )}
           </p>
         </div>

--- a/src/components/projekti/lukutila/KasittelynTilaLukutila.tsx
+++ b/src/components/projekti/lukutila/KasittelynTilaLukutila.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import React, { ReactElement } from "react";
 import Section from "@components/layout/Section";
 import { ProjektiLisatiedolla } from "hassu-common/ProjektiValidationContext";
@@ -54,6 +55,15 @@ export default function KasittelynTilaLukutila({ projekti }: Readonly<Props>): R
           <p className="md:col-span-4 mb-0">
             {formatDateIfExistsAndValidOtherwiseDash(projekti.kasittelynTila?.hyvaksymisesitysTraficomiinPaiva)}
           </p>
+        </div>
+      </Section>
+      <Section>
+        <h3 className="vayla-subtitle">Nähtävilläolo</h3>
+        <div className="grid grid-cols-1 md:grid-cols-4">
+          <p className="vayla-label md:col-span-1">Nähtävilläolo alkaen</p>
+          <p className="vayla-label md:col-span-3">Nähtävilläolo päättyen</p>
+          <p className="md:col-span-1 mb-0">{formatDateIfExistsAndValidOtherwiseDash(projekti.kasittelynTila?.nahtavillaAlku)}</p>
+          <p className="md:col-span-3 mb-0">{formatDateIfExistsAndValidOtherwiseDash(projekti.kasittelynTila?.nahtavillaLoppu)}</p>
         </div>
       </Section>
       <Section>

--- a/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
@@ -202,6 +202,9 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
       kasittelynTila.suunnitelmanTila = projekti.kasittelynTila?.suunnitelmanTila ?? "";
       kasittelynTila.hyvaksymisesitysTraficomiinPaiva = projekti.kasittelynTila?.hyvaksymisesitysTraficomiinPaiva ?? null;
       kasittelynTila.ennakkoneuvotteluPaiva = projekti.kasittelynTila?.ennakkoneuvotteluPaiva ?? null;
+      kasittelynTila.nahtavillaAlku = projekti.kasittelynTila?.nahtavillaAlku ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva ?? null;
+      kasittelynTila.nahtavillaLoppu =
+        projekti.kasittelynTila?.nahtavillaLoppu ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva ?? null;
       kasittelynTila.valitustenMaara = projekti.kasittelynTila?.valitustenMaara ?? null;
       kasittelynTila.lainvoimaAlkaen = projekti.kasittelynTila?.lainvoimaAlkaen ?? null;
       kasittelynTila.lainvoimaPaattyen = projekti.kasittelynTila?.lainvoimaPaattyen ?? null;
@@ -401,6 +404,27 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
                 controllerProps={{ control, name: "kasittelynTila.hyvaksymisesitysTraficomiinPaiva" }}
                 value={parseValidDateOtherwiseReturnNull(projekti.kasittelynTila?.hyvaksymisesitysTraficomiinPaiva)}
                 onChange={() => trigger("kasittelynTila.ennakkotarkastus")}
+              />
+            </HassuGrid>
+          </SectionContent>
+        </Section>
+        <Section>
+          <SectionContent>
+            <H2>Nähtävilläolo</H2>
+            <HassuGrid cols={{ lg: 3 }}>
+              <DatePickerConditionallyInTheForm
+                label="Nähtävilläolo alkaen"
+                includeInForm={projekti.nykyinenKayttaja.onYllapitaja}
+                disabled={disableAdminOnlyFields}
+                controllerProps={{ control, name: "kasittelynTila.nahtavillaAlku" }}
+                value={parseValidDateOtherwiseReturnNull(projekti.kasittelynTila?.nahtavillaAlku)}
+              />
+              <DatePickerConditionallyInTheForm
+                label="Nähtävilläolo päättyen"
+                includeInForm={projekti.nykyinenKayttaja.onYllapitaja}
+                disabled={disableAdminOnlyFields}
+                controllerProps={{ control, name: "kasittelynTila.nahtavillaLoppu" }}
+                value={parseValidDateOtherwiseReturnNull(projekti.kasittelynTila?.nahtavillaLoppu)}
               />
             </HassuGrid>
           </SectionContent>

--- a/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
@@ -202,9 +202,10 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
       kasittelynTila.suunnitelmanTila = projekti.kasittelynTila?.suunnitelmanTila ?? "";
       kasittelynTila.hyvaksymisesitysTraficomiinPaiva = projekti.kasittelynTila?.hyvaksymisesitysTraficomiinPaiva ?? null;
       kasittelynTila.ennakkoneuvotteluPaiva = projekti.kasittelynTila?.ennakkoneuvotteluPaiva ?? null;
-      kasittelynTila.nahtavillaAlku = projekti.kasittelynTila?.nahtavillaAlku ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva ?? null;
-      kasittelynTila.nahtavillaLoppu =
-        projekti.kasittelynTila?.nahtavillaLoppu ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva ?? null;
+      kasittelynTila.nahtavillaoloAlkaen =
+        projekti.kasittelynTila?.nahtavillaoloAlkaen ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva ?? null;
+      kasittelynTila.nahtavillaoloPaattyen =
+        projekti.kasittelynTila?.nahtavillaoloPaattyen ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva ?? null;
       kasittelynTila.valitustenMaara = projekti.kasittelynTila?.valitustenMaara ?? null;
       kasittelynTila.lainvoimaAlkaen = projekti.kasittelynTila?.lainvoimaAlkaen ?? null;
       kasittelynTila.lainvoimaPaattyen = projekti.kasittelynTila?.lainvoimaPaattyen ?? null;
@@ -416,18 +417,18 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
                 label="Nähtävilläolo alkaen"
                 includeInForm={projekti.nykyinenKayttaja.onYllapitaja}
                 disabled={disableAdminOnlyFields}
-                controllerProps={{ control, name: "kasittelynTila.nahtavillaAlku" }}
+                controllerProps={{ control, name: "kasittelynTila.nahtavillaoloAlkaen" }}
                 value={parseValidDateOtherwiseReturnNull(
-                  projekti.kasittelynTila?.nahtavillaAlku ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva
+                  projekti.kasittelynTila?.nahtavillaoloAlkaen ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva
                 )}
               />
               <DatePickerConditionallyInTheForm
                 label="Nähtävilläolo päättyen"
                 includeInForm={projekti.nykyinenKayttaja.onYllapitaja}
                 disabled={disableAdminOnlyFields}
-                controllerProps={{ control, name: "kasittelynTila.nahtavillaLoppu" }}
+                controllerProps={{ control, name: "kasittelynTila.nahtavillaoloPaattyen" }}
                 value={parseValidDateOtherwiseReturnNull(
-                  projekti.kasittelynTila?.nahtavillaLoppu ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva
+                  projekti.kasittelynTila?.nahtavillaoloPaattyen ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva
                 )}
               />
             </HassuGrid>

--- a/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
+++ b/src/pages/yllapito/projekti/[oid]/kasittelyntila.tsx
@@ -417,14 +417,18 @@ function KasittelyntilaPageContent({ projekti, projektiLoadError, reloadProjekti
                 includeInForm={projekti.nykyinenKayttaja.onYllapitaja}
                 disabled={disableAdminOnlyFields}
                 controllerProps={{ control, name: "kasittelynTila.nahtavillaAlku" }}
-                value={parseValidDateOtherwiseReturnNull(projekti.kasittelynTila?.nahtavillaAlku)}
+                value={parseValidDateOtherwiseReturnNull(
+                  projekti.kasittelynTila?.nahtavillaAlku ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusPaiva
+                )}
               />
               <DatePickerConditionallyInTheForm
                 label="Nähtävilläolo päättyen"
                 includeInForm={projekti.nykyinenKayttaja.onYllapitaja}
                 disabled={disableAdminOnlyFields}
                 controllerProps={{ control, name: "kasittelynTila.nahtavillaLoppu" }}
-                value={parseValidDateOtherwiseReturnNull(projekti.kasittelynTila?.nahtavillaLoppu)}
+                value={parseValidDateOtherwiseReturnNull(
+                  projekti.kasittelynTila?.nahtavillaLoppu ?? projekti.nahtavillaoloVaiheJulkaisu?.kuulutusVaihePaattyyPaiva
+                )}
               />
             </HassuGrid>
           </SectionContent>


### PR DESCRIPTION
HASSUYP-764: Nähtävilläolon ajankohdalle päivämääräkentät käsittelyn tila - sivulle ja automaatiolla asettaminen

## Muutoksen kuvaus

Lisätään käsittelyn tilaan kaksi uutta päivämääräkenttää: **Nähtävilläolo alkaen** ja **Nähtävilläolo päättyen**. Kentät esitäytetään automaattisesti nähtävilläolokuulutuksen julkaisun päivämääristä, mutta admin voi muokata niitä jälkikäteen. Arvot synkronoidaan Velhoon käsittelyn tilan tallennuksen yhteydessä.

Uudet kentät ovat tarpeen, koska admin saattaa joutua korjaamaan Velhoon menevää arvoa jälkikäteen ilman että julkaisun alkuperäinen data muuttuu.

## Tekniset muutokset

- `KasittelynTila`-tyyppiin lisätty `nahtavillaoloAlkaen` ja `nahtavillaoloPaattyen`
- GraphQL-skeemaan lisätty kentät sekä `KasittelynTila`-tyypille että `KasittelyntilaInput`-inputille
- `velhoAdapter`: lukee `nahtavilla-olo.alkaen/paattyen` Velhosta ja kirjoittaa ne takaisin tallennuksen yhteydessä
- `nahtavillaoloTilaManager.approve`: päivittää käsittelyn tilan kentät automaattisesti nähtävilläolon hyväksynnän yhteydessä (myös uudelleenkuulutus)
- Käsittelyn tila -lomake: admin näkee date picker -kentät, muut käyttäjät näkevät arvot lukutilassa
- Esitäyttö: jos käsittelyn tilassa ei ole arvoa, näytetään fallbackina julkaisun päivämäärä

## Manuaaliset testausohjeet

Tarvitset projektin, jolla on hyväksytty nähtävilläolokuulutus.

### 1. Lukutila (ei-admin)

1. Kirjaudu ei-admin-käyttäjänä (vaihda `.env.local` tiedostoon `x-hassudev-roles = hassu_kayttaja`)
2. Avaa projektin käsittelyn tila -sivu
3. **Odotus:** "Nähtävilläolo"-osio näkyy sivulla
4. **Odotus:** "Nähtävilläolo alkaen" ja "Nähtävilläolo päättyen" näyttävät kuulutuksen päivämäärät
5. **Odotus:** Kentät ovat vain luku, ei muokattavissa

### 2. Muokkaus ja tallennus (admin)

1. Kirjaudu admin-käyttäjänä (revertoi 1. kohdan `.env.local` tiedoston muutos)
2. Avaa projektin käsittelyn tila -sivu
3. **Odotus:** Nähtävilläolo-osiossa näkyy kaksi date picker -kenttää esitäytettyinä julkaisun päivämäärillä
4. Muuta päivämääriä ja tallenna
5. **Odotus:** Muutetut arvot näkyvät oikein sivun uudelleenlatauksessa
6. **Odotus:** Tallennettu arvo korvaa julkaisun päivämäärän (ei enää fallback julkaisusta)

### 3. Esitäyttö — projekti ilman aiempia käsittelyn tilan arvoja

1. Avaa projekti, jolla on nähtävilläolokuulutus mutta `nahtavillaoloAlkaen`/`nahtavillaoloPaattyen` ei ole aiemmin tallennettu käsittelyn tilaan
2. **Odotus:** Kentät esitäytetään automaattisesti julkaisun `kuulutusPaiva` / `kuulutusVaihePaattyyPaiva` -arvoilla
3. Tallenna ilman muutoksia
4. **Odotus:** Esitäytetyt arvot tallentuvat käsittelyn tilaan

### 4. Automaattinen päivitys nähtävilläolon hyväksynnässä

1. Vie projekti nähtävilläolokuulutuksen hyväksyntää odottavaan tilaan
2. Hyväksy kuulutus
3. **Odotus:** Käsittelyn tilan `nahtavillaoloAlkaen`/`nahtavillaoloPaattyen` päivittyvät automaattisesti hyväksytyn julkaisun päivämääriin

### 5. Velho-synkronointi

1. Kirjaudu admin-käyttäjänä
2. Avaa käsittelyn tila -sivu ja tallenna (arvot voivat olla esitäytetyt tai muokatut)
3. **Odotus:** Velhossa projektin `nahtavilla-olo.alkaen` ja `nahtavilla-olo.paattyen` -kentät päivittyvät tallennettuihin arvoihin


## AI-Assisted: Amazon Q developer, none / suggestions / drafted / generated
