### PR TITLE
feat: HASSUYP-693 - Lisätään muistuttajille vapaaehtoinen kiinteistötunnus-kenttä

### DIFF
--- a/backend/integrationtest/api/testUtil/nahtavillaolo.ts
+++ b/backend/integrationtest/api/testUtil/nahtavillaolo.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { api } from "../apiClient";
 import { apiTestFixture } from "../apiTestFixture";
 import {
@@ -146,6 +147,7 @@ export async function testLisaaMuistutusIncrement(
     sahkoposti: "etunimi.sukunimi@org.fi",
     maa: "FI",
     liitteet: [],
+    kiinteistotunnus: "091-1234-0001-0001",
   });
   userFixture.loginAsProjektiKayttaja(projektiPaallikko);
   projekti = await loadProjektiFromDatabase(oid, Status.NAHTAVILLAOLO);

--- a/backend/src/database/model/nahtavillaoloVaihe.ts
+++ b/backend/src/database/model/nahtavillaoloVaihe.ts
@@ -80,4 +80,5 @@ export type Muistutus = {
   liitteet?: string[] | null;
   maakoodi?: string | null;
   puhelinnumero?: string | null;
+  kiinteistotunnus?: string | null;
 };

--- a/backend/src/database/muistuttajaDatabase.ts
+++ b/backend/src/database/muistuttajaDatabase.ts
@@ -38,6 +38,7 @@ export type DBMuistuttaja = {
   maakoodi?: string | null;
   suomifiLahetys?: boolean;
   kaytossa?: boolean;
+  kiinteistotunnus?: string | null;
 };
 
 export type MuistuttajaKey = {

--- a/backend/src/email/emailTemplates.ts
+++ b/backend/src/email/emailTemplates.ts
@@ -11,6 +11,7 @@ import { config } from "../config";
 import { DBEnnakkoNeuvotteluJulkaisu, DBProjekti, DBVaylaUser, Muistutus } from "../database/model";
 import { linkNahtavillaOlo, linkSuunnitteluVaiheYllapito } from "hassu-common/links";
 import { getLocalizedCountryName } from "hassu-common/getLocalizedCountryName";
+import { formatKiinteistotunnusForDisplay } from "hassu-common/util/formatKiinteistotunnus";
 import {
   findHyvaksymisPaatosVaiheWaitingForApproval,
   findJatkoPaatos1VaiheWaitingForApproval,
@@ -495,6 +496,8 @@ Sähköposti
 ${muistutus.sahkoposti ?? ""}
 Puhelinnumero
 ${muistutus.puhelinnumero ?? ""}
+Kiinteistötunnus
+${formatKiinteistotunnusForDisplay(muistutus.kiinteistotunnus)}
 Muistutus
 ${muistutus.muistutus}
 ${muistutusLiiteTeksti ? muistutusLiiteTeksti + "\n" : ""}

--- a/backend/src/mml/tiedotettavatExcel.ts
+++ b/backend/src/mml/tiedotettavatExcel.ts
@@ -19,7 +19,7 @@ import { PathTuple } from "../files/ProjektiPath";
 import { muistuttajaDatabase } from "../database/muistuttajaDatabase";
 import { formatKiinteistotunnusForDisplay } from "hassu-common/util/formatKiinteistotunnus";
 import { getLocalizedCountryName } from "hassu-common/getLocalizedCountryName";
-import { OMISTAJA_EXCEL_HEADERS, OMISTAJA_EXCEL_SHEETS } from "hassu-common/excelConstants";
+import { TIEDOTETTAVA_EXCEL_HEADERS, OMISTAJA_EXCEL_SHEETS } from "hassu-common/excelConstants";
 
 const CONTENT_TYPE_EXCEL = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
@@ -46,7 +46,7 @@ export async function generateExcelByQuery(variables: LataaTiedotettavatExcelQue
 }
 
 function getMuistuttajaColumns(): Columns {
-  return [{ width: 30 }, { width: 30 }, { width: 15 }, { width: 20 }, { width: 20 }, { width: 25 }, { width: 15 }];
+  return [{ width: 20 }, { width: 30 }, { width: 15 }, { width: 20 }, { width: 20 }, { width: 25 }, { width: 15 }];
 }
 
 function getMuistuttajaColumnsWithLahetysaika(): Columns {
@@ -68,6 +68,9 @@ function lisaaMuistuttajaRiviWithLahetysaika(rivi: Rivi): Row {
 function lisaaMuistuttajaRivi(rivi: Rivi): Row {
   auditLog.info("Lisätään muistuttajan tiedot exceliin", { muistuttajaId: rivi.id });
   return [
+    {
+      value: formatKiinteistotunnusForDisplay(rivi.kiinteistotunnus),
+    },
     {
       value: rivi.nimi,
     },
@@ -133,28 +136,28 @@ function lisaaRivi(rivi: Rivi): Row {
 function lisaaOtsikko(): { value: string }[] {
   return [
     {
-      value: OMISTAJA_EXCEL_HEADERS.kiinteistotunnus,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.kiinteistotunnus,
     },
     {
-      value: OMISTAJA_EXCEL_HEADERS.nimi,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.nimiOmistaja,
     },
     {
-      value: OMISTAJA_EXCEL_HEADERS.postiosoite,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.postiosoite,
     },
     {
-      value: OMISTAJA_EXCEL_HEADERS.postinumero,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.postinumero,
     },
     {
-      value: OMISTAJA_EXCEL_HEADERS.postitoimipaikka,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.postitoimipaikka,
     },
     {
-      value: OMISTAJA_EXCEL_HEADERS.maa,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.maa,
     },
     {
-      value: OMISTAJA_EXCEL_HEADERS.tiedotHaettu,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.tiedotHaettu,
     },
     {
-      value: OMISTAJA_EXCEL_HEADERS.tiedotustapa,
+      value: TIEDOTETTAVA_EXCEL_HEADERS.tiedotustapa,
     },
   ];
 }
@@ -163,28 +166,31 @@ function lisaaOtsikkoWithLahetysaika() {
   return lisaaOtsikko().concat({ value: "Lähetysaika" });
 }
 
-function lisaaMuistuttajanOtsikko() {
+function lisaaMuistuttajanOtsikko(): { value: string }[] {
   return [
     {
-      value: "Muistuttajan nimi",
+      value: TIEDOTETTAVA_EXCEL_HEADERS.kiinteistotunnus,
     },
     {
-      value: "Postiosoite",
+      value: TIEDOTETTAVA_EXCEL_HEADERS.nimiMuistuttaja,
     },
     {
-      value: "Postinumero",
+      value: TIEDOTETTAVA_EXCEL_HEADERS.postiosoite,
     },
     {
-      value: "Postitoimipaikka",
+      value: TIEDOTETTAVA_EXCEL_HEADERS.postinumero,
     },
     {
-      value: "Maa",
+      value: TIEDOTETTAVA_EXCEL_HEADERS.postitoimipaikka,
     },
     {
-      value: "Tiedot haettu",
+      value: TIEDOTETTAVA_EXCEL_HEADERS.maa,
     },
     {
-      value: "Tiedotustapa",
+      value: TIEDOTETTAVA_EXCEL_HEADERS.tiedotHaettu,
+    },
+    {
+      value: TIEDOTETTAVA_EXCEL_HEADERS.tiedotustapa,
     },
   ];
 }
@@ -195,7 +201,7 @@ function lisaaMuistuttajanOtsikkoWithLahetysaika() {
 
 type Rivi = {
   id: string;
-  kiinteistotunnus?: string;
+  kiinteistotunnus?: string | null;
   nimi: string;
   postiosoite: string;
   postinumero: string;
@@ -243,6 +249,7 @@ async function haeMuistuttajat(oid: string): Promise<Rivi[]> {
     .map((m) => {
       return {
         id: m.id,
+        kiinteistotunnus: m.kiinteistotunnus,
         nimi: m.nimi ? m.nimi : [m.etunimi, m.sukunimi].filter((n) => !!n).join(" "),
         postiosoite: m.lahiosoite ?? "",
         postinumero: m.postinumero ?? "",

--- a/backend/src/muistutus/muistutusAdapter.ts
+++ b/backend/src/muistutus/muistutusAdapter.ts
@@ -1,6 +1,7 @@
 import { MuistutusInput } from "hassu-common/graphql/apiModel";
 import { Muistutus } from "../database/model";
 import { SuomiFiCognitoKayttaja } from "../user/suomiFiCognitoKayttaja";
+import { formatKiinteistotunnusForDatabase } from "hassu-common/util/formatKiinteistotunnus";
 
 type AdaptMuistutusInputOptions = {
   aikaleima: string;
@@ -33,5 +34,6 @@ export function adaptMuistutusInput({
     postitoimipaikka: muistutusInput.postitoimipaikka,
     sahkoposti: muistutusInput.sahkoposti,
     puhelinnumero: muistutusInput.puhelinnumero,
+    kiinteistotunnus: formatKiinteistotunnusForDatabase(muistutusInput.kiinteistotunnus),
   };
 }

--- a/backend/src/muistutus/muistutusHandler.ts
+++ b/backend/src/muistutus/muistutusHandler.ts
@@ -92,6 +92,7 @@ class MuistutusHandler {
       liitteet: muistutus.liitteet,
       puhelinnumero: muistutus.puhelinnumero,
       kaytossa: true,
+      kiinteistotunnus: muistutus.kiinteistotunnus,
     };
     auditLog.info("Tallennetaan muistuttajan tiedot", { muistuttajaId: muistuttaja.id });
     await getDynamoDBDocumentClient().send(new PutCommand({ TableName: getMuistuttajaTableName(), Item: muistuttaja }));

--- a/backend/src/projektiSearch/muistuttajaSearch/muistuttajaSearchAdapter.ts
+++ b/backend/src/projektiSearch/muistuttajaSearch/muistuttajaSearchAdapter.ts
@@ -19,6 +19,7 @@ export type MuistuttajaDocument = Pick<
   | "suomifiLahetys"
   | "sahkoposti"
   | "kaytossa"
+  | "kiinteistotunnus"
 > & {
   maa: string | null;
   hasTunnus: boolean;
@@ -44,6 +45,7 @@ export function adaptMuistuttajaToIndex({
   kaytossa,
   lahetykset,
   henkilotunnus,
+  kiinteistotunnus,
 }: DBMuistuttaja): MuistuttajaDocument {
   const viimeisinLahetys = lahetykset?.sort((a, b) => b.lahetysaika.localeCompare(a.lahetysaika))[0];
   return {
@@ -64,6 +66,7 @@ export function adaptMuistuttajaToIndex({
     viimeisinLahetysaika: viimeisinLahetys?.lahetysaika ?? null,
     viimeisinTila: viimeisinLahetys?.tila ?? null,
     viimeisinLahetysTapa: viimeisinLahetys?.lahetysTapa ?? null,
+    kiinteistotunnus,
   };
 }
 
@@ -109,6 +112,7 @@ function mapHitToApiMuistuttaja(hit: MuistuttajaDocumentHit) {
     viimeisinLahetysaika: hit._source.viimeisinLahetysaika,
     viimeisinTila: hit._source.viimeisinTila,
     viimeisinLahetysTapa: hit._source.viimeisinLahetysTapa,
+    kiinteistotunnus: hit._source.kiinteistotunnus,
   };
   return dokumentti;
 }

--- a/backend/test/common/formatKiinteistotunnus.test.ts
+++ b/backend/test/common/formatKiinteistotunnus.test.ts
@@ -1,0 +1,63 @@
+import { expect } from "chai";
+import { formatKiinteistotunnusForDatabase, formatKiinteistotunnusForDisplay } from "hassu-common/util/formatKiinteistotunnus";
+
+describe("formatKiinteistotunnus", () => {
+  describe("formatKiinteistotunnusForDatabase", () => {
+    it("should convert display format to database format", () => {
+      expect(formatKiinteistotunnusForDatabase("091-123-0001-0001")).to.equal("09112300010001");
+    });
+
+    it("should pad short parts with leading zeros", () => {
+      expect(formatKiinteistotunnusForDatabase("1-1-1-1")).to.equal("00100100010001");
+      expect(formatKiinteistotunnusForDatabase("740-555-2-0")).to.equal("74055500020000");
+    });
+
+    it("should handle input without leading zeros", () => {
+      expect(formatKiinteistotunnusForDatabase("91-123-1-1")).to.equal("09112300010001");
+    });
+
+    it("should return undefined for empty input", () => {
+      expect(formatKiinteistotunnusForDatabase(undefined)).to.be.undefined;
+      expect(formatKiinteistotunnusForDatabase(null)).to.be.undefined;
+      expect(formatKiinteistotunnusForDatabase("")).to.be.undefined;
+    });
+
+    it("should throw for wrong number of parts", () => {
+      expect(() => formatKiinteistotunnusForDatabase("091-123-0001")).to.throw("Virheellinen kiinteistötunnus");
+      expect(() => formatKiinteistotunnusForDatabase("091-123-0001-0001-0001")).to.throw("Virheellinen kiinteistötunnus");
+    });
+
+    it("should throw for non-numeric parts", () => {
+      expect(() => formatKiinteistotunnusForDatabase("abc-123-0001-0001")).to.throw("Virheellinen kiinteistötunnus");
+      expect(() => formatKiinteistotunnusForDatabase("091-abc-0001-0001")).to.throw("Virheellinen kiinteistötunnus");
+    });
+  });
+
+  describe("formatKiinteistotunnusForDisplay", () => {
+    it("should convert database format to display format", () => {
+      expect(formatKiinteistotunnusForDisplay("09112300010001")).to.equal("91-123-1-1");
+    });
+
+    it("should strip leading zeros in display", () => {
+      expect(formatKiinteistotunnusForDisplay("00100100010001")).to.equal("1-1-1-1");
+      expect(formatKiinteistotunnusForDisplay("74055500020000")).to.equal("740-555-2-0");
+    });
+
+    it("should return empty string for empty input", () => {
+      expect(formatKiinteistotunnusForDisplay(undefined)).to.equal("");
+      expect(formatKiinteistotunnusForDisplay(null)).to.equal("");
+    });
+
+    it("roundtrip: database -> display -> database should be stable", () => {
+      const db = "09112300010001";
+      const display = formatKiinteistotunnusForDisplay(db);
+      expect(formatKiinteistotunnusForDatabase(display)).to.equal(db);
+    });
+
+    it("roundtrip: display -> database -> display should be stable", () => {
+      const display = "91-123-1-1";
+      const db = formatKiinteistotunnusForDatabase(display)!;
+      expect(formatKiinteistotunnusForDisplay(db)).to.equal(display);
+    });
+  });
+});

--- a/backend/test/mml/__snapshots__/tiedotettavatExcel.test.ts.snap
+++ b/backend/test/mml/__snapshots__/tiedotettavatExcel.test.ts.snap
@@ -354,9 +354,11 @@ Array [
     null,
     null,
     null,
+    null,
   ],
   Array [
     "21.02.2024",
+    null,
     null,
     null,
     null,
@@ -372,8 +374,10 @@ Array [
     null,
     null,
     null,
+    null,
   ],
   Array [
+    "Kiinteistötunnus",
     "Muistuttajan nimi",
     "Postiosoite",
     "Postinumero",
@@ -383,6 +387,7 @@ Array [
     "Tiedotustapa",
   ],
   Array [
+    "91-123-1-1",
     "Tytti Testaaja",
     "Osoite 456",
     "02600",
@@ -392,6 +397,7 @@ Array [
     "Suomi.fi",
   ],
   Array [
+    null,
     "Matti Testaaja",
     "Osoite 123",
     "01600",
@@ -413,9 +419,11 @@ Array [
     null,
     null,
     null,
+    null,
   ],
   Array [
     "21.02.2024",
+    null,
     null,
     null,
     null,
@@ -431,8 +439,10 @@ Array [
     null,
     null,
     null,
+    null,
   ],
   Array [
+    "Kiinteistötunnus",
     "Muistuttajan nimi",
     "Postiosoite",
     "Postinumero",
@@ -442,6 +452,7 @@ Array [
     "Tiedotustapa",
   ],
   Array [
+    "740-555-2-0",
     "Teppo Muistuttaja",
     "Muistuttajan osoite",
     "00100",
@@ -641,6 +652,7 @@ Array [
 exports[`tiedotettavatExcel tallenna muistuttajat  excel tiedostoon graphql muut 1`] = `
 Array [
   Array [
+    "Kiinteistötunnus",
     "Muistuttajan nimi",
     "Postiosoite",
     "Postinumero",
@@ -650,6 +662,7 @@ Array [
     "Tiedotustapa",
   ],
   Array [
+    "740-555-2-0",
     "Teppo Muistuttaja",
     "Muistuttajan osoite",
     "00100",
@@ -664,6 +677,7 @@ Array [
 exports[`tiedotettavatExcel tallenna muistuttajat excel tiedostoon graphql Suomi.fi 1`] = `
 Array [
   Array [
+    "Kiinteistötunnus",
     "Muistuttajan nimi",
     "Postiosoite",
     "Postinumero",
@@ -674,6 +688,7 @@ Array [
     "Lähetysaika",
   ],
   Array [
+    "91-123-1-1",
     "Tytti Testaaja",
     "Osoite 456",
     "02600",
@@ -684,6 +699,7 @@ Array [
     "04.11.2024 11:00:00+02:00",
   ],
   Array [
+    null,
     "Matti Testaaja",
     "Osoite 123",
     "01600",
@@ -699,6 +715,7 @@ Array [
 exports[`tiedotettavatExcel tallenna muistuttajat excel tiedostoon graphql kaikki 1`] = `
 Array [
   Array [
+    "Kiinteistötunnus",
     "Muistuttajan nimi",
     "Postiosoite",
     "Postinumero",
@@ -709,6 +726,7 @@ Array [
     "Lähetysaika",
   ],
   Array [
+    "91-123-1-1",
     "Tytti Testaaja",
     "Osoite 456",
     "02600",
@@ -719,6 +737,7 @@ Array [
     "04.11.2024 11:00:00+02:00",
   ],
   Array [
+    null,
     "Matti Testaaja",
     "Osoite 123",
     "01600",
@@ -734,6 +753,7 @@ Array [
 exports[`tiedotettavatExcel tallenna muistuttajat excel tiedostoon graphql kaikki 2`] = `
 Array [
   Array [
+    "Kiinteistötunnus",
     "Muistuttajan nimi",
     "Postiosoite",
     "Postinumero",
@@ -743,6 +763,7 @@ Array [
     "Tiedotustapa",
   ],
   Array [
+    "740-555-2-0",
     "Teppo Muistuttaja",
     "Muistuttajan osoite",
     "00100",

--- a/backend/test/mml/tiedotettavatExcel.test.ts
+++ b/backend/test/mml/tiedotettavatExcel.test.ts
@@ -120,6 +120,7 @@ const muistuttaja1: DBMuistuttaja = {
   postinumero: "02600",
   postitoimipaikka: "Espoo",
   maakoodi: "FI",
+  kiinteistotunnus: "09112300010001",
   suomifiLahetys: true,
   lahetykset: [
     { tila: TiedotettavanLahetyksenTila.VIRHE, lahetysaika: "2024-11-04 09:00:00+02:00" },
@@ -156,6 +157,7 @@ const muistuttaja3: DBMuistuttaja = {
   postinumero: "00100",
   postitoimipaikka: "Helsinki",
   maakoodi: "FI",
+  kiinteistotunnus: "74055500020000",
   tiedotustapa: "Eikös se sähköpostilla",
 };
 describe("tiedotettavatExcel", () => {

--- a/backend/test/muistutus/__snapshots__/muistutusHandler.test.ts.snap
+++ b/backend/test/muistutus/__snapshots__/muistutusHandler.test.ts.snap
@@ -26,6 +26,8 @@ Sähköposti
 test@test.fi
 Puhelinnumero
 0501234567
+Kiinteistötunnus
+
 Muistutus
 Hei. Haluaisin vain muistuttaa, että pihatieni yli täytyy rakentaa silta tai muu ratkaisu
 

--- a/backend/test/muistutus/muistutusHandler.test.ts
+++ b/backend/test/muistutus/muistutusHandler.test.ts
@@ -129,6 +129,31 @@ describe("muistutusHandler", () => {
         expect(updateCommand.args[0].input.ExpressionAttributeNames["#m"]).to.equal("muistuttajat");
       });
 
+      it("should save kiinteistotunnus to database and include it in email", async () => {
+        sinon
+          .stub(muistutusHandler, "getLoggedInUser")
+          .returns({ "custom:hetu": "12123-041212", given_name: "Mika", family_name: "Muistuttaja" } as SuomiFiCognitoKayttaja);
+        const dbMockClient = mockClient(DynamoDBDocumentClient);
+        mockClient(SQSClient);
+        const muistutusInput: MuistutusInput = {
+          katuosoite: "Muistojentie 1 a",
+          postitoimipaikka: "Helsinki",
+          postinumero: "00100",
+          maa: "FI",
+          sahkoposti: "test@test.fi",
+          muistutus: "Testiteksti",
+          liitteet: [],
+          kiinteistotunnus: "091-123-0001-0001",
+        };
+        MockDate.set("2024-04-09T03:00");
+        await muistutusHandler.kasitteleMuistutus({ oid: fixture.PROJEKTI3_OID, muistutus: muistutusInput });
+
+        const m = dbMockClient.commandCalls(PutCommand)[0].args[0].input.Item as DBMuistuttaja;
+        expect(m.kiinteistotunnus).to.equal("09112300010001");
+        const emailText: string = sendTurvapostiEmailStub.getCalls()[0].args[0].text;
+        expect(emailText).to.include("Kiinteistötunnus\n91-123-1-1");
+      });
+
       it("should send emails to kirjaamo and muistuttaja successfully", async () => {
         mockClient(DynamoDBDocumentClient);
         const sqsMock = mockClient(SQSClient);

--- a/common/excelConstants.ts
+++ b/common/excelConstants.ts
@@ -9,9 +9,10 @@
  *
  * If these change, both export and import will stay in sync.
  */
-export const OMISTAJA_EXCEL_HEADERS = {
+export const TIEDOTETTAVA_EXCEL_HEADERS = {
   kiinteistotunnus: "Kiinteistötunnus",
-  nimi: "Omistajan nimi",
+  nimiOmistaja: "Omistajan nimi",
+  nimiMuistuttaja: "Muistuttajan nimi",
   postiosoite: "Postiosoite",
   postinumero: "Postinumero",
   postitoimipaikka: "Postitoimipaikka",
@@ -20,6 +21,9 @@ export const OMISTAJA_EXCEL_HEADERS = {
   tiedotustapa: "Tiedotustapa",
   lahetysaika: "Lähetysaika",
 } as const;
+
+/** @deprecated use TIEDOTETTAVA_EXCEL_HEADERS */
+export const OMISTAJA_EXCEL_HEADERS = TIEDOTETTAVA_EXCEL_HEADERS;
 
 export const OMISTAJA_EXCEL_SHEETS = {
   suomifiKiinteistonomistajat: "Suomi.fi kiinteistönomistajat",

--- a/common/excelConstants.ts
+++ b/common/excelConstants.ts
@@ -22,9 +22,6 @@ export const TIEDOTETTAVA_EXCEL_HEADERS = {
   lahetysaika: "Lähetysaika",
 } as const;
 
-/** @deprecated use TIEDOTETTAVA_EXCEL_HEADERS */
-export const OMISTAJA_EXCEL_HEADERS = TIEDOTETTAVA_EXCEL_HEADERS;
-
 export const OMISTAJA_EXCEL_SHEETS = {
   suomifiKiinteistonomistajat: "Suomi.fi kiinteistönomistajat",
   muutKiinteistonomistajat: "Muut kiinteistönomistajat",

--- a/common/util/formatKiinteistotunnus.ts
+++ b/common/util/formatKiinteistotunnus.ts
@@ -12,7 +12,7 @@ export function formatKiinteistotunnusForDatabase(tunnus?: string | null): strin
   }
   const osienPituudet = [3, 3, 4, 4];
   const tunnusosat = tunnus.split("-");
-  if (tunnusosat.length !== osienPituudet.length && tunnusosat.every((osa) => !isNaN(+osa))) {
+  if (tunnusosat.length !== osienPituudet.length || !tunnusosat.every((osa) => !isNaN(+osa))) {
     throw Error("Virheellinen kiinteistötunnus");
   }
   return osienPituudet.map<string>((osanPituus, index) => tunnusosat[index].padStart(osanPituus, "0")).join("");

--- a/graphql/inputs.graphql
+++ b/graphql/inputs.graphql
@@ -529,6 +529,7 @@ input MuistutusInput {
   maa: String!
   liitteet: [String!]!
   puhelinnumero: String
+  kiinteistotunnus: String
 }
 
 input ListaaLisaAineistoInput {

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -1643,6 +1643,7 @@ type Muistuttaja {
   viimeisinLahetysaika: String
   viimeisinTila: TiedotettavanLahetyksenTila
   viimeisinLahetysTapa: LahetysTapa
+  kiinteistotunnus: String
 }
 
 type Muistuttajat {

--- a/src/components/projekti/kansalaisnakyma/MuistutusLomake.tsx
+++ b/src/components/projekti/kansalaisnakyma/MuistutusLomake.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { Autocomplete, DialogActions, DialogContent, styled, TextField, Typography, useMediaQuery, useTheme } from "@mui/material";
 import React, { ReactElement, useCallback, useMemo, useRef, useState } from "react";
 import Button from "@components/button/Button";
@@ -66,6 +67,7 @@ const getDefaultFormValues: (kayttaja: SuomifiKayttaja | undefined) => Muistutus
     liitteet: [],
     sahkoposti: kayttaja?.email ?? "",
     puhelinnumero: "",
+    kiinteistotunnus: "",
   };
 };
 
@@ -286,6 +288,10 @@ export default function MuistutusLomake({ projekti, nahtavillaolo, kayttaja }: R
               <TextFieldWithController
                 controllerProps={{ control, name: "puhelinnumero", constructErrorMessage }}
                 label={t("common:puhelinnumero")}
+              />
+              <TextFieldWithController
+                controllerProps={{ control, name: "kiinteistotunnus", constructErrorMessage }}
+                label={t("projekti:muistutuslomake.kiinteistotunnus")}
               />
             </HassuGrid>
           </HassuStack>

--- a/src/locales/fi/common.json
+++ b/src/locales/fi/common.json
@@ -223,7 +223,8 @@
     "puh_vain_numerot": "Puhelinnumero voi sisältää vain numeroita",
     "tiedosto_on_liian_suuri": "Tiedosto on liian suuri",
     "tiedostotyyppi_ei_tuettu": "Tiedostotyyppi ei ole tuettu",
-    "tiedostoja_liikaa": "Tiedostoja voi olla maksimissaan viisi"
+    "tiedostoja_liikaa": "Tiedostoja voi olla maksimissaan viisi",
+    "anna_kiinteistotunnus_esitysmuodossa": "Anna kiinteistötunnus muodossa 740-555-2-0"
   },
   "ilmoitukset": {
     "tallennus_onnistui": "Tallennus onnistui",

--- a/src/locales/fi/common.json
+++ b/src/locales/fi/common.json
@@ -224,7 +224,7 @@
     "tiedosto_on_liian_suuri": "Tiedosto on liian suuri",
     "tiedostotyyppi_ei_tuettu": "Tiedostotyyppi ei ole tuettu",
     "tiedostoja_liikaa": "Tiedostoja voi olla maksimissaan viisi",
-    "anna_kiinteistotunnus_esitysmuodossa": "Anna kiinteistötunnus muodossa 740-555-2-0"
+    "anna_kiinteistotunnus_esitysmuodossa": "Tarkista kiinteistötunnuksen muoto, esim. 740-555-2-0"
   },
   "ilmoitukset": {
     "tallennus_onnistui": "Tallennus onnistui",

--- a/src/locales/fi/projekti.json
+++ b/src/locales/fi/projekti.json
@@ -229,7 +229,8 @@
     "kerro_kayttokokemuksestasi": "Kerro käyttökokemuksestasi",
     "kerro_kayttokokemuksestasi_vastaa_kyselyyn": "Vastaa lyhyeen kyselyyn Valtion liikenneväylien suunnittelu -palvelusta.",
     "kerro_kayttokokemuksestasi_saatu_palaute": "Saatu palaute auttaa kehittämään palvelua.",
-    "kerro_kayttokokemuksestasi_linkki": "KYSELYYN"
+    "kerro_kayttokokemuksestasi_linkki": "KYSELYYN",
+    "kiinteistotunnus": "Kiinteistötunnus"
   },
   "asiakirja": {
     "aloituskuulutus": {

--- a/src/locales/sv/common.json
+++ b/src/locales/sv/common.json
@@ -224,7 +224,7 @@
     "tiedosto_on_liian_suuri": "Filen är för stor",
     "tiedostotyyppi_ei_tuettu": "Filtypen stöds inte",
     "tiedostoja_liikaa": "Det kan vara högst fem filer",
-    "anna_kiinteistotunnus_esitysmuodossa": "Ange fastighetsbeteckning i formatet 740-555-2-0"
+    "anna_kiinteistotunnus_esitysmuodossa": "Fastighetsbeteckningen har fel format, t.ex. 740-555-2-0"
   },
   "ilmoitukset": {
     "tallennus_onnistui": "Sparningen lyckades",

--- a/src/locales/sv/common.json
+++ b/src/locales/sv/common.json
@@ -223,7 +223,8 @@
     "puh_vain_numerot": "Ett telefonnummer kan bara innehålla nummer",
     "tiedosto_on_liian_suuri": "Filen är för stor",
     "tiedostotyyppi_ei_tuettu": "Filtypen stöds inte",
-    "tiedostoja_liikaa": "Det kan vara högst fem filer"
+    "tiedostoja_liikaa": "Det kan vara högst fem filer",
+    "anna_kiinteistotunnus_esitysmuodossa": "Ange fastighetsbeteckning i formatet 740-555-2-0"
   },
   "ilmoitukset": {
     "tallennus_onnistui": "Sparningen lyckades",

--- a/src/locales/sv/projekti.json
+++ b/src/locales/sv/projekti.json
@@ -228,7 +228,8 @@
     "kerro_kayttokokemuksestasi": "Berätta om dina erfarenheter av att använda tjänsten",
     "kerro_kayttokokemuksestasi_vastaa_kyselyyn": "Svara på en kort enkät om tjänsten Planering av statens trafikleder.",
     "kerro_kayttokokemuksestasi_saatu_palaute": "Responsen hjälper oss att utveckla tjänsten.",
-    "kerro_kayttokokemuksestasi_linkki": "TILL ENKÄT"
+    "kerro_kayttokokemuksestasi_linkki": "TILL ENKÄT",
+    "kiinteistotunnus": "Fastighetsbeteckning"
   },
   "asiakirja": {
     "aloituskuulutus": {

--- a/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
@@ -8,6 +8,7 @@ import { H2 } from "@components/Headings";
 import ContentSpacer from "@components/layout/ContentSpacer";
 import { Stack } from "@mui/system";
 import { GrayBackgroundText } from "@components/projekti/GrayBackgroundText";
+import { formatKiinteistotunnusForDisplay } from "common/util/formatKiinteistotunnus";
 import { useProjektinTiedottaminen } from "src/hooks/useProjektinTiedottaminen";
 import TiedotettavaHaitari, { GetTiedotettavaFunc } from "@components/projekti/tiedottaminen/TiedotettavaHaitari";
 import { Muistuttaja } from "@services/api";
@@ -31,6 +32,7 @@ const columnsSuomifi: ColumnDef<Muistuttaja>[] = [
     header: "Kiinteistötunnus",
     accessorKey: "kiinteistotunnus",
     id: "kiinteistotunnus_suomifi",
+    cell: (info) => formatKiinteistotunnusForDisplay(info.getValue<string>()),
     meta: {
       widthFractions: 2,
       minWidth: 140,
@@ -88,6 +90,7 @@ const columnsMuut: ColumnDef<Muistuttaja>[] = [
     header: "Kiinteistötunnus",
     accessorKey: "kiinteistotunnus",
     id: "kiinteistotunnus_muut",
+    cell: (info) => formatKiinteistotunnusForDisplay(info.getValue<string>()),
     meta: {
       widthFractions: 2,
       minWidth: 140,

--- a/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
@@ -30,9 +30,8 @@ export default function Muistuttajat() {
 const columnsSuomifi: ColumnDef<Muistuttaja>[] = [
   {
     header: "Kiinteistötunnus",
-    accessorKey: "kiinteistotunnus",
+    accessorFn: (row) => formatKiinteistotunnusForDisplay(row.kiinteistotunnus),
     id: "kiinteistotunnus_suomifi",
-    cell: (info) => formatKiinteistotunnusForDisplay(info.getValue<string>()),
     meta: {
       widthFractions: 2,
       minWidth: 140,
@@ -88,9 +87,8 @@ const columnsSuomifi: ColumnDef<Muistuttaja>[] = [
 const columnsMuut: ColumnDef<Muistuttaja>[] = [
   {
     header: "Kiinteistötunnus",
-    accessorKey: "kiinteistotunnus",
+    accessorFn: (row) => formatKiinteistotunnusForDisplay(row.kiinteistotunnus),
     id: "kiinteistotunnus_muut",
-    cell: (info) => formatKiinteistotunnusForDisplay(info.getValue<string>()),
     meta: {
       widthFractions: 2,
       minWidth: 140,

--- a/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
+++ b/src/pages/yllapito/projekti/[oid]/tiedottaminen/muistuttajat/index.tsx
@@ -28,6 +28,15 @@ export default function Muistuttajat() {
 
 const columnsSuomifi: ColumnDef<Muistuttaja>[] = [
   {
+    header: "Kiinteistötunnus",
+    accessorKey: "kiinteistotunnus",
+    id: "kiinteistotunnus_suomifi",
+    meta: {
+      widthFractions: 2,
+      minWidth: 140,
+    },
+  },
+  {
     header: "Nimi",
     accessorKey: "nimi",
     id: "muistuttajan_nimi",
@@ -75,6 +84,15 @@ const columnsSuomifi: ColumnDef<Muistuttaja>[] = [
 ];
 
 const columnsMuut: ColumnDef<Muistuttaja>[] = [
+  {
+    header: "Kiinteistötunnus",
+    accessorKey: "kiinteistotunnus",
+    id: "kiinteistotunnus_muut",
+    meta: {
+      widthFractions: 2,
+      minWidth: 140,
+    },
+  },
   {
     header: "Nimi",
     accessorKey: "nimi",

--- a/src/schemas/nahtavillaoloMuistutus.ts
+++ b/src/schemas/nahtavillaoloMuistutus.ts
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 import { allowedFileTypesKansalaisille, maxFileSize } from "common/fileValidationSettings";
 import * as Yup from "yup";
 import { phoneNumberRegex } from "hassu-common/schema/puhelinNumero";
@@ -18,4 +19,10 @@ export const muistutusSchema = Yup.object().shape({
     })
   ),
   puhelinnumero: Yup.string().notRequired().matches(new RegExp(phoneNumberRegex), "puh_vain_numerot").max(20, "puh_max_20").nullable(),
+  kiinteistotunnus: Yup.string()
+    .notRequired()
+    .nullable()
+    .test("is-valid-kiinteistotunnus", "anna_kiinteistotunnus_esitysmuodossa", (value) =>
+      !value ? true : /^\d{1,3}-\d{1,3}-\d{1,4}-\d{1,4}$/.test(value)
+    ),
 });

--- a/src/util/excelImport.ts
+++ b/src/util/excelImport.ts
@@ -1,5 +1,5 @@
 // Contains code generated or recommended by Amazon Q
-import { OMISTAJA_EXCEL_HEADERS } from "common/excelConstants";
+import { TIEDOTETTAVA_EXCEL_HEADERS } from "common/excelConstants";
 import { OMISTAJA_EXCEL_SHEETS } from "common/excelConstants";
 import lookup from "country-code-lookup";
 
@@ -14,18 +14,18 @@ export type ExcelColumnIndices = {
 };
 
 export function findColumnIndices(rows: unknown[][]): ExcelColumnIndices | null {
-  const headerRow = rows.find((row) => row.some((cell) => String(cell ?? "").trim() === OMISTAJA_EXCEL_HEADERS.kiinteistotunnus));
+  const headerRow = rows.find((row) => row.some((cell) => String(cell ?? "").trim() === TIEDOTETTAVA_EXCEL_HEADERS.kiinteistotunnus));
   if (!headerRow) {
     return null;
   }
   const indexOf = (header: string) => headerRow.findIndex((cell) => String(cell ?? "").trim() === header);
   return {
-    kiinteistotunnus: indexOf(OMISTAJA_EXCEL_HEADERS.kiinteistotunnus),
-    nimi: indexOf(OMISTAJA_EXCEL_HEADERS.nimi),
-    postiosoite: indexOf(OMISTAJA_EXCEL_HEADERS.postiosoite),
-    postinumero: indexOf(OMISTAJA_EXCEL_HEADERS.postinumero),
-    postitoimipaikka: indexOf(OMISTAJA_EXCEL_HEADERS.postitoimipaikka),
-    maa: indexOf(OMISTAJA_EXCEL_HEADERS.maa),
+    kiinteistotunnus: indexOf(TIEDOTETTAVA_EXCEL_HEADERS.kiinteistotunnus),
+    nimi: indexOf(TIEDOTETTAVA_EXCEL_HEADERS.nimiOmistaja),
+    postiosoite: indexOf(TIEDOTETTAVA_EXCEL_HEADERS.postiosoite),
+    postinumero: indexOf(TIEDOTETTAVA_EXCEL_HEADERS.postinumero),
+    postitoimipaikka: indexOf(TIEDOTETTAVA_EXCEL_HEADERS.postitoimipaikka),
+    maa: indexOf(TIEDOTETTAVA_EXCEL_HEADERS.maa),
     headerRowIndex: rows.indexOf(headerRow),
   };
 }


### PR DESCRIPTION
## Yhteenveto

Lisätty valinnainen kiinteistötunnus-kenttä muistutuslomakkeelle. Tunnus tallennetaan tietokantamuodossa (14 merkkiä, esim. `09112300010001`) ja näytetään käyttäjälle näyttömuodossa (esim. `91-123-1-1`) kaikkialla: UI-listauksessa, excel-viennissä ja sähköpostissa. Päädytty käyttämään tietokanta-näyttömuotoja, koska kiinteistönomistajien osalta kiinteistötunnukset käsitellään näin.

## Muutokset

### Uusi toiminnallisuus

- **Muistutuslomake** (`MuistutusLomake.tsx`): Uusi valinnainen kiinteistötunnus-kenttä. Validointi regex-pohjaisesti muodossa `xxx-xxx-xxxx-xxxx` (esim. `91-123-1-1`). Virheviesti: "Tarkista kiinteistötunnuksen muoto, esim. 740-555-2-0".
- **GraphQL-skeema** (`inputs.graphql`, `types.graphql`): `kiinteistotunnus`-kenttä lisätty `MuistutusInput`- ja `Muistuttaja`-tyyppeihin.
- **Tietomalli** (`nahtavillaoloVaihe.ts`, `muistuttajaDatabase.ts`): Kenttä lisätty DynamoDB-malliin.
- **Muistuttajien listaus** (`muistuttajat/index.tsx`): Kiinteistötunnus ensimmäisenä sarakkeena molemmissa taulukoissa (Suomi.fi-tunnistautuneet ja muut). Tyhjä arvo näkyy automaattisesti `-`.
- **Excel-vienti** (`tiedotettavatExcel.ts`): Kiinteistötunnus lisätty muistuttajien sarakkeisiin (7 saraketta aiemman 6:n sijaan). Sama sarake näkyy sekä käyttäjän lataamassa excelissä että hyväksymispäätösvaiheessa S3:een tallennettavassa excelissä.
- **Sähköposti** (`emailTemplates.ts`): Kiinteistötunnus näytetään kirjaamolle lähetettävässä sähköpostissa näyttömuodossa.

### TODO
- Varmistettava (Elinalta), että näytetäänkö lomakkeella teksti `Kiinteistötunnus` vai `Kiinteistötunnus, johon muistutus liittyy`? Jälkimmäinen oli vaihtoehtoisena nimenä tiketillä
- Onko lomakkeen validoinnin virheviesti `Tarkista kiinteistötunnuksen muoto, esim. 740-555-2-0` ja sen käännös ok vai vaatiiko viilausta? Näille ei määritystä tiketillä.

### Tekninen velka / bugikorjaukset

- **Yhtenäinen tallennusmuoto**: `muistutusAdapter.ts` muuntaa käyttäjän syöttämän näyttömuodon tietokantamuotoon `formatKiinteistotunnusForDatabase`:lla ennen tallennusta.
- **`formatKiinteistotunnusForDatabase` bugikorjaus**: Validointiehdon `&&` korjattu `||`:ksi — virhe heitetään nyt oikein jos osia on väärä määrä TAI jokin osa ei ole numero.
- **`TIEDOTETTAVA_EXCEL_HEADERS`**: `OMISTAJA_EXCEL_HEADERS` nimetty uudelleen kuvaamaan paremmin sisältöä (sisältää sekä omistajat että muistuttajat). 

### Testit

- **Uusi testitiedosto** `backend/test/common/formatKiinteistotunnus.test.ts`: 11 yksikkötestiä kattaen muunnokset molempiin suuntiin, etunollat, tyhjät syötteet, virheelliset syötteet ja roundtrip-symmetrian.
- **`muistutusHandler.test.ts`**: Testi varmistaa että kiinteistötunnus tallennetaan tietokantamuodossa ja näkyy sähköpostissa näyttömuodossa.
- **`tiedotettavatExcel.test.ts`**: Snapshot päivitetty vastaamaan uutta sarakerakennetta.

## Taaksepäin yhteensopivuus

Vanhat muistuttajat joilla ei ole kiinteistötunnusta toimivat normaalisti — `undefined`/`null` näkyy tyhjänä (`-`) UI:ssa ja tyhjänä soluna excelissä. Mikään ei kaadu.

---

## Manuaalitestausohjeet

### Esitiedot

- Tarvitset projektin joka on nähtävilläolovaiheessa ja kuulutus on julkaistu (jotta muistutuslomake on auki kansalaisille).
- Tarvitset virkamiestunnukset muistuttajien listaukseen ja excel-vientiin.

### 1. Muistutuslomake — kiinteistötunnus-kenttä

1. Avaa projektin kansalaisnäkymä nähtävilläolovaiheessa.
2. Täytä muistutuslomake. Kiinteistötunnus-kenttä on valinnainen.
3. **Validointi — virheellinen muoto**: Syötä `123456` → pitäisi näyttää virhe "Tarkista kiinteistötunnuksen muoto, esim. 740-555-2-0".
4. **Validointi — oikea muoto**: Syötä `91-123-1-1` → virhe häviää.
5. Lähetä muistutus.

### 2. Muistuttajien listaus virkamiesnäkymässä

1. Avaa projekti virkamiesnäkymässä → Tiedottaminen → Muistuttajat.
2. Tarkista että kiinteistötunnus näkyy ensimmäisenä sarakkeena molemmissa taulukoissa.
3. Äsken lähetetyn muistutuksen kiinteistötunnus pitäisi näkyä näyttömuodossa (`91-123-1-1`), ei tietokantamuodossa (`09112300010001`).
4. Muistuttajalla jolla ei ole kiinteistötunnusta pitäisi näkyä `-`.

### 3. Excel-vienti

1. Samalla Muistuttajat-sivulla klikkaa "Lataa Excel".
2. Avaa ladattu Excel.
3. Muistuttajat-välilehdellä pitäisi olla kiinteistötunnus-sarake ensimmäisenä.
4. Kiinteistötunnus pitäisi näkyä näyttömuodossa (`91-123-1-1`).
5. Muistuttajalla ilman kiinteistötunnusta solu on tyhjä.

### 4. Sähköposti kirjaamolle

1. Lähetä muistutus kiinteistötunnuksella (kohta 1).
2. Tarkista kirjaamolle lähtenyt sähköposti.
3. Kiinteistötunnus pitäisi näkyä näyttömuodossa (`91-123-1-1`).

### 5. Ruotsinkielinen lomake

1. Vaihda kieli ruotsiksi.
2. Tarkista että kiinteistötunnus-kenttä ja sen virheviesti näkyvät ruotsiksi.



## AI-Assisted: Amazon Q developer, generated
