### PR TITLE
fix: HASSUYP-834 VideolinkParseri refaktoroitu

### DIFF
--- a/src/__tests__/VideoParser.test.tsx
+++ b/src/__tests__/VideoParser.test.tsx
@@ -1,3 +1,4 @@
+// Contains code generated or recommended by Amazon Q
 /**
  * @jest-environment jsdom
  */
@@ -11,10 +12,10 @@ describe("VideoParser", () => {
     expect(embeddedURL).toMatchSnapshot();
   });
 
-  it("accepts youtube urls with v query parameters only", () => {
-    const url = "https://youtu.be/dQw4w9WgXcQ";
+  it("accepts youtube short urls (youtu.be)", () => {
+    const url = "https://youtu.be/jNQXAC9IVRw?si=1EAXh4PILmvrGXXS";
     const embeddedURL = parseVideoURL(url);
-    expect(embeddedURL).toBeUndefined();
+    expect(embeddedURL).toMatchSnapshot();
   });
 
   it("returns embedded vimeo urls correctly", () => {

--- a/src/__tests__/__snapshots__/VideoParser.test.tsx.snap
+++ b/src/__tests__/__snapshots__/VideoParser.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`VideoParser accepts youtube short urls (youtu.be) 1`] = `"https://www.youtube.com/embed/jNQXAC9IVRw"`;
+
 exports[`VideoParser returns embedded vimeo urls correctly 1`] = `"https://player.vimeo.com/video/76979871"`;
 
 exports[`VideoParser returns embedded youtube urls correctly 1`] = `"https://www.youtube.com/embed/jNQXAC9IVRw"`;

--- a/src/util/videoParser.ts
+++ b/src/util/videoParser.ts
@@ -1,23 +1,31 @@
+// Contains code generated or recommended by Amazon Q
 const youtubeBaseURL = "https://www.youtube.com/embed/";
 const vimeoBaseURL = "https://player.vimeo.com/video/";
+
+const YOUTUBE_HOSTNAMES = new Set(["www.youtube.com", "youtube.com", "m.youtube.com", "youtu.be"]);
+const VIMEO_HOSTNAMES = new Set(["vimeo.com", "www.vimeo.com"]);
+
 export const parseVideoURL = (url: string): string | undefined => {
-  if (!url) {
+  if (!url) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
     return undefined;
   }
-  if (url.includes("youtube")) {
-    const youtubeID = url.split("v=")?.[1];
-    return youtubeID ? youtubeBaseURL.concat(youtubeID) : undefined;
-  } else if (url.includes("vimeo")) {
-    const lastIndex = url.lastIndexOf("/");
-    if (lastIndex < 0) {
-      return undefined;
-    }
-    const vimeoID = url.substring(lastIndex + 1);
-    if (isNaN(Number(vimeoID))) {
-      return undefined;
-    }
-    return vimeoBaseURL.concat(vimeoID);
+
+  const { hostname, pathname, searchParams } = parsed;
+
+  if (YOUTUBE_HOSTNAMES.has(hostname)) {
+    const videoId = hostname === "youtu.be" ? pathname.slice(1).split("?")[0] : (searchParams.get("v") ?? undefined);
+    return videoId ? youtubeBaseURL + videoId : undefined;
   }
-  // not supported yet
+
+  if (VIMEO_HOSTNAMES.has(hostname)) {
+    const lastSegment = pathname.split("/").filter(Boolean).pop();
+    return lastSegment && !isNaN(Number(lastSegment)) ? vimeoBaseURL + lastSegment : undefined;
+  }
+
   return undefined;
 };


### PR DESCRIPTION
## Muutokset
VideolinkParseri refaktoroitu. Tukee nyt huomioon useampia hostname -muotoja. Esim. youtube.com youtu.be, m.youtube.com.

## AI-Assisted: Amazon Q developer, generated
