### PR TITLE
feat: HASSUYP-844 - Karttarajaukseen mahdollisuus tuoda alueita useammasta kuin yhdestä tiedostosta

### DIFF
--- a/src/components/projekti/common/KiinteistonOmistajaTiedottaminenMap.tsx
+++ b/src/components/projekti/common/KiinteistonOmistajaTiedottaminenMap.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { styled } from "@mui/system";
 import { DetailedHTMLProps, HTMLAttributes, useRef, useEffect, useMemo, useState, useCallback } from "react";
 import * as ReactDOMServer from "react-dom/server";
@@ -681,7 +682,6 @@ export function getControls({
         }
         return false;
       });
-      source.clear();
       source.addFeatures(suodatetut);
       zoomToExtent(view, source.getExtent());
       const unsupportedGeometryError = errors.some((error) => error instanceof UnsupportedGeometryTypeError);


### PR DESCRIPTION
## Muutos

Karttarajaukseen lisätty mahdollisuus tuoda useita alueita eri GeoJSON-tiedostoista. Aiemmin uuden tiedoston tuominen korvasi olemassa olevan karttarajauksen — nyt uudet alueet lisätään vanhojen rinnalle.


## Muutokset

- `KiinteistonOmistajaTiedottaminenMap.tsx`: Poistettu `source.clear()` kutsu `onGeoJsonUpload`-callbackista

## Testaus

Testaa manuaalisesti selaimessa:
1. Tuo karttarajaus GeoJSON-tiedostosta (Väylän Teamsin kansiossa Testauksen tueksi -> Karttarajauksia löytyy 4 valmista rajausta)
2. Tuo toinen karttarajaus toisesta GeoJSON-tiedostosta
3. Varmista että molemmat alueet näkyvät kartalla yhtä aikaa
4. Varmista että tallentaminen tallentaa molemmat alueet
5. Varmista että yksittäisen alueen poistaminen toimii edelleen

## Huomiot

- Muutos koskee ainoastaan tiedostosta tuontia — piirtotyökaluilla (monikulmio, suorakulmio) on jo aiemmin voinut piirtää useita alueita kartalle
- Yksittäinen GeoJSON-tiedosto voi edelleen sisältää useita geometrioita
- Alueiden määrää ei ole tällä hetkellä rajoitettu frontend- eikä backendissä
- **Jos vaatimus on tarkasti maksimi 2 rajausta, tarvitaan lisävalidointi sekä frontendiin (estä tuonti jos rajauksia on jo 2) että backendiin (validoi GeoJSON-tiedoston geometrioiden määrä ennen tallennusta)**

AI-Assisted: Amazon Q Developer, generated



## AI-Assisted: Amazon Q developer, generated
