### PR TITLE
fix: HASSUYP-845-korjaus Virkamiespuolen navigaatiolle itsenäinen scrollaus

### DIFF
--- a/src/components/projekti/ProjektiPageLayout.tsx
+++ b/src/components/projekti/ProjektiPageLayout.tsx
@@ -96,9 +96,24 @@ export default function ProjektiPageLayout({ children, title, contentAsideTitle,
         <div className="flex flex-col md:flex-row gap-8 mb-3">
           <div
             data-sidebar
-            style={{ minWidth: "345px", ...(!isMobile && { position: "sticky", top: sidebarTop, alignSelf: "flex-start" }) }}
+            style={{
+              minWidth: "345px",
+              ...(!isMobile && {
+                position: "sticky",
+                top: sidebarTop,
+                alignSelf: "flex-start",
+              }),
+            }}
           >
-            <ProjektiSideNavigation />
+            <div
+              style={
+                !isMobile
+                  ? { maxHeight: `calc(100vh - ${sidebarTop}px)`, overflowY: "auto" }
+                  : undefined
+              }
+            >
+              <ProjektiSideNavigation />
+            </div>
           </div>
           <div className="grow min-w-0">
             <Stack


### PR DESCRIPTION
## Muutokset
Virkamiespuolen navigaatio muutettiin aiemmin stickyksi, jotta se ei häviäisi näkyvistä pitkää sivua scrollatessa. Pienemmillä näytöillä tämä johti siihen, että pitkän sivun joutuu scrollaamaan melkein loppuun, jotta saa navigaation alaosan näkyviin. Muutettiin toimimaan niin, että jos navigaatio ei mahdu kokonaan näkyviin, niin sitä voi scrollata itsenäisesti.

## AI-Assisted: Amazon Q developer, generated
