### PR TITLE
fix: HASSUYP-757-korjaus Lisää try-catch, jotta kirjaamomeilin epäonnistuminen ei estä muistutusta

### DIFF
--- a/backend/src/muistutus/muistutusHandler.ts
+++ b/backend/src/muistutus/muistutusHandler.ts
@@ -96,7 +96,11 @@ class MuistutusHandler {
     auditLog.info("Tallennetaan muistuttajan tiedot", { muistuttajaId: muistuttaja.id });
     await getDynamoDBDocumentClient().send(new PutCommand({ TableName: getMuistuttajaTableName(), Item: muistuttaja }));
     await projektiDatabase.appendMuistuttajatList(oid, [muistuttaja.id], !henkilotunnus);
-    await muistutusEmailService.sendEmailToKirjaamo(projektiFromDB, muistutus);
+    try {
+      await muistutusEmailService.sendEmailToKirjaamo(projektiFromDB, muistutus);
+    } catch (e) {
+      log.error("Muistutuksen lähetys kirjaamoon epäonnistui", e);
+    }
     const msg: SuomiFiSanoma = {
       oid,
       muistuttajaId: muistuttaja.id,


### PR DESCRIPTION
## Muutokset
HASSUYP-757 lisättiin logitusta, jotta saatiin parempi näkyvyys kirjaamoon epäonnistuneista sähköposteista. Tämä kuitenkin esti kokonaan muistutuksen tallentumisen kansalaispuolella, jos meilin lähetys kirjaamoon ei onnistu syystä tai toisesta. Lisättiin try-catch, jotta muistutus kuitenkin tallentuu sähköpostivirheestä huolimatta.

## AI-Assisted: Amazon Q developer, generated
