### PR TITLE
fix: HASSUYP-894 - Käsittelyn tila päivittymään automaatiolla: ennakkotarkastus / ennakkoneuvottelu

### DIFF
--- a/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
+++ b/src/__tests__/util/asetaKasittelynTilaAutomaatiolla.test.ts
@@ -181,6 +181,80 @@ describe("asetaKasittelynTilaAutomaatiolla", () => {
     expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil14");
   });
 
+  describe("Ennakkotarkastus/Ennakkoneuvottelu (sutil02)", () => {
+    it("asettaa sutil02 kun ennakkotarkastus muuttuu ja tila on sutil01", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.ennakkotarkastus = "2024-03-01";
+      data.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil01";
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil01";
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil02");
+    });
+
+    it("asettaa sutil02 kun ennakkoneuvottelu muuttuu ja tila on sutil13", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.ennakkoneuvotteluPaiva = "2024-03-01";
+      data.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil13";
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil13";
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil02");
+    });
+
+    it("asettaa sutil02 kun tila on null (ei asetettu)", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.ennakkotarkastus = "2024-03-01";
+      const defaults = baseFormValues();
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil02");
+    });
+
+    it("ei muuta tilaa kun ennakkotarkastus muuttuu mutta tila on jokin muu (esim. sutil04)", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.ennakkotarkastus = "2024-03-01";
+      data.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil04";
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil04";
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil04");
+    });
+
+    it("ei muuta tilaa kun päivämäärä ei muutu", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.ennakkotarkastus = "2024-03-01";
+      data.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil01";
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.ennakkotarkastus = "2024-03-01";
+      defaults.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil01";
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil01");
+    });
+
+    it("ei muuta tilaa kun päivämäärä muuttuu mutta kenttä on tyhjä", () => {
+      const data = baseFormValues();
+      data.kasittelynTila!.ennakkotarkastus = null;
+      data.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil01";
+      const defaults = baseFormValues();
+      defaults.kasittelynTila!.ennakkotarkastus = "2024-03-01";
+      defaults.kasittelynTila!.suunnitelmanTila = "suunnitelman-tila/sutil01";
+
+      asetaKasittelynTilaAutomaatiolla(data, defaults, true, false);
+
+      expect(data.kasittelynTila!.suunnitelmanTila).toBe("suunnitelman-tila/sutil01");
+    });
+  });
+
   it("ei muuta tilaa kun mitään ei muuteta", () => {
     const data = baseFormValues();
     const defaults = baseFormValues();

--- a/src/util/asetaKasittelynTilaAutomaatiolla.ts
+++ b/src/util/asetaKasittelynTilaAutomaatiolla.ts
@@ -7,6 +7,22 @@ export const asetaKasittelynTilaAutomaatiolla = (
   onYllapitaja: boolean,
   hyvaksymispaatosAktiivinen: boolean
 ) => {
+  const SUTIL02_ELIGIBLE = new Set(["suunnitelman-tila/sutil01", "suunnitelman-tila/sutil13"]);
+  const currentTila = data.kasittelynTila?.suunnitelmanTila ?? null;
+  const ennakkotarkastusChanged =
+    (data.kasittelynTila?.ennakkotarkastus ?? null) !== (defaults.kasittelynTila?.ennakkotarkastus ?? null);
+  const ennakkoneuvotteluChanged =
+    (data.kasittelynTila?.ennakkoneuvotteluPaiva ?? null) !== (defaults.kasittelynTila?.ennakkoneuvotteluPaiva ?? null);
+  const ennakkoPvmTaytetty = !!(data.kasittelynTila?.ennakkotarkastus || data.kasittelynTila?.ennakkoneuvotteluPaiva);
+  if (
+    (ennakkotarkastusChanged || ennakkoneuvotteluChanged) &&
+    ennakkoPvmTaytetty &&
+    (!currentTila || SUTIL02_ELIGIBLE.has(currentTila))
+  ) {
+    data.kasittelynTila ??= {};
+    data.kasittelynTila.suunnitelmanTila = "suunnitelman-tila/sutil02";
+  }
+
   const asianumeroChanged =
     (data.kasittelynTila?.hyvaksymispaatos?.asianumero ?? null) !== defaults?.kasittelynTila?.hyvaksymispaatos?.asianumero;
   const hyvaksymisPvmChanged =


### PR DESCRIPTION
Muutokset
asetaKasittelynTilaAutomaatiolla.ts — lisätty uusi tarkistus funktion alkuun (ennen muita automaatioita):

Jos ennakkotarkastus tai ennakkoneuvotteluPaiva muuttuu ja uusi arvo on täytetty ja nykyinen tila on sutil01, sutil13 tai null → asetetaan sutil02

Sijoitettu ennen muita automaatioita, joten esim. jos samalla tallennuksella täytetään sekä ennakkotarkastus että hyväksymispäätös, sutil04 ylikirjoittaa sutil02:n (mikä on oikein)

asetaKasittelynTilaAutomaatiolla.test.ts — lisätty 6 testiä kattamaan kaikki tapaukset.


AI-Assisted: Amazon Q developer, generated
