### PR TITLE
fix: HASSUYP-883 - Nosta Lambda Layerit uusimpaan versioon

### DIFF
--- a/deployment/lib/hassu-account.ts
+++ b/deployment/lib/hassu-account.ts
@@ -101,7 +101,7 @@ export class HassuAccountStack extends Stack {
       vpc,
       tracing: Tracing.ACTIVE,
       insightsVersion: LambdaInsightsVersion.fromInsightVersionArn(
-        "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:64"
+        "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:66"
       ),
       layers: [
         new LayerVersion(this, "BaseLayer-" + Config.env, {

--- a/deployment/lib/hassu-account.ts
+++ b/deployment/lib/hassu-account.ts
@@ -112,7 +112,7 @@ export class HassuAccountStack extends Stack {
         LayerVersion.fromLayerVersionArn(
           this,
           "paramLayer",
-          "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:82"
+          "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:90"
         ),
       ],
       logRetention: RetentionDays.SEVEN_YEARS,

--- a/deployment/lib/hassu-backend.ts
+++ b/deployment/lib/hassu-backend.ts
@@ -35,7 +35,7 @@ import { RetentionDays } from "aws-cdk-lib/aws-logs";
 
 const lambdaRuntime = lambda.Runtime.NODEJS_22_X;
 const insightsVersion = LambdaInsightsVersion.fromInsightVersionArn(
-  "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:64"
+  "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension:66"
 );
 // layers/lambda-base valmiiksi asennetut kirjastot
 const externalModules = ["aws-xray-sdk-core", "nodemailer", "@aws-sdk/*"];
@@ -97,7 +97,7 @@ export class HassuBackendStack extends Stack {
       LayerVersion.fromLayerVersionArn(
         this,
         "paramLayer",
-        "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:82"
+        "arn:aws:lambda:eu-west-1:015030872274:layer:AWS-Parameters-and-Secrets-Lambda-Extension:90"
       ),
     ];
   }


### PR DESCRIPTION
# TODO

Ennen mergeä:
- varmista että onko layereista julkaistu uudempaa versiota https://docs.aws.amazon.com/systems-manager/latest/userguide/ps-integration-lambda-extensions.html#ps-integration-lambda-extensions-add ja https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versionsx86-64.html. Jos niin päivitä niihin. Huom region Europe (Ireland) ja arkkitehtuuri x86_64.
- Mergeä ensin hassu-asianhallinta repon vastaava PR https://github.com/finnishtransportagency/hassu-asianhallinta/pull/72 ja nosta sitten uudessa commitissa ashan versiota package.jsoniin ja aja `npm i` 
- Kun tämä mergetty mainiin tulee ajaa `npm run deploy:account:dev`, koska muutoksia account-stackissa olevaan lambdaan. Ja tuotantoon viennin yhteydessä tulee ajaa `npm run deploy:account:prod`


## AI-Assisted: Amazon Q developer, none
